### PR TITLE
implemented generic ND fill

### DIFF
--- a/notebooks/PerformanceComparison.ipynb
+++ b/notebooks/PerformanceComparison.ipynb
@@ -63,7 +63,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "186 ms ± 34.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "148 ms ± 1.55 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -122,14 +122,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "180 ms ± 2.88 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "164 ms ± 4.63 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
     "hist = bh.hist.any_int([bh.axis.regular(bins[0], *ranges[0])])\n",
-    "hist.fill(vals1d)"
+    "hist(vals1d)"
    ]
   },
   {
@@ -164,7 +164,7 @@
    ],
    "source": [
     "hist = bh.hist.regular_int([bh.axis.regular(bins[0], *ranges[0])])\n",
-    "hist.fill(vals1d)\n",
+    "hist(vals1d)\n",
     "np.asarray(hist)"
    ]
   },
@@ -218,14 +218,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "119 ms ± 965 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "97.6 ms ± 9.47 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
     "hist = bh.hist.regular_int([bh.axis.regular(bins[0], *ranges[0])])\n",
-    "hist.fill(vals1d)"
+    "hist(vals1d)"
    ]
   },
   {
@@ -260,7 +260,7 @@
    ],
    "source": [
     "hist = bh.hist.regular_int([bh.axis.regular(bins[0], *ranges[0])])\n",
-    "hist.fill(vals1d)\n",
+    "hist(vals1d)\n",
     "np.asarray(hist)"
    ]
   },
@@ -280,14 +280,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "83.5 ms ± 321 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "94.6 ms ± 4.27 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
     "hist = bh.hist.regular_int_1d((bh.axis.regular(bins[0], *ranges[0]),))\n",
-    "hist.fill(vals1d)"
+    "hist(vals1d)"
    ]
   },
   {
@@ -322,7 +322,7 @@
    ],
    "source": [
     "hist = bh.hist.regular_int_1d((bh.axis.regular(bins[0], *ranges[0]),))\n",
-    "hist.fill(vals1d)\n",
+    "hist(vals1d)\n",
     "np.asarray(hist)"
    ]
   },
@@ -342,14 +342,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "79.7 ms ± 223 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "87 ms ± 4.5 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
     "hist = bh.hist.regular_int_noflow_1d((bh.axis.regular_noflow(bins[0], *ranges[0]),))\n",
-    "hist.fill(vals1d)"
+    "hist(vals1d)"
    ]
   },
   {
@@ -381,7 +381,7 @@
    ],
    "source": [
     "hist = bh.hist.regular_int_noflow_1d((bh.axis.regular_noflow(bins[0], *ranges[0]),))\n",
-    "hist.fill(vals1d)\n",
+    "hist(vals1d)\n",
     "np.asarray(hist)"
    ]
   },
@@ -410,7 +410,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "124 ms ± 9.04 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "134 ms ± 9.86 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -461,7 +461,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "22.7 ms ± 980 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "18.6 ms ± 732 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -469,7 +469,7 @@
     "%%timeit\n",
     "hist = bh.hist.regular_int([bh.axis.regular(bins[0], *ranges[0]),\n",
     "                            bh.axis.regular(bins[1], *ranges[1])])\n",
-    "hist.fill(vals)"
+    "hist(*vals)"
    ]
   },
   {
@@ -497,7 +497,7 @@
    "source": [
     "hist = bh.hist.regular_int([bh.axis.regular(bins[0], *ranges[0]),\n",
     "                            bh.axis.regular(bins[1], *ranges[1])])\n",
-    "hist.fill(vals)\n",
+    "hist(*vals)\n",
     "np.asarray(hist)"
    ]
   },
@@ -517,7 +517,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "17.2 ms ± 497 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "19 ms ± 809 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -525,7 +525,7 @@
     "%%timeit\n",
     "hist = bh.hist.regular_int_2d((bh.axis.regular(bins[0], *ranges[0]),\n",
     "                               bh.axis.regular(bins[1], *ranges[1])))\n",
-    "hist.fill(vals)"
+    "hist(*vals)"
    ]
   },
   {
@@ -553,7 +553,7 @@
    "source": [
     "hist = bh.hist.regular_int_2d((bh.axis.regular(bins[0], *ranges[0]),\n",
     "                               bh.axis.regular(bins[1], *ranges[1])))\n",
-    "hist.fill(vals)\n",
+    "hist(*vals)\n",
     "np.asarray(hist)"
    ]
   },
@@ -573,7 +573,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "16.4 ms ± 197 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "18.4 ms ± 1.33 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -581,7 +581,7 @@
     "%%timeit\n",
     "hist = bh.hist.regular_int_noflow_2d((bh.axis.regular_noflow(bins[0], *ranges[0]),\n",
     "                               bh.axis.regular_noflow(bins[1], *ranges[1])))\n",
-    "hist.fill(vals)"
+    "hist(*vals)"
    ]
   },
   {
@@ -609,7 +609,7 @@
    "source": [
     "hist = bh.hist.regular_int_noflow_2d((bh.axis.regular_noflow(bins[0], *ranges[0]),\n",
     "                               bh.axis.regular_noflow(bins[1], *ranges[1])))\n",
-    "hist.fill(vals)\n",
+    "hist(*vals)\n",
     "np.asarray(hist)"
    ]
   },

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -48,12 +48,15 @@ struct fill_helper {
       ++size;
   }
 
+  // keep function small to minimize code bloat, it is instantiated 32 times :(
+  // TODO: solve this more efficiently on the lower Boost::Histogram level
   template <class N>
   void operator()(N) {
     using namespace boost::mp11;
     // N is a compile-time number with N == arrs.size()
     mp_repeat<std::tuple<double>, N> tp;
-    py::gil_scoped_release gil; // HD: is this really safe?
+    // TODO: only release gil when storage is thread-safe
+    // py::gil_scoped_release gil;
     for (std::size_t i = 0; i < size; ++i) {
       mp_for_each<mp_iota<N>>([&](auto I) {
         // I is mp_size_t<0>, mp_size_t<1>, ..., mp_size_t<N-1>
@@ -77,7 +80,8 @@ struct fill_helper {
       const double* ptr;
       std::size_t size;
     };
-    py::gil_scoped_release gil; // HD: is this really safe?
+    // TODO: only release gil when storage is thread-safe
+    // py::gil_scoped_release gil;
     for (double xi : span{arrs.front().second, size})
       hist(xi); // throws invalid_argument if hist.rank() != 1 
   }

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -15,11 +15,77 @@
 #include <boost/histogram/axis/ostream.hpp>
 #include <boost/histogram/ostream.hpp>
 
+#include <boost/mp11.hpp>
+
 #include <cassert>
 #include <vector>
 #include <sstream>
+#include <tuple>
+#include <cmath>
 
 namespace bh = boost::histogram;
+
+template <class Histogram>
+struct fill_helper {
+  fill_helper(Histogram& h, py::args args) : hist(h) {
+    auto dim = args.size();
+    if (dim == 0)
+      throw std::invalid_argument("at least one argument required");
+
+    arrs.reserve(dim);
+    for (std::size_t i = 0; i < dim; ++i) {
+      auto a = py::cast<py::array_t<double>>(args[i]);
+      if (a.ndim() > 1)
+        throw std::invalid_argument("array dim must be 0 or 1");
+      arrs.emplace_back(a, a.data());
+    }
+
+    size = arrs[0].first.size();
+    for (std::size_t i = 1; i < dim; ++i)
+      if (arrs[i].first.size() != size)
+        throw std::invalid_argument("arrays must have same length");
+    if (size == 0) // handle scalars by setting size to 1
+      ++size;
+  }
+
+  template <class N>
+  void operator()(N) {
+    using namespace boost::mp11;
+    // N is a compile-time number with N == arrs.size()
+    mp_repeat<std::tuple<double>, N> tp;
+    py::gil_scoped_release gil; // HD: is this really safe?
+    for (std::size_t i = 0; i < size; ++i) {
+      mp_for_each<mp_iota<N>>([&](auto I) {
+        // I is mp_size_t<0>, mp_size_t<1>, ..., mp_size_t<N-1>
+        std::get<I>(tp) = arrs[I].second[i];
+      });
+      hist(tp); // throws invalid_argument if tup has wrong size      
+    }
+  }
+
+  // specialization for N=0 to prevent compile-time error in histogram
+  void operator()(boost::mp11::mp_size_t<0>) {
+    throw std::invalid_argument("at least one argument required");
+  }
+
+  // specialization for N=1, implement potential optimizations here
+  void operator()(boost::mp11::mp_size_t<1>) {
+    // compilers often emit faster code for range-based for loops
+    struct span {
+      const double* begin() const { return ptr; }
+      const double* end() const { return ptr + size; }
+      const double* ptr;
+      std::size_t size;
+    };
+    py::gil_scoped_release gil; // HD: is this really safe?
+    for (double xi : span{arrs.front().second, size})
+      hist(xi); // throws invalid_argument if hist.rank() != 1 
+  }
+
+  Histogram& hist;
+  std::vector<std::pair<py::array_t<double>, const double*>> arrs;
+  std::size_t size;
+};
 
 template<typename A, typename S>
 py::class_<bh::histogram<A, S>>&& register_histogram_by_type(py::module& m, const char* name, const char* desc) {
@@ -50,42 +116,13 @@ py::class_<bh::histogram<A, S>>&& register_histogram_by_type(py::module& m, cons
     .def("axis",
         [](histogram_t &self, unsigned i){return self.axis(i);},
      "Get N-th axis with runtime index")
-    
-    .def("fill", [](histogram_t &self, py::array_t<double> &data){
-        py::buffer_info data_buf = data.request(); // TODO: make const?
-        if(self.rank() == 1 && data_buf.shape.size() == 1) {
-            const double *ptr1 = (const double *) data_buf.ptr;
-            py::gil_scoped_release gil;
-            for(size_t i = 0; i<data_buf.shape.at(0); i++)
-                self(ptr1[i]);
-        } else {
-            if(data_buf.ndim > 2)
-                throw std::runtime_error("max 2D array required");
-            else if(data_buf.ndim < 2 && self.rank() > 1)
-                throw std::runtime_error("2D array required for >1D histograms");
-            else if(data_buf.shape.at(0) != self.rank())
-                throw std::runtime_error("First dimension must match histogram");
-        
-            auto r = data.unchecked<2>();
-            
-            py::gil_scoped_release gil;
-            for(size_t i=0; i<r.shape(1); i++)
-                self(r(0, i), r(1, i));
-        }
-        
-    }, "Add data to histogram, diminsionality must match", "data"_a)
-    
-    .def("__call__", [](histogram_t &self, py::args &args){
-        size_t size = args.size();
-        if(size == 1)
-            self(py::cast<double>(args[0]));
-        else if (size == 2)
-            self(py::cast<double>(args[0]), py::cast<double>(args[1]));
-        else
-            throw py::index_error();
-        },
-        "Add a value to the historgram")
-    
+
+    // generic fill for 1 to N args
+    .def("__call__",
+      [](histogram_t &self, py::args args) {
+        boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(), fill_helper<histogram_t>(self, args));
+      }, "Insert data into histogram")
+
     .def("at", [](histogram_t &self, py::args &args) {
         // Optimize for no dynamic?
         auto int_args = py::cast<std::vector<int>>(args);


### PR DESCRIPTION
Generic fill for scalars and arrays. Tests are missing, because I cannot run tests from my build directory. Need to investigate.

You can do any of the following:
```
h1d(1)
h1d([1, 2, 3])
h2d(1, 2)
h2d([1, 2], [3, 4])
h4d([1], [2], [3], [4])
```