### PR TITLE
Adding axis::ariable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ target_compile_options(histogram PRIVATE
                        $<$<CXX_COMPILER_ID:MSVC>:
                            /W4>)
 
-# Tests (Require pytest to be available)
+# Tests (Requires pytest to be available to run)
 include(CTest)
 
 if(BUILD_TESTING)

--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -27,6 +27,8 @@ using circular = bh::axis::circular<>;
 using regular_log = bh::axis::regular<double, bh::axis::transform::log>;
 using regular_sqrt = bh::axis::regular<double, bh::axis::transform::sqrt>;
 using regular_pow = bh::axis::regular<double, bh::axis::transform::pow>;
+    
+using variable = bh::axis::variable<double>;
 
 } // namespace axis
 
@@ -38,7 +40,8 @@ using any = std::vector<bh::axis::variant<axis::regular,
                                           axis::circular,
                                           axis::regular_log,
                                           axis::regular_pow,
-                                          axis::regular_sqrt>>;
+                                          axis::regular_sqrt,
+                                          axis::variable>>;
 
 // Specialization for some speed improvement
 using regular = std::vector<axis::regular>;

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -50,4 +50,8 @@ void register_axis(py::module &m) {
     .def(py::init([](double pow, unsigned n, double start, double stop){
         return new axis::regular_pow(bh::axis::transform::pow{pow}, n, start , stop);} ), "pow"_a, "n"_a, "start"_a, "stop"_a)
     ;
+    
+    py::class_<axis::variable>(ax, "variable")
+    .def(py::init<std::vector<double>>(), "edges"_a)
+    ;
 }

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -60,6 +60,6 @@ def test_edges_histogram():
         ])
 
     vals = (13,15,24,29)
-    hist.fill(vals)
+    hist(vals)
 
     assert np.all(hist == [0,0,2,2,0,0])

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -16,7 +16,7 @@ def test_1D_fill_unlimited():
 
 methods = [
     bh.hist.regular_int,
-    bh.hist.any_int
+    bh.hist.any_int,
 ]
 
 @pytest.mark.parametrize("hist_func", methods + [bh.hist.regular_int_1d])
@@ -31,7 +31,9 @@ def test_1D_fill_int(hist_func):
         ])
     hist(vals)
 
-    assert [hist.at(i) for i in range(10)] == [0, 1, 2, 0, 0, 0, 0, 0, 0, 0]
+    H =  np.array([0, 1, 2, 0, 0, 0, 0, 0, 0, 0])
+
+    assert np.all(np.asarray(hist)[1:-1] == H)
 
 @pytest.mark.parametrize("hist_func", methods + [bh.hist.regular_int_2d])
 def test_2D_fill_int(hist_func):
@@ -48,4 +50,16 @@ def test_2D_fill_int(hist_func):
 
     H = np.histogram2d(*vals, bins=bins, range=ranges)[0]
 
-    assert [hist.at(i // 10, i % 10) for i in range(100)] == [H[i // 10, i % 10] for i in range(100)]
+    assert np.all(np.asarray(hist)[1:-1,1:-1] == H)
+
+
+def test_edges_histogram():
+    edges = (1, 12, 22, 79)
+    hist = bh.hist.any_int([
+        bh.axis.variable(edges)
+        ])
+
+    vals = (13,15,24,29)
+    hist.fill(vals)
+
+    assert np.all(hist == [0,0,2,2,0,0])

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -62,4 +62,5 @@ def test_edges_histogram():
     vals = (13,15,24,29)
     hist(vals)
 
-    assert np.all(hist == [0,0,2,2,0,0])
+    bins = np.asarray(hist)
+    assert np.all(bins == [0,0,2,2,0])


### PR DESCRIPTION
This currently cases the following error:

<details><summary>
Click to expand
</summary>

```
In file included from /Users/henryiii/git/software/histogram-python/src/histogram/histogram.cpp:10:
In file included from /Users/henryiii/git/software/histogram-python/include/boost/histogram/python/axis.hpp:7:
In file included from /Users/henryiii/git/software/histogram-python/extern/histogram/include/boost/histogram.hpp:25:
In file included from /Users/henryiii/git/software/histogram-python/extern/histogram/include/boost/histogram/algorithm/project.hpp:12:
In file included from /Users/henryiii/git/software/histogram-python/extern/histogram/include/boost/histogram/histogram.hpp:10:
In file included from /Users/henryiii/git/software/histogram-python/extern/histogram/include/boost/histogram/detail/axes.hpp:12:
In file included from /Users/henryiii/git/software/histogram-python/extern/histogram/include/boost/histogram/axis/variant.hpp:24:
/Users/henryiii/git/software/histogram-python/extern/variant/include/boost/variant/variant.hpp:1733:9: error: call to member function
      'convert_construct' is ambiguous
        convert_construct(operand, 1L);
        ^~~~~~~~~~~~~~~~~
/Users/henryiii/git/software/histogram-python/extern/histogram/include/boost/histogram/axis/variant.hpp:235:59: note: in instantiation of
      function template specialization 'boost::variant<boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::histogram::axis::option::bitset<0> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::id,
      boost::use_default, boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::log, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::pow, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::sqrt, boost::use_default, boost::use_default>, boost::histogram::axis::variable<double,
      boost::use_default, boost::use_default, std::__1::allocator<double> >
      >::variant<boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::histogram::axis::option::bitset<0> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::id,
      boost::use_default, boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::log, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::pow, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::sqrt, boost::use_default, boost::use_default>, boost::histogram::axis::variable<double,
      boost::use_default, boost::use_default, std::__1::allocator<double> > > >' requested here
  return boost::apply_visitor(std::forward<Visitor>(vis), static_cast<B>(var));
                                                          ^
/Users/henryiii/git/software/histogram-python/extern/pybind11/include/pybind11/stl.h:317:16: note: in instantiation of function template
      specialization 'boost::histogram::axis::visit<pybind11::detail::variant_caster_visitor,
      boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>,
      boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::histogram::axis::option::bitset<0> >,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::id, boost::use_default,
      boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::log,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::pow,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::sqrt,
      boost::use_default, boost::use_default>, boost::histogram::axis::variable<double, boost::use_default, boost::use_default,
      std::__1::allocator<double> > > >' requested here
        return visit(std::forward<Args>(args)...);
               ^
/Users/henryiii/git/software/histogram-python/extern/pybind11/include/pybind11/stl.h:352:33: note: in instantiation of function template
      specialization 'pybind11::detail::visit_helper<variant>::call<pybind11::detail::variant_caster_visitor,
      boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>,
      boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::histogram::axis::option::bitset<0> >,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::id, boost::use_default,
      boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::log,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::pow,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::sqrt,
      boost::use_default, boost::use_default>, boost::histogram::axis::variable<double, boost::use_default, boost::use_default,
      std::__1::allocator<double> > > >' requested here
        return visit_helper<V>::call(variant_caster_visitor{policy, parent},
                                ^
/Users/henryiii/git/software/histogram-python/extern/pybind11/include/pybind11/pybind11.h:154:39: note: in instantiation of function template
      specialization 'pybind11::detail::variant_caster<boost::histogram::axis::variant<boost::histogram::axis::regular<double,
      boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::use_default,
      boost::use_default, boost::histogram::axis::option::bitset<0> >, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::id, boost::use_default, boost::histogram::axis::option::bitset<6> >,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::log, boost::use_default, boost::use_default>,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::pow, boost::use_default, boost::use_default>,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::sqrt, boost::use_default, boost::use_default>,
      boost::histogram::axis::variable<double, boost::use_default, boost::use_default, std::__1::allocator<double> > >
      >::cast<boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::histogram::axis::option::bitset<0> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::id,
      boost::use_default, boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::log, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::pow, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::sqrt, boost::use_default, boost::use_default>, boost::histogram::axis::variable<double,
      boost::use_default, boost::use_default, std::__1::allocator<double> > > >' requested here
            handle result = cast_out::cast(
                                      ^
/Users/henryiii/git/software/histogram-python/extern/pybind11/include/pybind11/pybind11.h:65:9: note: in instantiation of function template
      specialization 'pybind11::cpp_function::initialize<(lambda at
      /Users/henryiii/git/software/histogram-python/src/histogram/histogram.cpp:121:9),
      boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>,
      boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::histogram::axis::option::bitset<0> >,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::id, boost::use_default,
      boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::log,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::pow,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::sqrt,
      boost::use_default, boost::use_default>, boost::histogram::axis::variable<double, boost::use_default, boost::use_default,
      std::__1::allocator<double> > >,
      boost::histogram::histogram<std::__1::vector<boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::histogram::axis::option::bitset<0> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::id,
      boost::use_default, boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::log, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::pow, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::sqrt, boost::use_default, boost::use_default>, boost::histogram::axis::variable<double,
      boost::use_default, boost::use_default, std::__1::allocator<double> > >,
      std::__1::allocator<boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::histogram::axis::option::bitset<0> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::id,
      boost::use_default, boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::log, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::pow, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::sqrt, boost::use_default, boost::use_default>, boost::histogram::axis::variable<double,
      boost::use_default, boost::use_default, std::__1::allocator<double> > > > >, boost::histogram::storage_adaptor<std::__1::vector<unsigned
      long long, std::__1::allocator<unsigned long long> > > > &, unsigned int, pybind11::name, pybind11::is_method, pybind11::sibling, char
      [33]>' requested here
        initialize(std::forward<Func>(f),
        ^
/Users/henryiii/git/software/histogram-python/extern/pybind11/include/pybind11/pybind11.h:1085:22: note: in instantiation of function template
      specialization 'pybind11::cpp_function::cpp_function<(lambda at
      /Users/henryiii/git/software/histogram-python/src/histogram/histogram.cpp:121:9), pybind11::name, pybind11::is_method, pybind11::sibling,
      char [33], void>' requested here
        cpp_function cf(method_adaptor<type>(std::forward<Func>(f)), name(name_), is_method(*this),
                     ^
/Users/henryiii/git/software/histogram-python/src/histogram/histogram.cpp:120:6: note: in instantiation of function template specialization
      'pybind11::class_<boost::histogram::histogram<std::__1::vector<boost::histogram::axis::variant<boost::histogram::axis::regular<double,
      boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::use_default,
      boost::use_default, boost::histogram::axis::option::bitset<0> >, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::id, boost::use_default, boost::histogram::axis::option::bitset<6> >,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::log, boost::use_default, boost::use_default>,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::pow, boost::use_default, boost::use_default>,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::sqrt, boost::use_default, boost::use_default>,
      boost::histogram::axis::variable<double, boost::use_default, boost::use_default, std::__1::allocator<double> > >,
      std::__1::allocator<boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::histogram::axis::option::bitset<0> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::id,
      boost::use_default, boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::log, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::pow, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::sqrt, boost::use_default, boost::use_default>, boost::histogram::axis::variable<double,
      boost::use_default, boost::use_default, std::__1::allocator<double> > > > >, boost::histogram::storage_adaptor<std::__1::vector<unsigned
      long long, std::__1::allocator<unsigned long long> > > >>::def<(lambda at
      /Users/henryiii/git/software/histogram-python/src/histogram/histogram.cpp:121:9), char [33]>' requested here
    .def("axis",
     ^
/Users/henryiii/git/software/histogram-python/src/histogram/histogram.cpp:167:5: note: in instantiation of function template specialization
      'register_histogram_by_type<std::__1::vector<boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::histogram::axis::option::bitset<0> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::id,
      boost::use_default, boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::log, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::pow, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::sqrt, boost::use_default, boost::use_default>, boost::histogram::axis::variable<double,
      boost::use_default, boost::use_default, std::__1::allocator<double> > >,
      std::__1::allocator<boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::histogram::axis::option::bitset<0> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::id,
      boost::use_default, boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::log, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::pow, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::sqrt, boost::use_default, boost::use_default>, boost::histogram::axis::variable<double,
      boost::use_default, boost::use_default, std::__1::allocator<double> > > > >, boost::histogram::storage_adaptor<std::__1::vector<unsigned
      long long, std::__1::allocator<unsigned long long> > > >' requested here
    register_histogram_by_type<axes::any, vector_int_storage>(hist,
    ^
/Users/henryiii/git/software/histogram-python/extern/variant/include/boost/variant/variant.hpp:1544:10: note: candidate function [with T =
      boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>,
      boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::histogram::axis::option::bitset<0> >,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::id, boost::use_default,
      boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::log,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::pow,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::sqrt,
      boost::use_default, boost::use_default>, boost::histogram::axis::variable<double, boost::use_default, boost::use_default,
      std::__1::allocator<double> > >]
    void convert_construct(
         ^
/Users/henryiii/git/software/histogram-python/extern/variant/include/boost/variant/variant.hpp:1673:15: note: candidate function [with U0 =
      boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, UN =
      <boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::histogram::axis::option::bitset<0> >,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::id, boost::use_default,
      boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::log,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::pow,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::sqrt,
      boost::use_default, boost::use_default>, boost::histogram::axis::variable<double, boost::use_default, boost::use_default,
      std::__1::allocator<double> >>]
    > >::type convert_construct(
              ^
/Users/henryiii/git/software/histogram-python/extern/variant/include/boost/variant/variant.hpp:1685:15: note: candidate function [with U0 =
      boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, UN =
      <boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::histogram::axis::option::bitset<0> >,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::id, boost::use_default,
      boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::log,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::pow,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::sqrt,
      boost::use_default, boost::use_default>, boost::histogram::axis::variable<double, boost::use_default, boost::use_default,
      std::__1::allocator<double> >>]
    > >::type convert_construct(
              ^
/Users/henryiii/git/software/histogram-python/extern/variant/include/boost/variant/variant.hpp:1698:15: note: candidate function [with U0 =
      boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, UN =
      <boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::histogram::axis::option::bitset<0> >,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::id, boost::use_default,
      boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::log,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::pow,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::sqrt,
      boost::use_default, boost::use_default>, boost::histogram::axis::variable<double, boost::use_default, boost::use_default,
      std::__1::allocator<double> >>] not viable: no known conversion from
      'boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>,
      boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::histogram::axis::option::bitset<0> >,
      boost::histogram::axis::regular<double, boost::histogram::axis::transform::id, boost::use_default,
      boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::log,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::pow,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::histogram::axis::transform::sqrt,
      boost::use_default, boost::use_default>, boost::histogram::axis::variable<double, boost::use_default, boost::use_default,
      std::__1::allocator<double> > >' to 'boost::variant<regular<double, use_default, use_default, use_default>, regular<double, use_default,
      use_default, bitset<0> >, regular<double, id, use_default, bitset<6> >, regular<double, log, use_default, use_default>, regular<double,
      pow, use_default, use_default>, regular<double, sqrt, use_default, use_default>, variable<double, use_default, use_default,
      allocator<double> > > &&' for 1st argument
    > >::type convert_construct(
              ^
/Users/henryiii/git/software/histogram-python/extern/variant/include/boost/variant/variant.hpp:1565:31: note: candidate template ignored:
      disabled by 'enable_if' [with T = boost::histogram::axis::variant<boost::histogram::axis::regular<double, boost::use_default,
      boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default,
      boost::histogram::axis::option::bitset<0> >, boost::histogram::axis::regular<double, boost::histogram::axis::transform::id,
      boost::use_default, boost::histogram::axis::option::bitset<6> >, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::log, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::pow, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double,
      boost::histogram::axis::transform::sqrt, boost::use_default, boost::use_default>, boost::histogram::axis::variable<double,
      boost::use_default, boost::use_default, std::__1::allocator<double> > > &]
    typename boost::enable_if<boost::is_rvalue_reference<T&&> >::type convert_construct(
                              ^
/Users/henryiii/git/software/histogram-python/extern/variant/include/boost/variant/variant.hpp:1586:10: note: candidate function template not
      viable: requires 3 arguments, but 2 were provided
    void convert_construct(
         ^
/Users/henryiii/git/software/histogram-python/extern/variant/include/boost/variant/variant.hpp:1600:77: note: candidate function template not
      viable: requires 3 arguments, but 2 were provided
    typename boost::enable_if<boost::is_rvalue_reference<Variant&&> >::type convert_construct(
                                                                            ^
1 error generated.
```

</details>