### PR TITLE
Adding CI

### DIFF
--- a/.ci/azure-cmake-steps.yml
+++ b/.ci/azure-cmake-steps.yml
@@ -1,0 +1,30 @@
+steps:
+
+- checkout: self
+  fetchDepth: 50
+  submodules: true
+
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(python.version)'
+    architecture: 'x64'
+
+- script: |
+    python -m pip install --upgrade pip
+    python -m pip install --upgrade pytest
+    python -m pip install numpy
+  displayName: 'Install dependencies'
+
+- task: CMake@1
+  inputs:
+    cmakeArgs: .. -DCMAKE_BUILD_TYPE=Debug
+  displayName: 'Configure'
+
+- script: cmake --build . -j
+  displayName: 'Build'
+  workingDirectory: build
+
+- script: ctest --output-on-failure -C Debug
+  displayName: 'Test'
+  workingDirectory: build
+

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -1,0 +1,24 @@
+steps:
+
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(python.version)'
+    architecture: 'x64'
+
+- checkout: self
+  fetchDepth: 50
+  submodules: true
+
+- script: |
+    python -m pip install --upgrade pip
+    python -m pip install --upgrade pytest
+    python -m pip install numpy
+  displayName: 'Install dependencies'
+
+- script: |
+    python -m pip install --verbose -e .
+  displayName: 'Build and install package'
+
+- script: |
+    python -m pytest tests
+  displayName: 'Test with pytest'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,11 +71,12 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/extern/histogram/include PREFIX "H
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include PREFIX "Header Files" FILES ${BOOST_HIST_PY_HEADERS})
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX "Source Files" FILES ${BOOST_HIST_PY_SRC})
 
+# Adding warnings (will cause errors except in MSVC, since PyBind11 might cause a few there - add /WX if you want to try)
 target_compile_options(histogram PRIVATE
                        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
                            -Wall -Wextra -Werror -pedantic-errors -Wconversion -Wsign-conversion>
                        $<$<CXX_COMPILER_ID:MSVC>:
-                           /WX /W4>)
+                           /W4>)
 
 # Tests (Require pytest to be available)
 include(CTest)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # boost-histogram for Python
 
-[![Gitter](https://badges.gitter.im/HSF/PyHEP-histogramming.svg)](https://gitter.im/HSF/PyHEP-histogramming?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Gitter][gitter-badge]][[gitter-link]
+[![Build Status][azure-badge]][azure-link]
 
 Python bindings for [Boost::Histogram][], a C++14 library. This should become one of the [fastest libraries][] for histogramming, while still providing the power of a full histogram object.
 
@@ -11,21 +12,32 @@ Python bindings for [Boost::Histogram][], a C++14 library. This should become on
 [Boost::Histogram]:  https://www.boost.org/doc/libs/develop/libs/histogram/doc/html/index.html 
 [fastest libraries]: https://iscinumpy.gitlab.io/post/histogram-speeds-in-python/
 
-## Hacking
+## Developing
 
 This repository has dependencies in submodules. Check out the repository like this.
 
-    git clone https://github.com/scikit-hep/boost-histogram.git
-    cd boost-histogram
-    git submodule update --init --depth 10
+```bash
+git clone https://github.com/scikit-hep/boost-histogram.git
+cd boost-histogram
+git submodule update --init --depth 10
+```
 
-Make a build directory and run cmake.
+Make a build directory and run CMake.
 
-    mkdir build
-    cd build
-    cmake .. 
-    make -j4
+```bash
+mkdir build
+cd build
+cmake ..
+make -j4
+```
 
-Run the unit tests.
+Run the unit tests (requires pytest and numpy).
 
-    make test
+```bash
+make test
+```
+
+[gitter-badge]: https://badges.gitter.im/HSF/PyHEP-histogramming.svg
+[gitter-link]:  https://gitter.im/HSF/PyHEP-histogramming?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
+[azure-badge]:  https://dev.azure.com/scikit-hep/boost-histogram/_apis/build/status/scikit-hep.boost-histogram?branchName=develop
+[azure-link]:   https://dev.azure.com/scikit-hep/boost-histogram/_build/latest?definitionId=2&branchName=develop

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,48 @@
+trigger:
+- master
+- develop
+
+jobs:
+- job: Linux
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python36:
+        python.version: '3.6'
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - template: .ci/azure-steps.yml
+
+- job: macOS
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python37:
+        python.version: '3.7'
+  pool:
+    vmImage: 'macOS-10.13'
+  steps:
+    - template: .ci/azure-steps.yml
+
+- job: Windows
+  strategy:
+    matrix:
+      Python37:
+        python.version: '3.7'
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+    - template: .ci/azure-steps.yml
+
+- job: Linux_CMake
+  strategy:
+    matrix:
+      Python37:
+        python.version: '3.7'
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - template: .ci/azure-cmake-steps.yml

--- a/include/boost/histogram/python/histogram.hpp
+++ b/include/boost/histogram/python/histogram.hpp
@@ -45,4 +45,4 @@ py::buffer_info make_buffer(bh::histogram<A, S>& h) {
 template<typename A>
 py::buffer_info make_buffer(bh::histogram<A, bh::default_storage>&) {
     return py::buffer_info();
-};
+}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,105 @@
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+import sys
+import setuptools
+
+__version__ = '0.0.1'
+
+ext_modules = [
+    Extension(
+        'histogram',
+        ['src/module.cpp',
+         'src/histogram/axis.cpp',
+         'src/histogram/histogram.cpp',
+         'src/histogram/storage.cpp'
+        ],
+        include_dirs=[
+            'include',
+            'extern/assert/include',
+            'extern/callable_traits/include',
+            'extern/config/include',
+            'extern/container_hash/include',
+            'extern/core/include',
+            'extern/detail/include',
+            'extern/histogram/include',
+            'extern/integer/include',
+            'extern/iterator/include',
+            'extern/move/include',
+            'extern/mp11/include',
+            'extern/mpl/include',
+            'extern/preprocessor/include',
+            'extern/pybind11/include',
+            'extern/static_assert/include',
+            'extern/throw_exception/include',
+            'extern/type_index/include',
+            'extern/type_traits/include',
+            'extern/utility/include',
+            'extern/variant/include',
+        ],
+        language='c++'
+    ),
+]
+
+# As of Python 3.6, CCompiler has a `has_flag` method.
+# cf http://bugs.python.org/issue26689
+def has_flag(compiler, flagname):
+    """Return a boolean indicating whether a flag name is supported on
+    the specified compiler.
+    """
+    import tempfile
+    with tempfile.NamedTemporaryFile('w', suffix='.cpp') as f:
+        f.write('int main (int argc, char **argv) { return 0; }')
+        try:
+            compiler.compile([f.name], extra_postargs=[flagname])
+        except setuptools.distutils.errors.CompileError:
+            return False
+    return True
+
+
+def cpp_flag(compiler):
+    """Return the -std=c++14 compiler flag.
+    """
+    if has_flag(compiler, '-std=c++14'):
+        return '-std=c++14'
+    else:
+        raise RuntimeError('Unsupported compiler -- at least C++14 support '
+                           'is needed!')
+
+
+class BuildExt(build_ext):
+    """A custom build extension for adding compiler-specific options."""
+    c_opts = {
+        'msvc': ['/EHsc'],
+        'unix': [],
+    }
+
+    if sys.platform == 'darwin':
+        c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
+
+    def build_extensions(self):
+        ct = self.compiler.compiler_type
+        opts = self.c_opts.get(ct, [])
+        if ct == 'unix':
+            opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
+            opts.append(cpp_flag(self.compiler))
+            if has_flag(self.compiler, '-fvisibility=hidden'):
+                opts.append('-fvisibility=hidden')
+        elif ct == 'msvc':
+            opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
+        for ext in self.extensions:
+            ext.extra_compile_args = opts
+        build_ext.build_extensions(self)
+
+setup(
+    name='histogram',
+    version=__version__,
+    author='Henry Schreiner',
+    author_email='hschrein@cern.ch',
+    url='https://github.com/scikit-hep/boost-histogram',
+    description='The Boost::Histogram Python wrapper.',
+    long_description='',
+    ext_modules=ext_modules,
+    cmdclass={'build_ext': BuildExt},
+    zip_safe=False,
+    tests_require=['pytest', 'numpy']
+)

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -46,6 +46,6 @@ def test_2D_fill_int(hist_func):
         ])
     hist(*vals)
 
-    H, *ledges = np.histogram2d(*vals, bins=bins, range=ranges)
+    H = np.histogram2d(*vals, bins=bins, range=ranges)[0]
 
     assert [hist.at(i // 10, i % 10) for i in range(100)] == [H[i // 10, i % 10] for i in range(100)]


### PR DESCRIPTION
This adds CI with Azure. Also adds setup.py support, and some warning fixes.

I'm testing a couple of versions of setup.py Python per platform (macOS, Linux, and Windows), and running the CMake build on a Linux node. The CMake one is a bit trickier to run with multiple Pythons, since its hard to get the python executable path in the recipe in a completely shell independent way.