### PR TITLE
Adding a slighly more comprehensive test

### DIFF
--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -43,7 +43,6 @@ py::class_<A> register_axis_by_type(py::module& m, const char* name, const char*
     .def(py::self != py::self)
     
     .def("index", &A::index, "The index at a point on the axis", "x"_a)
-    .def("bin", &A::bin, "The bin contents", "idx"_a, py::keep_alive<0, 1>())
     .def("value", &A::value, "The value for a fractional bin in the axis", "i"_a)
     .def("size", &A::size, "Returns the number of bins, without over- or underflow")
     .def("extent", [](const A& self){return bh::axis::traits::extend(self);},
@@ -56,9 +55,16 @@ py::class_<A> register_axis_by_type(py::module& m, const char* name, const char*
     
     ;
     
+    // This could be a constexpr if, but no cost for being runtime (since pybind config runs once)
+    if(std::is_same<A, axis::category_str>::value) {
+        axis.def("bin", &A::bin, "The bin name", "idx"_a);
+    } else {
+        axis.def("bin", &A::bin, "The bin details (center, lower, upper)", "idx"_a, py::keep_alive<0, 1>());
+    }
+
+
     return axis;
 }
-
 
 /// Add helpers common to all types with a range of values
 template<typename A, typename R=int>

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -43,7 +43,7 @@ py::class_<A> register_axis_by_type(py::module& m, const char* name, const char*
     .def(py::self != py::self)
     
     .def("index", &A::index, "The index at a point on the axis", "x"_a)
-    .def("bin", &A::bin, "The bin contents", "idx"_a)
+    .def("bin", &A::bin, "The bin contents", "idx"_a, py::keep_alive<0, 1>())
     .def("value", &A::value, "The value for a fractional bin in the axis", "i"_a)
     .def("size", &A::size, "Returns the number of bins, without over- or underflow")
     .def("extent", [](const A& self){return bh::axis::traits::extend(self);},

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -197,7 +197,5 @@ void register_histogram(py::module& m) {
     // register_histogram_by_type<axes::any, bh::weighted_profile_storage>(hist,
     //    "any_weighted_profile",
     //    "N-dimensional histogram for weighted and sampled data with any axis types.");
-    
-    
 
 }

--- a/tests/test_axis_internal.py
+++ b/tests/test_axis_internal.py
@@ -6,8 +6,11 @@ import numpy as np
 
 
 @pytest.mark.parametrize("axtype", [bh.axis.regular, bh.axis.regular_noflow])
-def test_axis_regular(axtype):
-    ax = axtype(10, 0, 1)
+@pytest.mark.parametrize("function", [lambda x: x,
+                                       lambda x: bh.make_histogram(x).axis(0),
+                                       ])
+def test_axis_regular(axtype, function):
+    ax = function(axtype(10, 0, 1))
 
     assert 3 == ax.index(.34)
     assert 2 == ax.index(.26)

--- a/tests/test_axis_internal.py
+++ b/tests/test_axis_internal.py
@@ -68,3 +68,9 @@ def test_regular_axis_repr(axis):
     ax = axis(7,2,4, label='That')
     assert 'That' in repr(ax)
     assert ax.label == 'That'
+
+def test_cat_str():
+    ax = bh.axis.category_str(["a", "b", "c"])
+    assert ax.bin(0) == "a"
+    assert ax.bin(1) == "b"
+    assert ax.bin(2) == "c"

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -1,5 +1,6 @@
 import pytest
 from pytest import approx
+import math
 
 import histogram as bh
 
@@ -36,18 +37,34 @@ def test_make_regular_2D(axis, extent):
 def test_make_any_hist(storage):
     hist = bh.make_histogram(bh.axis.regular(5,1,2),
                              bh.axis.regular_noflow(6,2,3),
-                             bh.axis.circular(7,3,4),
+                             bh.axis.circular(8,3,4),
                              storage=storage)
 
     assert hist.rank() == 3
     assert hist.axis(0).size() == 5
     assert hist.axis(0).extent() == 7
+    assert hist.axis(0).bin(1).center() == approx(1.3)
     assert hist.axis(1).size() == 6
     assert hist.axis(1).extent() == 6
-    assert hist.axis(2).size() == 7
-    assert hist.axis(2).extent() == 8
+    assert hist.axis(1).bin(1).center() == approx(2.25)
+    assert hist.axis(2).size() == 8
+    assert hist.axis(2).extent() == 9
+    assert hist.axis(2).bin(1).center() == approx(3.1875)
 
 def test_make_any_hist_storage():
 
     assert float != type(bh.make_histogram(bh.axis.regular(5,1,2), storage=bh.storage.dense_int()).at(0))
     assert float == type(bh.make_histogram(bh.axis.regular(5,1,2), storage=bh.storage.dense_double()).at(0))
+
+def test_issue_axis_bin_swan():
+    hist = bh.make_histogram(bh.axis.regular_sqrt(10,0,10, label='x'),
+                             bh.axis.circular(10,0,1, label='y'))
+
+    b = hist.axis(1).bin(1)
+    assert repr(b) == '<bin [0.100000, 0.200000]>'
+    assert b.lower() == approx(0.1)
+    assert b.upper() == approx(0.2)
+
+    assert hist.axis(0).bin(0).lower() == 0
+    assert hist.axis(0).bin(1).lower() == approx(.1)
+    assert hist.axis(0).bin(2).lower() == approx(.4)


### PR DESCRIPTION
This fixes a lifetime bug (something named `lightweight_view` should have made it pretty obvious that a `keep_alive` was needed!), as well as enables string bins (categories) to be accessed. Still no fill for non-double axis. It would also be nice if there was a trait that could detect a real axis from a category one.