### PR TITLE
Allow any python object for a label

### DIFF
--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -43,19 +43,7 @@ py::array_t<double> axis_to_edges(const A& ax, bool flow) {
     return edges;
 }
 
-/*
-struct metadata_t {
-    std::string label;
-    metadata_t() = default;
-    metadata_t(std::string txt) : label(txt) {}
-    operator const char*() const {return label.c_str();}
-};
-inline std::ostream& operator<< (std::ostream& out, const metadata_t& meta) {
-    return out << meta.label;
-}
-*/
-
-using metadata_t = std::string;
+using metadata_t = py::object;
 
 namespace axis {
 

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -81,8 +81,8 @@ py::class_<A> register_axis_by_type(py::module& m, const char* name, const char*
     .def("update", &A::update, "Bin and add a value if allowed", "i"_a)
     .def_static("options", &A::options, "Return the options associated to the axis")
     .def_property("label",
-                  [](const A& self){return std::string(self.metadata());},
-                  [](A& self, std::string label){self.metadata() = label;},
+                  [](const A& self){return self.metadata();},
+                  [](A& self, metadata_t label){self.metadata() = label;},
                   "Set the axis label")
 
     ;
@@ -129,9 +129,7 @@ void register_axis(py::module &m) {
     opt.attr("overflow") =  (unsigned) bh::axis::option::overflow;
     opt.attr("circular") =  (unsigned) bh::axis::option::circular;
     opt.attr("growth") =    (unsigned) bh::axis::option::growth;
-
-
-    using metadata_t = std::string;
+    
     
     register_axis_by_type<axis::regular>(ax, "regular", "Evenly spaced bins")
     .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "label"_a = "")

--- a/tests/test_axis_internal.py
+++ b/tests/test_axis_internal.py
@@ -76,14 +76,15 @@ def test_axis_circular():
     assert .1 == ax.value(1)
     assert ax.options() == bh.axis.options.circular | bh.axis.options.overflow
 
-
-@pytest.mark.parametrize("axis", [
+normal_axs = [
     bh.axis.regular,
     bh.axis.regular_noflow,
     bh.axis.circular,
     bh.axis.regular_log,
     bh.axis.regular_sqrt,
-])
+]
+
+@pytest.mark.parametrize("axis", normal_axs)
 def test_regular_axis_repr(axis):
     ax = axis(2,3,4)
     assert 'object at' not in repr(ax)
@@ -96,6 +97,13 @@ def test_regular_axis_repr(axis):
     ax = axis(7,2,4, label='That')
     assert 'That' in repr(ax)
     assert ax.label == 'That'
+
+@pytest.mark.parametrize("axis", normal_axs)
+def test_any_label(axis):
+    ax = axis(2,3,4, label={"one": "1"})
+    assert ax.label == {"one": "1"}
+    ax.label = 64
+    assert ax.label == 64
 
 def test_cat_str():
     ax = bh.axis.category_str(["a", "b", "c"])


### PR DESCRIPTION
This could be used to attach units, for example.