### PR TITLE
Accumulators

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ ext_modules = [
         ['src/module.cpp',
          'src/histogram/axis.cpp',
          'src/histogram/histogram.cpp',
-         'src/histogram/storage.cpp'
+         'src/histogram/storage.cpp',
+         'src/histogram/accumulators.cpp',
         ],
         include_dirs=[
             'include',

--- a/src/histogram/accumulators.cpp
+++ b/src/histogram/accumulators.cpp
@@ -1,0 +1,122 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#include <boost/histogram/python/pybind11.hpp>
+#include <pybind11/operators.h>
+
+#include <boost/histogram.hpp>
+#include <boost/histogram/accumulators/weighted_sum.hpp>
+#include <boost/histogram/accumulators/weighted_mean.hpp>
+#include <boost/histogram/accumulators/mean.hpp>
+#include <boost/histogram/accumulators/sum.hpp>
+#include <boost/histogram/accumulators/ostream.hpp>
+
+namespace bh = boost::histogram;
+
+void register_accumulators(py::module &m) {
+    
+    py::module accumulator = m.def_submodule("accumulator");
+
+
+    using weighted_sum = bh::accumulators::weighted_sum<double>;
+    
+    py::class_<weighted_sum>(accumulator, "weighted_sum")
+        .def(py::init<>())
+        .def(py::init<const double&>(), "value"_a)
+        .def(py::init<const double&, const double&>(), "value"_a, "variance"_a)
+    
+        .def_property_readonly("variance", &weighted_sum::variance)
+        .def_property_readonly("value", &weighted_sum::value)
+    
+        .def(py::self += double())
+        .def(py::self += py::self)
+        .def(py::self *= double())
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+    
+        .def("__repr__", [](const weighted_sum& self){
+                std::ostringstream out;
+                out << self;
+                return out.str();
+            })
+    ;
+
+    using weighted_mean = bh::accumulators::weighted_mean<double>;
+
+    py::class_<weighted_mean>(accumulator, "weighted_mean")
+        .def(py::init<>())
+        .def(py::init<const double&, const double&, const double&, const double&>(),
+             "wsum"_a, "wsum2"_a, "mean"_a, "variance"_a)
+
+
+        .def_property_readonly("sum_of_weights", &weighted_mean::sum_of_weights)
+        .def_property_readonly("variance", &weighted_mean::variance)
+        .def_property_readonly("value", &weighted_mean::value)
+
+        .def(py::self += py::self)
+        .def(py::self *= double())
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+    
+        .def("__call__", py::overload_cast<const double&>(&weighted_mean::operator()), "x"_a)
+        .def("__call__", py::overload_cast<const double&, const double&>(&weighted_mean::operator()), "w"_a, "x"_a)
+
+        .def("__repr__", [](const weighted_mean& self){
+            std::ostringstream out;
+            out << self;
+            return out.str();
+        })
+    ;
+
+    
+    using mean = bh::accumulators::mean<double>;
+    
+    py::class_<mean>(accumulator, "mean")
+        .def(py::init<>())
+        .def(py::init<std::size_t, const double&, const double&>(),
+             "n"_a, "mean"_a, "variance"_a)
+    
+        .def_property_readonly("count", &mean::count)
+        .def_property_readonly("variance", &mean::variance)
+        .def_property_readonly("value", &mean::value)
+    
+        .def(py::self += py::self)
+        .def(py::self *= double())
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+    
+        .def("__call__", py::overload_cast<const double&>(&mean::operator()), "x"_a)
+    
+        .def("__repr__", [](const mean& self){
+            std::ostringstream out;
+            out << self;
+            return out.str();
+        })
+    ;
+    
+    using sum = bh::accumulators::sum<double>;
+    
+    py::class_<sum>(accumulator, "sum")
+        .def(py::init<>())
+        .def(py::init<const double&>(), "value"_a)
+    
+        .def_property("value", &sum::operator double, [](sum& s, double v){s = v;})
+    
+        .def(py::self += double())
+        .def(py::self *= double())
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+    
+        .def_property_readonly("small", &sum::small)
+        .def_property_readonly("large", &sum::large)
+    
+        .def("__repr__", [](const sum& self){
+            std::ostringstream out;
+            out << self;
+            return out.str();
+        })
+    ;
+
+}

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -80,7 +80,7 @@ py::class_<A> register_axis_by_type(py::module& m, const char* name, const char*
          "Retuns the number of bins, including over- or underflow")
     .def("update", &A::update, "Bin and add a value if allowed", "i"_a)
     .def_static("options", &A::options, "Return the options associated to the axis")
-    .def_property("label",
+    .def_property("metadata",
                   [](const A& self){return self.metadata();},
                   [](A& self, metadata_t label){self.metadata() = label;},
                   "Set the axis label")
@@ -132,67 +132,67 @@ void register_axis(py::module &m) {
     
     
     register_axis_by_type<axis::regular>(ax, "regular", "Evenly spaced bins")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "label"_a = "")
+    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = "")
     ;
     register_axis_iv_by_type<axis::regular>(ax, "_regular_internal_view");
 
 
     register_axis_by_type<axis::regular_noflow>(ax, "regular_noflow", "Evenly spaced bins without over/under flow")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "label"_a = "")
+    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = "")
     ;
     register_axis_iv_by_type<axis::regular_noflow>(ax, "_regular_noflow_internal_view");
 
 
     register_axis_by_type<axis::regular_growth>(ax, "regular_growth", "Evenly spaced bins that grow as needed")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "label"_a = "")
+    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = "")
     ;
     register_axis_iv_by_type<axis::regular_growth>(ax, "_regular_growth_internal_view");
 
 
     register_axis_by_type<axis::circular>(ax, "circular", "Evenly spaced bins with wraparound")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "label"_a = "")
+    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = "")
     ;
     register_axis_iv_by_type<axis::circular>(ax, "_circular_internal_view");
 
 
     register_axis_by_type<axis::regular_log>(ax, "regular_log", "Evenly spaced bins in log10")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "label"_a = "")
+    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = "")
     ;
     register_axis_iv_by_type<axis::regular_log>(ax, "_regular_log_internal_view");
 
 
     register_axis_by_type<axis::regular_sqrt>(ax, "regular_sqrt", "Evenly spaced bins in sqrt")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "label"_a = "")
+    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = "")
     ;
     register_axis_iv_by_type<axis::regular_sqrt>(ax, "_regular_sqrt_internal_view");
 
 
     register_axis_by_type<axis::regular_pow>(ax, "regular_pow", "Evenly spaced bins in a power")
-    .def(py::init([](double pow, unsigned n, double start, double stop, metadata_t label){
-        return new axis::regular_pow(bh::axis::transform::pow{pow}, n, start , stop, label);} ),
-         "pow"_a, "n"_a, "start"_a, "stop"_a, "label"_a = "")
+    .def(py::init([](double pow, unsigned n, double start, double stop, metadata_t metadata){
+        return new axis::regular_pow(bh::axis::transform::pow{pow}, n, start, stop, metadata);} ),
+         "pow"_a, "n"_a, "start"_a, "stop"_a, "metadata"_a = "")
     ;
     register_axis_iv_by_type<axis::regular_pow>(ax, "_regular_pow_internal_view");
 
 
     register_axis_by_type<axis::variable>(ax, "variable", "Unevenly spaced bins")
-    .def(py::init<std::vector<double>, metadata_t>(), "edges"_a, "label"_a = "")
+    .def(py::init<std::vector<double>, metadata_t>(), "edges"_a, "metadata"_a = "")
     ;
     register_axis_iv_by_type<axis::variable>(ax, "_variable_internal_view");
 
 
     register_axis_by_type<axis::integer>(ax, "integer", "Contigious integers")
-    .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "label"_a = "")
+    .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = "")
     ;
     register_axis_iv_by_type<axis::integer>(ax, "_integer_internal_view");
 
 
     register_axis_by_type<axis::category_str, std::string>(ax, "category_str", "Text label bins")
-    .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "label"_a = "")
+    .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "metadata"_a = "")
     ;
 
     register_axis_by_type<axis::category_str_growth, std::string>(ax, "category_str_growth", "Text label bins")
-    .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "label"_a = "")
+    .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "metadata"_a = "")
     // Add way to allow empty list of strings
     .def(py::init<>())
     ;

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -87,7 +87,7 @@ py::class_<bh::histogram<A, S>> register_histogram_by_type(py::module& m, const 
         },
          "Access bin counter at indices")
 
-    .def("__repr__", [](histogram_t &self){
+    .def("__repr__", [](const histogram_t &self){
         std::ostringstream out;
         out << self;
         return out.str();

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -8,9 +8,11 @@
 void register_axis(py::module &);
 void register_histogram(py::module &);
 void register_storage(py::module &);
+void register_accumulators(py::module &);
 
 PYBIND11_MODULE(histogram, m) {
     register_storage(m);
     register_axis(m);
     register_histogram(m);
+    register_accumulators(m);
 }

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -16,6 +16,14 @@ def test_weighted_sum():
     assert v.value == 3.0
     assert v.variance == 4.75
 
+    v = bh.accumulator.weighted_sum()
+    v([1,2,3], [4,5,6])
+
+    assert v.value == 6
+    assert v.variance == 15
+
+
+
 def test_weighted_mean():
     v = bh.accumulator.weighted_mean()
     v(1,4)
@@ -25,11 +33,27 @@ def test_weighted_mean():
     assert v.variance == 4.5
     assert v.value == 2.0
 
+    v = bh.accumulator.weighted_mean()
+    v([1,2],[4,1])
+
+    assert v.sum_of_weights == 3.0
+    assert v.variance == 4.5
+    assert v.value == 2.0
+
+
+
 def test_mean():
     v = bh.accumulator.mean()
     v(1)
     v(2)
     v(3)
+
+    assert v.count == 3
+    assert v.variance == 1
+    assert v.value == 2
+
+    v = bh.accumulator.mean()
+    v([1,2,3])
 
     assert v.count == 3
     assert v.variance == 1
@@ -42,5 +66,9 @@ def test_sum():
     v += 2
     v += 3
 
+    assert v.value == 6
+
+    v = bh.accumulator.sum()
+    v([1,2,3])
     assert v.value == 6
 

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -1,0 +1,46 @@
+import pytest
+from pytest import approx
+
+import histogram as bh
+import numpy as np
+
+
+def test_weighted_sum():
+    v = bh.accumulator.weighted_sum(1.5, 2.5)
+
+    assert v.value == 1.5
+    assert v.variance == 2.5
+
+    v += 1.5
+
+    assert v.value == 3.0
+    assert v.variance == 4.75
+
+def test_weighted_mean():
+    v = bh.accumulator.weighted_mean()
+    v(1,4)
+    v(2,1)
+
+    assert v.sum_of_weights == 3.0
+    assert v.variance == 4.5
+    assert v.value == 2.0
+
+def test_mean():
+    v = bh.accumulator.mean()
+    v(1)
+    v(2)
+    v(3)
+
+    assert v.count == 3
+    assert v.variance == 1
+    assert v.value == 2
+
+
+def test_sum():
+    v = bh.accumulator.sum()
+    v += 1
+    v += 2
+    v += 3
+
+    assert v.value == 6
+

--- a/tests/test_axis_internal.py
+++ b/tests/test_axis_internal.py
@@ -89,21 +89,21 @@ def test_regular_axis_repr(axis):
     ax = axis(2,3,4)
     assert 'object at' not in repr(ax)
 
-    ax = axis(7,2,4, label='This')
+    ax = axis(7,2,4, metadata='This')
     assert 'This' in repr(ax)
-    assert ax.label == 'This'
+    assert ax.metadata == 'This'
 
-    ax.label = 'That'
-    ax = axis(7,2,4, label='That')
+    ax.metadata = 'That'
+    ax = axis(7,2,4, metadata='That')
     assert 'That' in repr(ax)
-    assert ax.label == 'That'
+    assert ax.metadata == 'That'
 
 @pytest.mark.parametrize("axis", normal_axs)
-def test_any_label(axis):
-    ax = axis(2,3,4, label={"one": "1"})
-    assert ax.label == {"one": "1"}
-    ax.label = 64
-    assert ax.label == 64
+def test_any_metadata(axis):
+    ax = axis(2,3,4, metadata={"one": "1"})
+    assert ax.metadata == {"one": "1"}
+    ax.metadata = 64
+    assert ax.metadata == 64
 
 def test_cat_str():
     ax = bh.axis.category_str(["a", "b", "c"])

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -57,8 +57,8 @@ def test_make_any_hist_storage():
     assert float == type(bh.make_histogram(bh.axis.regular(5,1,2), storage=bh.storage.dense_double()).at(0))
 
 def test_issue_axis_bin_swan():
-    hist = bh.make_histogram(bh.axis.regular_sqrt(10,0,10, label='x'),
-                             bh.axis.circular(10,0,1, label='y'))
+    hist = bh.make_histogram(bh.axis.regular_sqrt(10,0,10, metadata='x'),
+                             bh.axis.circular(10,0,1, metadata='y'))
 
     b = hist.axis(1).bin(1)
     assert repr(b) == '<bin [0.100000, 0.200000]>'


### PR DESCRIPTION
This adds support for the built-in accumulators, mostly in case a histogram returns one, but also has vectorized (numpy sense) accumulation.

Renamed parameter x to value in a few cases, and providing `__call__` interface even when B::H does not (not sure how I feel about that; even VI is complaining about ignoring the return value of a "function".)

Also renames label -> metadata. Followup to #15, discussed in #14.