### PR TITLE
Rename histogram -> boost.histogram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,6 @@
 # Python binary files
 *.pyc
 *__pycache__*
+*.env
+*.egg-info
 .ipynb_checkpoints

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,13 @@ if(NOT "${BOOST_HISTOGRAM_DETAIL_AXES_LIMIT}" STREQUAL "")
     target_compile_definitions(histogram PRIVATE BOOST_HISTOGRAM_DETAIL_AXES_LIMIT=${BOOST_HISTOGRAM_DETAIL_AXES_LIMIT})
 endif()
 
+# Make the output be in boost/...
+set_property(TARGET histogram PROPERTY LIBRARY_OUTPUT_DIRECTORY "boost")
+configure_file(
+    "boost/__init__.py"
+    "${CMAKE_CURRENT_BINARY_DIR}/boost/__init__.py"
+    COPYONLY)
+
 # Tests (Requires pytest to be available to run)
 include(CTest)
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@
 [![Gitter][gitter-badge]][gitter-link]
 [![Build Status][azure-badge]][azure-link]
 
-Python bindings for [Boost::Histogram][], a C++14 library. This should become one of the [fastest libraries][] for histogramming, while still providing the power of a full histogram object.
+Python bindings for [Boost::Histogram][] ([source][Boost::Histogram source]), a C++14 library. This should become one of the [fastest libraries][] for histogramming, while still providing the power of a full histogram object.
 
 > # Warning: This bindings are in progress and are not yet in an alpha stage.
 >
 > Join the discussion on gitter to follow the development!
 
-[Boost::Histogram]:  https://www.boost.org/doc/libs/develop/libs/histogram/doc/html/index.html 
-[fastest libraries]: https://iscinumpy.gitlab.io/post/histogram-speeds-in-python/
+[Boost::Histogram]:        https://www.boost.org/doc/libs/develop/libs/histogram/doc/html/index.html 
+[Boost::Histogram source]: https://www.boost.org/doc/libs/develop/libs/histogram/doc/html/index.html 
+[fastest libraries]:       https://iscinumpy.gitlab.io/post/histogram-speeds-in-python/
+
 
 
 ## Installation
@@ -21,6 +23,70 @@ All the normal best-practices for Python apply; you should be in a virtual envir
 ```bash
 python -m pip install git+https://github.com/scikit-hep/boost-histogram.git@develop
 ```
+
+## Usage
+
+This is a suggested example of usage.
+
+```python
+import boost.histogram as bh
+
+# Compose axis however you like
+hist = bh.make_histogram(bh.axis.regular(2, 0, 1),
+                         bh.axis.regular(4, 0.0, 1.0))
+
+# Filling can be done with arrays, one per diminsion
+hist([.3, .5, .2],
+     [.1, .4, .9])
+
+# Numpy array view into histogram counts, no overflow bins
+counts = hist.view()
+```
+
+## Features
+
+* Many axis types (all support `metadata=...`)
+    * `bh.axis.regular(n, start, stop)`: `n` evenly spaced bins from `start` to `stop`
+    * `bh.axis.regular_noflow(n, start, stop)`: `regular` but with no underflow or overflow bins
+    * `bh.axis.regular_growth(n, start, stop)`: `regular` but grows if a value is added outside the range
+    * `bh.axis.circular(n, start, stop)`: Value outside the range wrap into the range
+    * `bh.axis.regular_log(n, start, stop)`: Regularly spaced values in log 10 scale
+    * `bh.axis.regular_sqrt(n, start, stop)`: Regularly spaced value in sqrt scale
+    * `bh.axis.regular_pow(power, n, start, stop)`: Regularly spaced value to some `power`
+    * `bh.axis.integer(start, stop)`: Special high-speed version of `regular` for evenly spaced bins of width 1
+    * `bh.axis.variable([start, edge1, edge2, ..., stop])`: Uneven bin spacing
+    * `bh.axis.category_str(["item1", "item2", ...])`: String bins
+    * `bh.axis.category_str_growth(["item1", "item2", ...])`: String bins where new items automatically get added
+* Many storage types
+    * `bh.storage.int`: 64 bit unsigned integers for high performance and useful view access
+    * `bh.storage.double`: Doubles for weighted values
+    * `bh.storage.unlimited`: Starts small, but can go up to unlimited precision ints or doubles.
+    * `bh.storage.atomic_int`: Threadsafe filling, for higher performance on multhreaded backends. Does not support growing axis in threads.
+    * `bh.storage.weight`: WIP
+    * `bh.storage.profile`: WIP
+    * `bh.storage.weighted_profile`: WIP
+* Accumulators
+    `bh.accumulator.weighted_sum`: Tracks a weighted sum and variance
+    `bh.accumulator.weighted_mean`: Tracks a weighted sum, mean, and variance (West's incremental algorithm)
+    `bh.accumulator.sum`: High accuracy sum (Neumaier)
+    `bh.accumulator.mean`: Running count, mean, and variance (Welfords's incremental algorithm)
+* Histogram operations
+    * `(a, b, ...)`: Fill with arrays or single values
+    * `+`: Add two histograms
+    * `.rank()`: The number of dimensions
+    * `.size()`: The number of bins (including under/overflow)
+    * `.reset()`: Set counters to 0
+    * `*=`: Multiply by a scaler (not all storages)
+    * `/=`: Divide by a scaler (not all storages)
+    * `.to_numpy(flow=False)`: Convert to a numpy style tuple (with or without under/overflow bins)
+    * `.view(flow=False)`: Get a view on the bin contents (with or without under/overflow bins)
+    * `np.asarray(...)`: Get a view on the bin contents with under/overflow bins
+    * `.axis(i)`: Get the `i`th axis
+    * `.at(i, j, ...)`: Get the bin contents as a location 
+* Details
+    * Use `bh.make_histogram(..., storage=...)` to make a histogram (there are several different types) 
+    * Several common combinations are optimized, such as 1 or 2D regular axes + int storage
+
 
 
 ## Developing
@@ -57,6 +123,18 @@ Run the unit tests (requires pytest and numpy). Use `ctest` or `make test`, like
 ```bash
 make test
 ```
+
+The tests require `numpy` and `pytest`. If you are using Python 2, you will need `futures` as well.
+
+To install using the pip method for development instead, run:
+
+```bash
+python3 -m venv .env
+. .env/bin/activate
+python -m pip install .[test]
+```
+
+You'll need to reinstall it if you want to rebuild.
 
 [gitter-badge]: https://badges.gitter.im/HSF/PyHEP-histogramming.svg
 [gitter-link]:  https://gitter.im/HSF/PyHEP-histogramming?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge

--- a/notebooks/AtomicHistograms.ipynb
+++ b/notebooks/AtomicHistograms.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import histogram as bh\n",
+    "import boost.histogram as bh\n",
     "from concurrent.futures import ThreadPoolExecutor\n",
     "from functools import reduce\n",
     "from operator import add"

--- a/notebooks/DevelopInstallExample.ipynb
+++ b/notebooks/DevelopInstallExample.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import histogram as bh\n",
+    "import boost.histogram as bh\n",
     "import numpy as np"
    ]
   },

--- a/notebooks/PerformanceComparison.ipynb
+++ b/notebooks/PerformanceComparison.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import histogram as bh\n",
+    "import boost.histogram as bh\n",
     "import numpy as np"
    ]
   },

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,13 @@ from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
+from setuptools import find_packages
 
 __version__ = '0.0.1'
 
 ext_modules = [
     Extension(
-        'histogram',
+        'boost.histogram',
         ['src/module.cpp',
          'src/histogram/axis.cpp',
          'src/histogram/histogram.cpp',
@@ -96,7 +97,7 @@ extras = {
 }
 
 setup(
-    name='histogram',
+    name='boost-histogram',
     version=__version__,
     author='Henry Schreiner',
     author_email='hschrein@cern.ch',
@@ -104,6 +105,7 @@ setup(
     description='The Boost::Histogram Python wrapper.',
     long_description='',
     ext_modules=ext_modules,
+    packages=find_packages(),
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,
     install_requires=['numpy'],

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest import approx
 
-import histogram as bh
+import boost.histogram as bh
 import numpy as np
 
 

--- a/tests/test_atomic_fill.py
+++ b/tests/test_atomic_fill.py
@@ -1,7 +1,7 @@
 import pytest
 
 import numpy as np
-import histogram as bh
+import boost.histogram as bh
 
 from concurrent.futures import ThreadPoolExecutor
 from functools import reduce

--- a/tests/test_axis_internal.py
+++ b/tests/test_axis_internal.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest import approx
 
-import histogram as bh
+import boost.histogram as bh
 import numpy as np
 
 

--- a/tests/test_basic_import.py
+++ b/tests/test_basic_import.py
@@ -1,4 +1,4 @@
-import histogram as bh
+import boost.histogram as bh
 
 def test_import():
     assert bh

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -1,6 +1,6 @@
 import pytest
 
-import histogram as bh
+import boost.histogram as bh
 import numpy as np
 
 

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -2,7 +2,7 @@ import pytest
 from pytest import approx
 import math
 
-import histogram as bh
+import boost.histogram as bh
 
 @pytest.mark.parametrize("axis,extent", ((bh.axis.regular, 2),
                                          (bh.axis.regular_noflow, 0)))


### PR DESCRIPTION
Move to subdirectory, now called boost.histogram. Note that __init__.py must match all other packages with the "boost" name.