### PR TITLE
Cereal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "extern/utility"]
 	path = extern/utility
 	url = ../../boostorg/utility.git
+[submodule "extern/cereal"]
+	path = extern/cereal
+	url = ../../USCiLab/cereal.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ target_include_directories(histogram SYSTEM PUBLIC
     extern/variant/include
     )
 
+# This is the Cereal heaader-only library required for serialization
+target_include_directories(histogram SYSTEM PUBLIC
+    extern/cereal/include
+    )
+
 # This makes IDE's like XCode mimic the Boost Histogram structure
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/extern/histogram/include PREFIX "Header Files" FILES ${BOOST_HIST_FILES})
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include PREFIX "Header Files" FILES ${BOOST_HIST_PY_HEADERS})
@@ -81,6 +86,9 @@ if(BOOST_HISTOGRAM_ERRORS)
             /WE>)
 endif()
 
+target_compile_options(histogram PRIVATE
+                       $<$<CXX_COMPILER_ID:AppleClang>:
+                           -ftemplate-backtrace-limit=0>)
 
 set(BOOST_HISTOGRAM_DETAIL_AXES_LIMIT "" CACHE STRING "Set the maximum number of axis in a histogram (affects compile time and size)")
 if(NOT "${BOOST_HISTOGRAM_DETAIL_AXES_LIMIT}" STREQUAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ option(BOOST_HISTOGRAM_ERRORS "Make warnings errors (for CI mostly)")
 # Adding warnings
 target_compile_options(histogram PRIVATE
                        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-                           -Wall -Wextra -pedantic-errors -Wconversion -Wsign-conversion>
+                           -Wall -Wextra -pedantic-errors -Wconversion -Wsign-conversion -Wno-return-std-move>
                        $<$<CXX_COMPILER_ID:MSVC>:
                            /W4>)
 if(BOOST_HISTOGRAM_ERRORS)

--- a/include/boost/histogram/python/cereal.hpp
+++ b/include/boost/histogram/python/cereal.hpp
@@ -1,0 +1,212 @@
+// Copyright 2015-2019 Hans Dembinski and Henry Schreiner
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_HISTOGRAM_CEREAL_HPP
+#define BOOST_HISTOGRAM_CEREAL_HPP
+
+#include <boost/assert.hpp>
+#include <boost/histogram/accumulators/mean.hpp>
+#include <boost/histogram/accumulators/sum.hpp>
+#include <boost/histogram/accumulators/weighted_mean.hpp>
+#include <boost/histogram/accumulators/weighted_sum.hpp>
+#include <boost/histogram/axis/category.hpp>
+#include <boost/histogram/axis/integer.hpp>
+#include <boost/histogram/axis/regular.hpp>
+#include <boost/histogram/axis/variable.hpp>
+#include <boost/histogram/axis/variant.hpp>
+#include <boost/histogram/histogram.hpp>
+#include <boost/histogram/storage_adaptor.hpp>
+#include <boost/histogram/unlimited_storage.hpp>
+#include <boost/histogram/unsafe_access.hpp>
+#include <boost/mp11/tuple.hpp>
+
+#include <cereal/cereal.hpp>
+
+#include <cereal/types/array.hpp>
+#include <cereal/types/map.hpp>
+#include <cereal/types/string.hpp>
+#include <cereal/types/boost_variant.hpp>
+#include <cereal/types/vector.hpp>
+
+//#include <boost/serialization/array.hpp>
+//#include <boost/serialization/map.hpp>
+//#include <boost/serialization/nvp.hpp>
+//#include <boost/serialization/string.hpp>
+//#include <boost/serialization/variant.hpp>
+//#include <boost/serialization/vector.hpp>
+
+#include <tuple>
+#include <type_traits>
+
+namespace std {
+template <class Archive, class... Ts>
+void serialize(Archive& ar, tuple<Ts...>& t, unsigned /* version */) {
+  ::boost::mp11::tuple_for_each(
+      t, [&ar](auto& x) { ar& cereal::make_nvp("item", x); });
+}
+} // namespace std
+
+namespace boost {
+namespace histogram {
+
+namespace accumulators {
+template <class RealType>
+template <class Archive>
+void sum<RealType>::serialize(Archive& ar, unsigned /* version */) {
+  ar& cereal::make_nvp("large", large_);
+  ar& cereal::make_nvp("small", small_);
+}
+
+template <class RealType>
+template <class Archive>
+void weighted_sum<RealType>::serialize(Archive& ar, unsigned /* version */) {
+  ar& cereal::make_nvp("sum_of_weights", sum_of_weights_);
+  ar& cereal::make_nvp("sum_of_weights_squared", sum_of_weights_squared_);
+}
+
+template <class RealType>
+template <class Archive>
+void mean<RealType>::serialize(Archive& ar, unsigned /* version */) {
+  ar& cereal::make_nvp("sum", sum_);
+  ar& cereal::make_nvp("mean", mean_);
+  ar& cereal::make_nvp("sum_of_deltas_squared", sum_of_deltas_squared_);
+}
+
+template <class RealType>
+template <class Archive>
+void weighted_mean<RealType>::serialize(Archive& ar, unsigned /* version */) {
+  ar& cereal::make_nvp("sum_of_weights", sum_of_weights_);
+  ar& cereal::make_nvp("sum_of_weights_squared", sum_of_weights_squared_);
+  ar& cereal::make_nvp("weighted_mean", weighted_mean_);
+  ar& cereal::make_nvp("sum_of_weighted_deltas_squared",
+                              sum_of_weighted_deltas_squared_);
+}
+} // namespace accumulators
+
+namespace axis {
+
+namespace transform {
+template <class Archive>
+void serialize(Archive&, id&, unsigned /* version */) {}
+
+template <class Archive>
+void serialize(Archive&, log&, unsigned /* version */) {}
+
+template <class Archive>
+void serialize(Archive&, sqrt&, unsigned /* version */) {}
+
+template <class Archive>
+void serialize(Archive& ar, pow& t, unsigned /* version */) {
+  ar& cereal::make_nvp("power", t.power);
+}
+} // namespace transform
+
+template <class Archive>
+void serialize(Archive&, null_type&, unsigned /* version */) {}
+
+template <class T, class Tr, class M, class O>
+template <class Archive>
+void regular<T, Tr, M, O>::serialize(Archive& ar, unsigned /* version */) {
+  ar& cereal::make_nvp("transform", static_cast<transform_type&>(*this));
+  ar& cereal::make_nvp("size", size_meta_.first());
+  ar& cereal::make_nvp("meta", size_meta_.second());  // Python stores metadata seperately
+  ar& cereal::make_nvp("min", min_);
+  ar& cereal::make_nvp("delta", delta_);
+}
+
+template <class T, class M, class O>
+template <class Archive>
+void integer<T, M, O>::serialize(Archive& ar, unsigned /* version */) {
+  ar& cereal::make_nvp("size", size_meta_.first());
+  ar& cereal::make_nvp("meta", size_meta_.second());
+  ar& cereal::make_nvp("min", min_);
+}
+
+template <class T, class M, class O, class A>
+template <class Archive>
+void variable<T, M, O, A>::serialize(Archive& ar, unsigned /* version */) {
+  ar& cereal::make_nvp("seq", vec_meta_.first());
+  ar& cereal::make_nvp("meta", vec_meta_.second());
+}
+
+template <class T, class M, class O, class A>
+template <class Archive>
+void category<T, M, O, A>::serialize(Archive& ar, unsigned /* version */) {
+  ar& cereal::make_nvp("seq", vec_meta_.first());
+  ar& cereal::make_nvp("meta", vec_meta_.second());
+}
+
+template <class... Ts>
+template <class Archive>
+void variant<Ts...>::serialize(Archive& ar, unsigned /* version */) {
+  ar& cereal::make_nvp("variant", impl);
+}
+} // namespace axis
+
+namespace detail {
+template <class Archive, class T>
+void serialize(Archive& ar, vector_impl<T>& impl, unsigned /* version */) {
+  ar& cereal::make_nvp("vector", static_cast<T&>(impl));
+}
+
+template <class Archive, class T>
+void serialize(Archive& ar, array_impl<T>& impl, unsigned /* version */) {
+  ar& cereal::make_nvp("size", impl.size_);
+  ar& cereal::make_nvp("array", impl);
+                       // cereal::binary_data(&impl.front(), impl.size_));
+}
+
+template <class Archive, class T>
+void serialize(Archive& ar, map_impl<T>& impl, unsigned /* version */) {
+  ar& cereal::make_nvp("size", impl.size_);
+  ar& cereal::make_nvp("map", static_cast<T&>(impl));
+}
+
+template <class Archive, class Allocator>
+void serialize(Archive& ar, mp_int<Allocator>& x, unsigned /* version */) {
+  ar& cereal::make_nvp("data", x.data);
+}
+} // namespace detail
+
+template <class Archive, class T>
+void serialize(Archive& ar, storage_adaptor<T>& s, unsigned /* version */) {
+  ar& cereal::make_nvp("impl", static_cast<detail::storage_adaptor_impl<T>&>(s));
+}
+
+template <class A>
+template <class Archive>
+void unlimited_storage<A>::serialize(Archive& ar, unsigned /* version */) {
+  if (Archive::is_loading::value) {
+    buffer_type dummy(buffer.alloc);
+    std::size_t size;
+    ar& cereal::make_nvp("type", dummy.type);
+    ar& cereal::make_nvp("size", size);
+    dummy.apply([this, size](auto* tp) {
+      BOOST_ASSERT(tp == nullptr);
+      using T = detail::remove_cvref_t<decltype(*tp)>;
+      buffer.template make<T>(size);
+    });
+  } else {
+    ar& cereal::make_nvp("type", buffer.type);
+    ar& cereal::make_nvp("size", buffer.size);
+  }
+  buffer.apply([this, &ar](auto* tp) {
+    using T = detail::remove_cvref_t<decltype(*tp)>;
+    ar& cereal::make_nvp("buffer", buffer);
+        //cereal::binary_data(reinterpret_cast<T*>(buffer.ptr), buffer.size));
+  });
+}
+
+template <class Archive, class A, class S>
+void serialize(Archive& ar, histogram<A, S>& h, unsigned /* version */) {
+  ar& cereal::make_nvp("axes", unsafe_access::axes(h));
+  ar& cereal::make_nvp("storage", unsafe_access::storage(h));
+}
+
+} // namespace histogram
+} // namespace boost
+
+#endif

--- a/include/boost/histogram/python/cereal.hpp
+++ b/include/boost/histogram/python/cereal.hpp
@@ -191,7 +191,7 @@ template <class Archive, class T>
 void serialize(Archive& ar, storage_adaptor<T>& s, unsigned /* version */) {
   ar& cereal::make_nvp("impl", static_cast<detail::storage_adaptor_impl<T>&>(s));
 }
-
+    
 template <class A>
 template <class Archive>
 void unlimited_storage<A>::serialize(Archive& ar, unsigned /* version */) {
@@ -209,8 +209,8 @@ void unlimited_storage<A>::serialize(Archive& ar, unsigned /* version */) {
     ar& cereal::make_nvp("type", buffer.type);
     ar& cereal::make_nvp("size", buffer.size);
   }
-  buffer.apply([this, &ar](auto* tp) {
-    using T = detail::remove_cvref_t<decltype(*tp)>;
+  buffer.apply([this, &ar](auto*) {
+    // using T = detail::remove_cvref_t<decltype(*tp)>;
     ar& cereal::make_nvp("buffer", buffer);
         //cereal::binary_data(reinterpret_cast<T*>(buffer.ptr), buffer.size));
   });

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ ext_modules = [
             'extern/type_traits/include',
             'extern/utility/include',
             'extern/variant/include',
+            'extern/cereal/include',
         ],
         language='c++'
     ),

--- a/src/histogram/accumulators.cpp
+++ b/src/histogram/accumulators.cpp
@@ -13,6 +13,9 @@
 #include <boost/histogram/accumulators/sum.hpp>
 #include <boost/histogram/accumulators/ostream.hpp>
 
+#include <boost/histogram/python/cereal.hpp>
+#include <cereal/archives/binary.hpp>
+
 
 void register_accumulators(py::module &m) {
     
@@ -45,6 +48,22 @@ void register_accumulators(py::module &m) {
         }), "values"_a, "variances"_a)
     
         .def("__repr__", shift_to_string<weighted_sum>())
+    
+        .def(py::pickle(
+         [](const weighted_sum &p){
+             std::stringstream data;
+             cereal::BinaryOutputArchive archive( data );
+             archive(p);
+             return py::make_tuple(py::bytes(data.str()));
+             },
+         [](py::tuple t){
+             std::stringstream data;
+             data << py::cast<std::string>(t[0]);
+             cereal::BinaryInputArchive archive( data );
+             weighted_sum p;
+             archive(p);
+             return p;
+         }))
     ;
 
     using weighted_mean = bh::accumulators::weighted_mean<double>;

--- a/src/histogram/accumulators.cpp
+++ b/src/histogram/accumulators.cpp
@@ -14,7 +14,6 @@
 #include <boost/histogram/accumulators/ostream.hpp>
 
 #include <boost/histogram/python/cereal.hpp>
-#include <cereal/archives/binary.hpp>
 
 
 void register_accumulators(py::module &m) {
@@ -49,21 +48,8 @@ void register_accumulators(py::module &m) {
     
         .def("__repr__", shift_to_string<weighted_sum>())
     
-        .def(py::pickle(
-         [](const weighted_sum &p){
-             std::stringstream data;
-             cereal::BinaryOutputArchive archive( data );
-             archive(p);
-             return py::make_tuple(py::bytes(data.str()));
-             },
-         [](py::tuple t){
-             std::stringstream data;
-             data << py::cast<std::string>(t[0]);
-             cereal::BinaryInputArchive archive( data );
-             weighted_sum p;
-             archive(p);
-             return p;
-         }))
+        .def(py::pickle([](const weighted_sum &p){return pickle_totuple(p);},
+                        [](py::tuple t){return pickle_fromtuple<weighted_sum>(t);}))
     ;
 
     using weighted_mean = bh::accumulators::weighted_mean<double>;
@@ -94,6 +80,8 @@ void register_accumulators(py::module &m) {
 
       .def("__repr__", shift_to_string<weighted_mean>())
     
+      .def(py::pickle([](const weighted_mean &p){return pickle_totuple(p);},
+                      [](py::tuple t){return pickle_fromtuple<weighted_mean>(t);}))
       ;
 
     
@@ -119,6 +107,9 @@ void register_accumulators(py::module &m) {
         }), "value"_a)
     
         .def("__repr__", shift_to_string<mean>())
+    
+        .def(py::pickle([](const mean &p){return pickle_totuple(p);},
+                        [](py::tuple t){return pickle_fromtuple<mean>(t);}))
     ;
     
     using sum = bh::accumulators::sum<double>;
@@ -143,6 +134,9 @@ void register_accumulators(py::module &m) {
         .def_property_readonly("large", &sum::large)
     
         .def("__repr__", shift_to_string<sum>())
+    
+        .def(py::pickle([](const sum &p){return pickle_totuple(p);},
+                        [](py::tuple t){return pickle_fromtuple<sum>(t);}))
     ;
 
 }

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -141,6 +141,9 @@ void register_axis(py::module &m) {
 
     register_axis_by_type<axis::circular>(ax, "circular", "Evenly spaced bins with wraparound")
     .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
+    .def(py::init([](unsigned n, double stop, metadata_t metadata){
+        return new axis::circular{n, 0.0, stop, metadata};
+    }), "n"_a, "stop"_a, "metadata"_a = py::str())
     ;
     register_axis_iv_by_type<axis::circular>(ax, "_circular_internal_view");
 
@@ -184,6 +187,7 @@ void register_axis(py::module &m) {
 
     register_axis_by_type<axis::category_int_growth, std::string>(ax, "category_int_growth", "Text label bins")
     .def(py::init<std::vector<int>, metadata_t>(), "labels"_a, "metadata"_a = py::str())
+    .def(py::init<>())
     ;
 
 

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -9,11 +9,14 @@
 #include <pybind11/operators.h>
 
 #include <boost/histogram/python/axis.hpp>
+#include <boost/histogram/python/cereal.hpp>
 
+#include <boost/histogram/axis/traits.hpp>
 #include <boost/histogram/axis/ostream.hpp>
 #include <boost/histogram.hpp>
 
-#include <boost/histogram/axis/traits.hpp>
+// Non-portable across endianess
+#include <cereal/archives/binary.hpp>
 
 #include <iostream>
 #include <sstream>
@@ -76,6 +79,25 @@ py::class_<A> register_axis_by_type(py::module& m, const char* name, const char*
                   "Set the axis label")
 
     ;
+    /*
+    axis.def(py::pickle(
+        [](const A &p){
+            std::stringstream data;
+            {
+                cereal::BinaryOutputArchive archive( data );
+                archive(p);
+            }
+            return py::make_tuple(data.str());
+        },
+        [](py::tuple t){
+            std::stringstream data;
+            data << py::cast<std::string>(t[0]);
+            cereal::BinaryInputArchive archive( data );
+            A* p = new A();
+            archive(&p);
+            return p;
+        }));
+     */
 
     // We only need keepalive if this is a reference.
     using Result = decltype(std::declval<A>().bin(std::declval<int>()));

--- a/tests/test_public_axis.py
+++ b/tests/test_public_axis.py
@@ -1,0 +1,475 @@
+import pytest
+from pytest import approx
+
+from boost.histogram.axis import (regular, regular_noflow,
+                                  regular_log, regular_sqrt,
+                                  regular_pow, circular,
+                                  variable, integer,
+                                  category_int as category)
+
+import numpy as np
+
+import abc
+
+# compatible with Python 2 *and* 3:
+ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
+
+# histogram -> boost.histogram
+# regular(..., noflow=True) -> regular_noflow(...)
+# label -> metadata
+# regular_pow(n,start,stop,power) +> regular_pow(power,n,start,stop)
+# len(ax) -> ax.size() # also .extent()
+# ax[i] -> ax.bin(i) # (.lower() and .upper() instead of [0] and [1]) (may return)
+# Circular is very different (Boost::Histogram change)
+# Variable and category take an array/list now
+
+class Axis(ABC):
+
+    @abc.abstractmethod
+    def test_init(self):
+        pass
+
+    @abc.abstractmethod
+    def test_len(self):
+        pass
+
+    @abc.abstractmethod
+    def test_repr(self):
+        pass
+
+    @abc.abstractmethod
+    def test_getitem(self):
+        pass
+
+    @abc.abstractmethod
+    def test_iter(self):
+        pass
+
+    @abc.abstractmethod
+    def test_index(self):
+        pass
+
+
+
+class TestRegular(Axis):
+
+    def test_init(self):
+        # Should not throw
+        regular(1, 1.0, 2.0)
+        regular(1, 1.0, 2.0, metadata="ra")
+        regular_noflow(1, 1.0, 2.0)
+        regular_noflow(1, 1.0, 2.0, metadata="ra")
+        regular_log(1, 1.0, 2.0)
+        regular_sqrt(1, 1.0, 2.0)
+        regular_pow(1.5, 1, 1.0, 2.0)
+
+        with pytest.raises(TypeError):
+            regular()
+        with pytest.raises(TypeError):
+            regular()
+        with pytest.raises(TypeError):
+            regular(1)
+        with pytest.raises(TypeError):
+            regular(1, 1.0)
+        with pytest.raises(ValueError):
+            regular(0, 1.0, 2.0)
+        with pytest.raises(TypeError):
+            regular("1", 1.0, 2.0)
+        with pytest.raises(Exception):
+            regular(-1, 1.0, 2.0)
+        # CLASSIC
+        #with pytest.raises(ValueError):
+        regular(1, 2.0, 1.0)
+
+        with pytest.raises(ValueError):
+            regular(1, 1.0, 1.0)
+
+        # CLASSIC: this was not allowed. Now it is.
+        # with pytest.raises(TypeError):
+        regular(1, 1.0, 2.0, metadata=0)
+
+
+
+        with pytest.raises(TypeError):
+            regular(1, 1.0, 2.0, bad_keyword="ra")
+        with pytest.raises(TypeError):
+            regular_pow(1, 1.0, 2.0)
+
+        a = regular(4, 1.0, 2.0)
+        assert a == regular(4, 1.0, 2.0)
+        assert a != regular(3, 1.0, 2.0)
+        assert a != regular(4, 1.1, 2.0)
+        assert a != regular(4, 1.0, 2.1)
+
+
+    def test_len(self):
+        a = regular(4, 1.0, 2.0)
+        # CLASSIC: Not explicit
+        # assert len(a) == 4
+
+        assert a.size() == 4
+        assert a.extent() == 6
+
+    def test_repr(self):
+        ax = regular(4, 1.1, 2.2)
+        assert repr(ax) == "regular(4, 1.1, 2.2, options=underflow | overflow)"
+
+        ax = regular(4, 1.1, 2.2, metadata='ra')
+        assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra", options=underflow | overflow)'
+
+        ax = regular_noflow(4, 1.1, 2.2)
+        assert repr(ax) == "regular(4, 1.1, 2.2, options=none)"
+
+        ax = regular_noflow(4, 1.1, 2.2, metadata='ra')
+        assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra", options=none)'
+
+        ax = regular_log(4, 1.1, 2.2)
+        assert repr(ax) == 'regular_log(4, 1.1, 2.2, options=underflow | overflow)'
+
+        ax = regular_sqrt(3, 1.1, 2.2)
+        assert repr(ax) == 'regular_sqrt(3, 1.1, 2.2, options=underflow | overflow)'
+
+        ax = regular_pow(0.5, 4, 1.1, 2.2)
+        assert repr(ax) == 'regular_pow(4, 1.1, 2.2, options=underflow | overflow, power=0.5)'
+
+
+    def test_getitem(self):
+        v = [1.0, 1.25, 1.5, 1.75, 2.0]
+        a = regular(4, 1.0, 2.0)
+        for i in range(4):
+            a.bin(i).lower() == approx(v[i])
+            a.bin(i).upper() == approx(v[i+1])
+        assert a.bin(-1).lower() == -float("infinity")
+        assert a.bin(4).upper() == float("infinity")
+
+        # CLASSIC: bins outside the range now have different behavior
+        # with pytest.raises(IndexError):
+        #     a.bin(-2)
+        # with pytest.raises(IndexError):
+        #     a.bin(5)
+
+        assert a.bin(-2).lower() == -float("infinity")
+        assert a.bin(-2).upper() == -float("infinity")
+        assert a.bin(5).lower() == float("infinity")
+        assert a.bin(5).upper() == float("infinity")
+
+    def test_iter(self):
+        v = np.array([1.0, 1.25, 1.5, 1.75, 2.0])
+        a = regular(4, 1.0, 2.0)
+        assert np.all(a.edges() == v)
+
+        c = (v[:-1] + v[1:])/2
+        assert np.all(a.centers() == approx(c))
+
+    def test_index(self):
+        a = regular(4, 1.0, 2.0)
+
+        assert a.index(-1) == -1
+        assert a.index(0.99) == -1
+        assert a.index(1.0) == 0
+        assert a.index(1.249) == 0
+        assert a.index(1.250) == 1
+        assert a.index(1.499) == 1
+        assert a.index(1.500) == 2
+        assert a.index(1.749) == 2
+        assert a.index(1.750) == 3
+        assert a.index(1.999) == 3
+        assert a.index(2.000) == 4
+        assert a.index(20) == 4
+
+    def test_reversed_index(self):
+        a = regular(4, 2.0, 1.0)
+
+        assert a.index(-1) == 4
+        assert a.index(0.99) == 4
+        assert a.index(1.0) == 4
+        assert a.index(1.249) == 3
+        assert a.index(1.250) == 3
+        assert a.index(1.499) == 2
+        assert a.index(1.500) == 2
+        assert a.index(1.749) == 1
+        assert a.index(1.750) == 1
+        assert a.index(1.999) == 0
+        assert a.index(2.000) == 0
+        assert a.index(20) == -1
+
+
+    def test_log_transform(self):
+        a = regular_log(2, 1e0, 1e2)
+
+        assert a.index(-1) == 2
+        assert a.index(0.99) == -1
+        assert a.index(1.0) == 0
+        assert a.index(9.99) == 0
+        assert a.index(10.0) == 1
+        assert a.index(99.9) == 1
+        assert a.index(100) == 2
+        assert a.index(1000) == 2
+
+        assert a.bin(0).lower() == approx(1e0)
+        assert a.bin(1).lower() == approx(1e1)
+        assert a.bin(1).upper() == approx(1e2)
+
+    def test_pow_transform(self):
+        a = regular_pow(0.5, 2, 1.0, 9.0)
+
+        assert a.index(-1) == 2
+        assert a.index(0.99) == -1
+        assert a.index(1.0) == 0
+        assert a.index(3.99) == 0
+        assert a.index(4.0) == 1
+        assert a.index(8.99) == 1
+        assert a.index(9) == 2
+        assert a.index(1000) == 2
+
+        assert a.bin(0).lower(), approx(1.0)
+        assert a.bin(1).lower(), approx(4.0)
+        assert a.bin(1).upper(), approx(9.0)
+
+
+
+
+class TestCircular(Axis):
+
+    def test_init(self):
+        # Should not throw
+
+        # CLASSIC: This was supported. Now it is not (ambiguous)
+        with pytest.raises(TypeError):
+            circular(1)
+
+        circular(4, 1.0)
+        circular(4, 0.0, 1.0)
+        circular(4, 1.0, metadata="pa")
+        circular(4, 0.0, 1.0, metadata="pa")
+
+        with pytest.raises(TypeError):
+            circular()
+        with pytest.raises(Exception):
+            circular(-1)
+        # CLASSIC: Used to be disallowed, now matches as metadata.
+        circular(1, 1.0, 2.0, 3.0)
+        # CLASSIC: Used to be disallowed.
+        circular(1, 1.0, metadata=1)
+        with pytest.raises(TypeError):
+            circular("1")
+
+        a = circular(4, 1.0)
+        assert a == circular(4, 1.0)
+        assert a != circular(2, 1.0)
+
+        # CLASSIC: This used to do something, now is range of 0 error
+        with pytest.raises(ValueError):
+            circular(4, 0.0)
+
+    def test_len(self):
+        assert circular(4, 1.0).size() == 4
+        assert circular(4, 1.0).extent() == 5
+        assert circular(4, 0.0, 1.0).size() == 4
+        assert circular(4, 0.0, 1.0).extent() == 5
+
+    def test_repr(self):
+        ax = circular(4, 1.1, 2.2)
+        assert repr(ax) == "regular(4, 1.1, 2.2, options=overflow | circular)"
+
+        ax = circular(4, 1.1, 2.2, metadata='hi')
+        assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="hi", options=overflow | circular)'
+
+        ax = circular(4, 2.0)
+        assert repr(ax) == "regular(4, 0, 2, options=overflow | circular)"
+
+        ax = circular(4, 2.0, metadata='hi')
+        assert repr(ax) == 'regular(4, 0, 2, metadata="hi", options=overflow | circular)'
+
+
+    def test_getitem(self):
+        v = [1.0,
+             1.0 + 0.5 * np.pi,
+             1.0 + np.pi,
+             1.0 + 1.5 * np.pi,
+             1.0 + 2.0 * np.pi]
+
+        # CLASSIC: Used to be 1 (phase 2pi automatic?)
+        a = circular(4, 1, 1+np.pi*2)
+
+        for i in range(4):
+            assert a.bin(i).lower() == v[i]
+            assert a.bin(i).upper() == v[i + 1]
+
+        # CLASSIC: Out of range used to raise
+        # TODO: test out of range
+
+
+    def test_iter(self):
+        v = np.array([1.0,
+             1.0 + 0.5 * np.pi,
+             1.0 + np.pi,
+             1.0 + 1.5 * np.pi,
+             1.0 + 2.0 * np.pi])
+
+        a = circular(4, 1, 1+np.pi*2)
+        assert np.all(a.edges() == v)
+
+        c = (v[:-1] + v[1:])/2
+        assert np.all(a.centers() == approx(c))
+
+    def test_index(self):
+        a = circular(4, 1, 1+np.pi*2)
+        d = 0.5 * np.pi
+        assert a.index(0.99 - 4 * d) == 3
+        assert a.index(0.99 - 3 * d) == 0
+        assert a.index(0.99 - 2 * d) == 1
+        assert a.index(0.99 - d) == 2
+        assert a.index(0.99) == 3
+        assert a.index(1.0) == 0
+        assert a.index(1.01) == 0
+        assert a.index(0.99 + d) == 0
+        assert a.index(1.0 + d) == 1
+        assert a.index(1.0 + 2 * d) == 2
+        assert a.index(1.0 + 3 * d) == 3
+        assert a.index(1.0 + 4 * d) == 0
+        assert a.index(1.0 + 5 * d) == 1
+
+
+class TestVariable(Axis):
+
+    def test_init(self):
+        variable([0, 1])
+        variable([0, 1, 2, 3, 4])
+        variable([0, 1], metadata="va")
+        with pytest.raises(TypeError):
+            variable()
+        with pytest.raises(ValueError):
+            variable([1])
+        with pytest.raises(TypeError):
+            variable(1)
+        with pytest.raises(ValueError):
+            variable([1, -1])
+        with pytest.raises(ValueError):
+            variable([1, 1])
+        with pytest.raises(TypeError):
+            variable(["1", 2])
+        with pytest.raises(TypeError):
+            variable([0.0, 1.0, 2.0], bad_keyword="ra")
+
+        a = variable([-0.1, 0.2, 0.3])
+        assert a == variable([-0.1, 0.2, 0.3])
+        assert a != variable([0, 0.2, 0.3])
+        assert a != variable([-0.1, 0.1, 0.3])
+        assert a != variable([-0.1, 0.1])
+
+    def test_len(self):
+        assert variable([-0.1, 0.2, 0.3]).size() == 2
+        assert variable([-0.1, 0.2, 0.3]).extent() == 4
+
+    def test_repr(self):
+        ax = variable([-0.1, 0.2])
+        assert repr(ax) == "variable(-0.1, 0.2, options=underflow | overflow)"
+
+        ax = variable([-0.1, 0.2], metadata='hi')
+        assert repr(ax) == 'variable(-0.1, 0.2, metadata="hi", options=underflow | overflow)'
+
+
+    def test_getitem(self):
+        v = [-0.1, 0.2, 0.3]
+        a = variable(v)
+
+        for i in range(2):
+            assert a.bin(i).lower() == v[i]
+            assert a.bin(i).upper() == v[i + 1]
+
+        assert a.bin(-1).lower() == -float("infinity")
+        assert a.bin(-1).upper() == v[0]
+
+        assert a.bin(2).lower() == v[2]
+        assert a.bin(2).upper() == float("infinity")
+
+        # CLASSIC: out of range used to throw
+        assert a.bin(-2).upper() == -float("infinity")
+        assert a.bin(3).lower() == float("infinity")
+
+
+    def test_iter(self):
+        v = np.array([-0.1, 0.2, 0.3])
+        a = variable(v)
+
+        assert np.all(a.edges() == v)
+
+        c = (v[:-1] + v[1:])/2
+        assert np.all(a.centers() == approx(c))
+
+    def test_index(self):
+        a = variable([-0.1, 0.2, 0.3])
+        assert a.index(-10.0) == -1
+        assert a.index(-0.11) == -1
+        assert a.index(-0.1) == 0
+        assert a.index(0.0) == 0
+        assert a.index(0.19) == 0
+        assert a.index(0.2) == 1
+        assert a.index(0.21) == 1
+        assert a.index(0.29) == 1
+        assert a.index(0.3) == 2
+        assert a.index(0.31) == 2
+        assert a.index(10) == 2
+
+
+class TestCategory(Axis):
+
+    def test_init(self):
+        category([1, 2, 3])
+        category([1, 2, 3], metadata="ca")
+        with pytest.raises(TypeError):
+            category()
+        with pytest.raises(TypeError):
+            category(["1"])
+        with pytest.raises(TypeError):
+            category([1, "2"])
+        # CLASSIC: Used to raise TypeError
+        category([1, 2], metadata=1)
+        with pytest.raises(TypeError):
+            category([1, 2, 3], uoflow=True)
+
+        assert category([1, 2, 3]) == category([1, 2, 3])
+        assert category([1, 2, 3]) != category([1, 3, 2])
+
+    def test_len(self):
+        assert category([1,2,3]).size() == 3
+        assert category([1,2,3]).extent() == 4
+
+    def test_repr(self):
+        ax = category([1,2,3])
+        assert repr(ax) == "category(1, 2, 3, options=overflow)"
+
+        ax = category([1,2,3], metadata='hi')
+        assert repr(ax) == 'category(1, 2, 3, metadata="hi", options=overflow)'
+
+
+    def test_getitem(self):
+        c = [1, 2, 3]
+        a = category(c)
+
+        for i in range(3):
+            assert a.bin(i) == c[i]
+
+        # CLASSIC: out of range used to throw
+        # TODO: Check out of range bin values
+
+
+    def test_iter(self):
+        c = [1, 2, 3]
+        a = category(c)
+
+        with pytest.raises(AttributeError):
+            a.edges()
+
+        with pytest.raises(AttributeError):
+            a.centers()
+
+    def test_index(self):
+        c = [1, 2, 3]
+        a = category(c)
+
+        assert a.index(1) == 0
+        assert a.index(2) == 1
+        assert a.index(3) == 2
+

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -1,0 +1,50 @@
+import pytest
+from pytest import approx
+
+
+from boost.histogram import make_histogram as histogram
+from boost.histogram.axis import (regular, regular_noflow,
+                                  regular_log, regular_sqrt,
+                                  regular_pow, circular,
+                                  variable, integer,
+                                  category_int as category)
+
+import numpy as np
+
+import abc
+
+# compatible with Python 2 *and* 3:
+ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
+
+# histogram -> boost.histogram
+# histogram -> make_histogram
+# dim -> rank()
+# ax.shape -> ax.extent()
+
+def test_init():
+    histogram()
+    histogram(integer(-1, 1))
+    with pytest.raises(RuntimeError):
+        histogram(1)
+    with pytest.raises(RuntimeError):
+        histogram("bla")
+    with pytest.raises(RuntimeError):
+        histogram([])
+    with pytest.raises(RuntimeError):
+        histogram(regular)
+    with pytest.raises(TypeError):
+        histogram(regular())
+    with pytest.raises(RuntimeError):
+        histogram([integer(-1, 1)])
+     # TODO: Should fail
+     # CLASSIC: with pytest.raises(ValueError):
+    histogram(integer(-1, 1), unknown_keyword="nh")
+
+    h = histogram(integer(-1, 2))
+    assert h.rank() == 1
+    assert h.axis(0) == integer(-1, 2)
+    assert h.axis(0).extent() == 5
+    assert h.axis(0).size() == 3
+    assert h != histogram(regular(1, -1, 1))
+    assert h != histogram(integer(-1, 1, metadata="ia"))
+

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,72 @@
+import pytest
+
+try:
+    # Python 2
+    from cPickle import loads, dumps
+except ImportError:
+    from pickle import loads, dumps
+
+import boost.histogram as bh
+
+class TestAccumulator:
+    def test_sum(self):
+        orig = bh.accumulator.sum(12)
+        new = loads(dumps(orig))
+        assert new == orig
+
+    def test_weighted_sum(self):
+        orig = bh.accumulator.weighted_sum(1.5, 2.5)
+        new = loads(dumps(orig))
+        assert new == orig
+
+    def test_mean(self):
+        orig = bh.accumulator.mean(5, 1.5, 2.5)
+        new = loads(dumps(orig))
+        assert new == orig
+
+    def test_weighted_mean(self):
+        orig = bh.accumulator.weighted_mean(1.5, 2.5, 3.5, 4.5)
+        new = loads(dumps(orig))
+        assert new == orig
+
+
+axes_creations = (
+        (bh.axis.regular,             (4, 2, 4)),
+        (bh.axis.regular_growth,      (4, 2, 4)),
+        (bh.axis.regular_noflow,      (4, 2, 4)),
+        (bh.axis.regular_log,         (4, 2, 4)),
+        (bh.axis.regular_sqrt,        (4, 2, 4)),
+        (bh.axis.regular_pow,         (0.5, 4, 2, 4)),
+        (bh.axis.circular,            (4, 2, 4)),
+        (bh.axis.variable,            ([1, 2, 3, 4],)),
+        (bh.axis.integer,             (1, 4)),
+        (bh.axis.category_int,        ([1, 2, 3],)),
+        (bh.axis.category_int_growth, ([1, 2, 3],)),
+        (bh.axis.category_str,        (["1", "2", "3"],)),
+        (bh.axis.category_str_growth, (["1", "2", "3"],)),
+        )
+
+@pytest.mark.parametrize("axis,args", axes_creations)
+def test_axes(axis, args):
+    orig = axis(*args)
+    new = loads(dumps(orig))
+    assert new == orig
+
+
+@pytest.mark.parametrize("axis,args", axes_creations)
+def test_metadata_str(axis, args):
+    orig = axis(*args, metadata="hi")
+    new = loads(dumps(orig))
+    assert new.metadata == orig.metadata
+    new.metadata = orig.metadata
+    assert new == orig
+
+@pytest.mark.parametrize("axis,args", axes_creations)
+def test_metadata_any(axis, args):
+    orig = axis(*args, metadata=(1,2,3))
+    new = loads(dumps(orig))
+    assert new.metadata == orig.metadata
+    new.metadata = orig.metadata
+    assert new == orig
+
+

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -8,6 +8,7 @@ except ImportError:
 
 import boost.histogram as bh
 
+
 class TestAccumulator:
     def test_sum(self):
         orig = bh.accumulator.sum(12)
@@ -70,3 +71,15 @@ def test_metadata_any(axis, args):
     assert new == orig
 
 
+def test_storage_int():
+    storage = bh.storage.int()
+    storage.push_back(1)
+    storage.push_back(3)
+    storage.push_back(2)
+
+    assert storage[0] == 1
+    assert storage[1] == 3
+    assert storage[2] == 2
+
+    # new = loads(dumps(storage))
+    # assert storage == new


### PR DESCRIPTION
One of two possibilities for serialization. This one replaces boost::serialization with cereal, but otherwise works quite similarly. The main issue is that now arbitrary python objects are allowed for axis labels, and therefore that needs to be handled. I'm currently handling that by saving metadata separately through py::pickle; might be tricky when saving histograms. I'm having an issue implementing storage serialization as well.

The other possibility is to convert all data to a tuple of Python objects, then using PyBind11's py::pickle directly. This isn't very easily supported for some objects, so not continuing on this method at the moment (I do have a local branch with it partially implemented).