### PR TITLE
Drop some warnings, regular_base

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,18 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Adding folders to keep the structure a bit nicer in IDE's
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+
+# This is a standard recipe for setting a default build type
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 # Adding PyBind11 and setting up Python
 add_subdirectory(extern/pybind11)
 
@@ -64,21 +76,25 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/extern/histogram/include PREFIX "H
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include PREFIX "Header Files" FILES ${BOOST_HIST_PY_HEADERS})
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX "Source Files" FILES ${BOOST_HIST_PY_SRC})
 
-# Cause warnings to be errors (not recommended for MSVC, since PyBind11 might cause a few there - add /WX if you want to try)
+# Cause warnings to be errors (not recommended for MSVC, since PyBind11 might cause a few there)
 option(BOOST_HISTOGRAM_ERRORS "Make warnings errors (for CI mostly)")
 
 # Adding warnings
-target_compile_options(histogram PRIVATE
-                       $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-                           -Wall -Wextra -pedantic-errors -Wconversion -Wsign-conversion>
-                       $<$<CXX_COMPILER_ID:MSVC>:
-                           /W4>)
-if(BOOST_HISTOGRAM_ERRORS)
-    target_compile_options(histogram PRIVATE
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-            -Werror>
-        $<$<CXX_COMPILER_ID:MSVC>:
-            /WE>)
+if("${CMAKE_COMPILER_ID}" MATCHES "CLANG" OR  "${CMAKE_COMPILER_ID}" MATCHES "GNU")
+    target_compile_options(histogram PRIVATE -Wall -Wextra -pedantic-errors -Wconversion -Wsign-conversion)
+    if(BOOST_HISTOGRAM_ERRORS)
+        target_compile_options(histogram PRIVATE -Werror)
+    endif()
+elseif("${CMAKE_COMPILER_ID}" MATCHES "MSVC")
+    target_compile_options(histogram PRIVATE /W4)
+    if(BOOST_HISTOGRAM_ERRORS)
+        target_compile_options(histogram PRIVATE /WE)
+    endif()
+endif()
+
+# Hide an error from PyBind11 (will be fixed upstream hopefully)
+if("${CMAKE_COMPILER_ID}" MATCHES "CLANG")
+     target_compile_options(histogram PRIVATE -Wno-return-std-move)
 endif()
 
 

--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -69,7 +69,7 @@ using regular_log = bh::axis::regular<double, bh::axis::transform::log, metadata
 using regular_sqrt = bh::axis::regular<double, bh::axis::transform::sqrt, metadata_t>;
 using regular_pow = bh::axis::regular<double, bh::axis::transform::pow, metadata_t>;
 using variable = bh::axis::variable<double, metadata_t>;
-using integer = bh::axis::integer<int, metadata_t>;
+using integer_uoflow = bh::axis::integer<int, metadata_t>;
 using integer_noflow = bh::axis::integer<int, metadata_t, bh::axis::option::none_t>;
 using integer_growth = bh::axis::integer<int, metadata_t, bh::axis::option::growth_t>;
 using category_int = bh::axis::category<int, metadata_t>;
@@ -90,7 +90,7 @@ using any = std::vector<bh::axis::variant<axis::regular_uoflow,
                                           axis::regular_pow,
                                           axis::regular_sqrt,
                                           axis::variable,
-                                          axis::integer,
+                                          axis::integer_uoflow,
                                           axis::integer_noflow,
                                           axis::integer_growth,
                                           axis::category_int,

--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -61,7 +61,7 @@ using metadata_t = py::object;
 namespace axis {
 
 // These match the Python names
-using regular = bh::axis::regular<double, bh::use_default, metadata_t>;
+using regular_uoflow = bh::axis::regular<double, bh::use_default, metadata_t>;
 using regular_noflow = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::none_t>;
 using regular_growth = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::growth_t>;
 using circular = bh::axis::circular<double, metadata_t>;
@@ -82,7 +82,7 @@ using category_str_growth = bh::axis::category<std::string, metadata_t, bh::axis
 namespace axes {
 
 // The following list is all types supported
-using any = std::vector<bh::axis::variant<axis::regular,
+using any = std::vector<bh::axis::variant<axis::regular_uoflow,
                                           axis::regular_noflow,
                                           axis::regular_growth,
                                           axis::circular,
@@ -100,14 +100,14 @@ using any = std::vector<bh::axis::variant<axis::regular,
                                           >>;
 
 // Specialization for some speed improvement
-using regular = std::vector<axis::regular>;
+using regular = std::vector<axis::regular_uoflow>;
 
 // Specialization for some speed improvement
 using regular_noflow = std::vector<axis::regular_noflow>;
 
 // Specializations for maximum speed!
-using regular_1D = std::tuple<axis::regular>;
-using regular_2D = std::tuple<axis::regular, axis::regular>;
+using regular_1D = std::tuple<axis::regular_uoflow>;
+using regular_2D = std::tuple<axis::regular_uoflow, axis::regular_uoflow>;
 
 using regular_noflow_1D = std::tuple<axis::regular_noflow>;
 using regular_noflow_2D = std::tuple<axis::regular_noflow, axis::regular_noflow>;

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -120,6 +120,8 @@ py::class_<bh::axis::interval_view<A>> register_axis_iv_by_type(py::module& m, c
     return axis_iv;
 }
 
+struct regular_type {};
+
 
 void register_axis(py::module &m) {
 
@@ -132,14 +134,12 @@ void register_axis(py::module &m) {
     opt.attr("overflow") =  (unsigned) bh::axis::option::overflow;
     opt.attr("circular") =  (unsigned) bh::axis::option::circular;
     opt.attr("growth") =    (unsigned) bh::axis::option::growth;
+    
 
-    py::class_<regular_base> py_regular_base(ax, "regular_base", "Regular base for others");
-
-
-    ax.def("_make_regular",
-        [](py::object, unsigned n, double start, double stop, metadata_t metadata, bool flow, bool growth) -> py::object {
+    ax.def("make_regular",
+        [](unsigned n, double start, double stop, metadata_t metadata, bool flow, bool growth) -> py::object {
             if(flow && ! growth) {
-                return py::cast(axis::regular(n, start, stop, metadata));
+                return py::cast(axis::regular_uoflow(n, start, stop, metadata));
             } else if (!flow && growth) {
                 return py::cast(axis::regular_growth(n, start, stop, metadata));
             } else if (!flow && !growth) {
@@ -148,18 +148,15 @@ void register_axis(py::module &m) {
                 throw std::runtime_error("Cannot make axis with both flow and growth options");
             }
         },
-       "cls"_a, "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str(), "flow"_a = false, "growth"_a = false,
+       "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str(), "flow"_a = false, "growth"_a = false,
        "Make a regular axis with nice keyword arguments for flow and growth");
 
-    // Hack for the fact we can't set a __new__ direcly in pybind11.
-    py_regular_base.attr("__new__") = ax.attr("_make_regular");
 
-
-    register_axis_by_type<axis::regular>(ax, "regular", "Evenly spaced bins")
+    register_axis_by_type<axis::regular_uoflow>(ax, "regular_uoflow", "Evenly spaced bins")
     .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
     ;
 
-    register_axis_iv_by_type<axis::regular>(ax, "_regular_internal_view");
+    register_axis_iv_by_type<axis::regular_uoflow>(ax, "_regular_internal_view");
 
 
     register_axis_by_type<axis::regular_noflow>(ax, "regular_noflow", "Evenly spaced bins without over/under flow")

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -132,10 +132,10 @@ void register_axis(py::module &m) {
     opt.attr("overflow") =  (unsigned) bh::axis::option::overflow;
     opt.attr("circular") =  (unsigned) bh::axis::option::circular;
     opt.attr("growth") =    (unsigned) bh::axis::option::growth;
-    
+
     py::class_<regular_base> py_regular_base(ax, "regular_base", "Regular base for others");
-    
-    
+
+
     ax.def("_make_regular",
         [](py::object, unsigned n, double start, double stop, metadata_t metadata, bool flow, bool growth) -> py::object {
             if(flow && ! growth) {
@@ -150,29 +150,31 @@ void register_axis(py::module &m) {
         },
        "cls"_a, "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str(), "flow"_a = false, "growth"_a = false,
        "Make a regular axis with nice keyword arguments for flow and growth");
-    
+
     // Hack for the fact we can't set a __new__ direcly in pybind11.
     py_regular_base.attr("__new__") = ax.attr("_make_regular");
-    
-    register_axis_by_type<axis::regular>(ax, "regular", "Evenly spaced bins", py_regular_base)
+
+
+    register_axis_by_type<axis::regular>(ax, "regular", "Evenly spaced bins")
     .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
     ;
+
     register_axis_iv_by_type<axis::regular>(ax, "_regular_internal_view");
 
 
-    register_axis_by_type<axis::regular_noflow>(ax, "regular_noflow", "Evenly spaced bins without over/under flow", py_regular_base)
+    register_axis_by_type<axis::regular_noflow>(ax, "regular_noflow", "Evenly spaced bins without over/under flow")
     .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
     ;
     register_axis_iv_by_type<axis::regular_noflow>(ax, "_regular_noflow_internal_view");
 
 
-    register_axis_by_type<axis::regular_growth>(ax, "regular_growth", "Evenly spaced bins that grow as needed", py_regular_base)
+    register_axis_by_type<axis::regular_growth>(ax, "regular_growth", "Evenly spaced bins that grow as needed")
     .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
     ;
     register_axis_iv_by_type<axis::regular_growth>(ax, "_regular_growth_internal_view");
 
 
-    register_axis_by_type<axis::circular>(ax, "circular", "Evenly spaced bins with wraparound", py_regular_base)
+    register_axis_by_type<axis::circular>(ax, "circular", "Evenly spaced bins with wraparound")
     .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
     .def(py::init([](unsigned n, double stop, metadata_t metadata){
         return new axis::circular{n, 0.0, stop, metadata};
@@ -181,19 +183,19 @@ void register_axis(py::module &m) {
     register_axis_iv_by_type<axis::circular>(ax, "_circular_internal_view");
 
 
-    register_axis_by_type<axis::regular_log>(ax, "regular_log", "Evenly spaced bins in log10", py_regular_base)
+    register_axis_by_type<axis::regular_log>(ax, "regular_log", "Evenly spaced bins in log10")
     .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
     ;
     register_axis_iv_by_type<axis::regular_log>(ax, "_regular_log_internal_view");
 
 
-    register_axis_by_type<axis::regular_sqrt>(ax, "regular_sqrt", "Evenly spaced bins in sqrt", py_regular_base)
+    register_axis_by_type<axis::regular_sqrt>(ax, "regular_sqrt", "Evenly spaced bins in sqrt")
     .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
     ;
     register_axis_iv_by_type<axis::regular_sqrt>(ax, "_regular_sqrt_internal_view");
 
 
-    register_axis_by_type<axis::regular_pow>(ax, "regular_pow", "Evenly spaced bins in a power", py_regular_base)
+    register_axis_by_type<axis::regular_pow>(ax, "regular_pow", "Evenly spaced bins in a power")
     .def(py::init([](unsigned n, double start, double stop, double pow, metadata_t metadata){
         return new axis::regular_pow(bh::axis::transform::pow{pow}, n, start, stop, metadata);} ),
          "n"_a, "start"_a, "stop"_a, "power"_a, "metadata"_a = py::str())
@@ -216,7 +218,7 @@ void register_axis(py::module &m) {
     .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str())
     ;
     register_axis_iv_by_type<axis::integer_noflow>(ax, "_integer_noflow_internal_view");
-    
+
     register_axis_by_type<axis::integer_growth>(ax, "integer_growth", "Contigious integers with growth")
     .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str())
     ;

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -206,10 +206,10 @@ void register_axis(py::module &m) {
     register_axis_iv_by_type<axis::variable>(ax, "_variable_internal_view");
 
 
-    register_axis_by_type<axis::integer>(ax, "integer", "Contigious integers")
+    register_axis_by_type<axis::integer_uoflow>(ax, "integer_uoflow", "Contigious integers")
     .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str())
     ;
-    register_axis_iv_by_type<axis::integer>(ax, "_integer_internal_view");
+    register_axis_iv_by_type<axis::integer_uoflow>(ax, "_integer_internal_view");
 
     register_axis_by_type<axis::integer_noflow>(ax, "integer_noflow", "Contigious integers with no under/overflow")
     .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str())

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -124,7 +124,7 @@ void register_histogram(py::module& m) {
          "regular_int_1d",
          "1-dimensional histogram for int valued data.");
 
-    m.def("make_histogram", [](axis::regular& ax1, storage::int_){
+    m.def("make_histogram", [](axis::regular_uoflow& ax1, storage::int_){
         return bh::make_histogram_with(storage::int_(), ax1);
     }, "axis"_a, "storage"_a=storage::int_(), "Make a 1D histogram of integers");
 
@@ -133,7 +133,7 @@ void register_histogram(py::module& m) {
         "regular_atomic_int_1d",
         "1-dimensional histogram for int valued data (atomic).");
     
-    m.def("make_histogram", [](axis::regular& ax1, storage::atomic_int){
+    m.def("make_histogram", [](axis::regular_uoflow& ax1, storage::atomic_int){
         return bh::make_histogram_with(storage::atomic_int(), ax1);
     }, "axis"_a, "storage"_a=storage::atomic_int(), "Make a 1D histogram of atomic integers");
     
@@ -141,7 +141,7 @@ void register_histogram(py::module& m) {
         "regular_int_2d",
         "2-dimensional histogram for int valued data.");
 
-    m.def("make_histogram", [](axis::regular& ax1, axis::regular& ax2, storage::int_){
+    m.def("make_histogram", [](axis::regular_uoflow& ax1, axis::regular_uoflow& ax2, storage::int_){
         return bh::make_histogram_with(storage::int_(), ax1, ax2);
     }, "axis1"_a, "axis2"_a, "storage"_a=storage::int_(), "Make a 2D histogram of integers");
 

--- a/tests/speed_numpy.py
+++ b/tests/speed_numpy.py
@@ -25,7 +25,7 @@ def compare_1d(n, distrib):
         t = timer() - t
         best_numpy = min(t, best_numpy)
 
-        h = histogram(regular(100, 0, 1))
+        h = histogram(regular_uoflow(100, 0, 1))
         t = timer()
         h.fill(r)
         t = timer() - t
@@ -51,7 +51,7 @@ def compare_2d(n, distrib):
         t = timer() - t
         best_numpy = min(t, best_numpy)
 
-        h = histogram(regular(100, 0, 1), regular(100, 0, 1))
+        h = histogram(regular_uoflow(100, 0, 1), regular_uoflow(100, 0, 1))
         t = timer()
         h.fill(r[0], r[1])
         t = timer() - t
@@ -79,9 +79,9 @@ def compare_3d(n, distrib):
         t = timer() - t
         best_numpy = min(t, best_numpy)
 
-        h = histogram(regular(100, 0, 1),
-                      regular(100, 0, 1),
-                      regular(100, 0, 1))
+        h = histogram(regular_uoflow(100, 0, 1),
+                      regular_uoflow(100, 0, 1),
+                      regular_uoflow(100, 0, 1))
         t = timer()
         h.fill(r[0], r[1], r[2])
         t = timer() - t
@@ -113,12 +113,12 @@ def compare_6d(n, distrib):
         t = timer() - t
         best_numpy = min(t, best_numpy)
 
-        h = histogram(regular(10, 0, 1),
-                      regular(10, 0, 1),
-                      regular(10, 0, 1),
-                      regular(10, 0, 1),
-                      regular(10, 0, 1),
-                      regular(10, 0, 1))
+        h = histogram(regular_uoflow(10, 0, 1),
+                      regular_uoflow(10, 0, 1),
+                      regular_uoflow(10, 0, 1),
+                      regular_uoflow(10, 0, 1),
+                      regular_uoflow(10, 0, 1),
+                      regular_uoflow(10, 0, 1))
         t = timer()
         h.fill(r[0], r[1], r[2], r[3], r[4], r[5])
         t = timer() - t

--- a/tests/test_atomic_fill.py
+++ b/tests/test_atomic_fill.py
@@ -8,8 +8,8 @@ from functools import reduce
 from operator import add
 
 def test_make_regular_1D():
-    hist_linear = bh.make_histogram(bh.axis.regular(1000,0,1))
-    hist_atomic = bh.make_histogram(bh.axis.regular(1000,0,1),
+    hist_linear = bh.make_histogram(bh.axis.regular_uoflow(1000,0,1))
+    hist_atomic = bh.make_histogram(bh.axis.regular_uoflow(1000,0,1),
                                     storage=bh.storage.atomic_int())
 
     vals = np.random.rand(10000)
@@ -20,8 +20,8 @@ def test_make_regular_1D():
     assert np.all(np.asarray(hist_linear) == np.asarray(hist_atomic))
 
 def test_atomic_fill_1D():
-    hist_linear = bh.make_histogram(bh.axis.regular(1000,0,1))
-    hist_atomic = bh.make_histogram(bh.axis.regular(1000,0,1),
+    hist_linear = bh.make_histogram(bh.axis.regular_uoflow(1000,0,1))
+    hist_atomic = bh.make_histogram(bh.axis.regular_uoflow(1000,0,1),
                                     storage=bh.storage.atomic_int())
 
     vals = np.random.rand(10000)

--- a/tests/test_axis_internal.py
+++ b/tests/test_axis_internal.py
@@ -6,11 +6,11 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 
-@pytest.mark.parametrize("axtype", [bh.axis.regular, bh.axis.regular_noflow])
+@pytest.mark.parametrize("axtype", [bh.axis.regular_uoflow, bh.axis.regular_noflow])
 @pytest.mark.parametrize("function", [lambda x: x,
                                        lambda x: bh.make_histogram(x).axis(0),
                                        ])
-def test_axis_regular(axtype, function):
+def test_axis_regular_uoflow(axtype, function):
     ax = function(axtype(10, 0, 1))
 
     assert 3 == ax.index(.34)
@@ -28,7 +28,7 @@ def test_axis_regular(axtype, function):
     assert ax.bin(3).center() == approx(.35)
 
 def test_axis_regular_extents():
-    ax = bh.axis.regular(10,0,1)
+    ax = bh.axis.regular_uoflow(10,0,1)
     assert 12 == ax.size(flow=True)
     assert 11 == len(ax.edges())
     assert 13 == len(ax.edges(True))
@@ -78,7 +78,7 @@ def test_axis_circular():
     assert ax.options() == bh.axis.options.circular | bh.axis.options.overflow
 
 normal_axs = [
-    bh.axis.regular,
+    bh.axis.regular_uoflow,
     bh.axis.regular_noflow,
     bh.axis.circular,
     bh.axis.regular_log,

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -10,7 +10,7 @@ def test_1D_fill_unlimited():
     ranges = (0, 1)
     vals = (.15, .25, .25)
     hist = bh.hist.regular_unlimited([
-        bh.axis.regular(bins, *ranges)
+        bh.axis.regular_uoflow(bins, *ranges)
         ])
     hist(vals)
 
@@ -28,7 +28,7 @@ def test_1D_fill_int(hist_func):
     vals = (.15, .25, .25)
 
     hist = hist_func([
-        bh.axis.regular(bins, *ranges)
+        bh.axis.regular_uoflow(bins, *ranges)
         ])
     hist(vals)
 
@@ -48,8 +48,8 @@ def test_2D_fill_int(hist_func):
     vals = ((.15, .25, .25), (.35, .45, .45))
 
     hist = hist_func([
-        bh.axis.regular(bins[0], *ranges[0]),
-        bh.axis.regular(bins[1], *ranges[1]),
+        bh.axis.regular_uoflow(bins[0], *ranges[0]),
+        bh.axis.regular_uoflow(bins[1], *ranges[1]),
         ])
     hist(*vals)
 
@@ -110,7 +110,7 @@ def test_growing_histogram():
     assert hist.size() == 15
 
 def test_numpy_flow():
-    h = bh.hist.regular_int_2d([bh.axis.regular(10,0,1), bh.axis.regular(5,0,1)])
+    h = bh.hist.regular_int_2d([bh.axis.regular_uoflow(10,0,1), bh.axis.regular_uoflow(5,0,1)])
 
     for i in range(10):
         for j in range(5):
@@ -133,7 +133,7 @@ def test_numpy_flow():
 
 
 def test_numpy_compare():
-    h = bh.hist.regular_int_2d([bh.axis.regular(10,0,1), bh.axis.regular(5,0,1)])
+    h = bh.hist.regular_int_2d([bh.axis.regular_uoflow(10,0,1), bh.axis.regular_uoflow(5,0,1)])
 
     xs = []
     ys = []

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -81,7 +81,7 @@ def test_edges_histogram():
 
 def test_int_histogram():
     hist = bh.hist.any_int([
-        bh.axis.integer(3,7)
+        bh.axis.integer_uoflow(3,7)
         ])
 
     vals = (1,2,3,4,5,6,7,8,9)

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -4,7 +4,7 @@ import math
 
 import boost.histogram as bh
 
-@pytest.mark.parametrize("axis,extent", ((bh.axis.regular, 2),
+@pytest.mark.parametrize("axis,extent", ((bh.axis.regular_uoflow, 2),
                                          (bh.axis.regular_noflow, 0)))
 def test_make_regular_1D(axis, extent):
     hist = bh.make_histogram(axis(3,2,5))
@@ -14,7 +14,7 @@ def test_make_regular_1D(axis, extent):
     assert hist.axis(0).size(flow=True) == 3 + extent
     assert hist.axis(0).bin(1).center() == approx(3.5)
 
-@pytest.mark.parametrize("axis,extent", ((bh.axis.regular, 2),
+@pytest.mark.parametrize("axis,extent", ((bh.axis.regular_uoflow, 2),
                                          (bh.axis.regular_noflow, 0)))
 def test_make_regular_2D(axis, extent):
     hist = bh.make_histogram(axis(3,2,5),
@@ -35,7 +35,7 @@ def test_make_regular_2D(axis, extent):
                                      bh.storage.unlimited(),
                                      bh.storage.weight()))
 def test_make_any_hist(storage):
-    hist = bh.make_histogram(bh.axis.regular(5,1,2),
+    hist = bh.make_histogram(bh.axis.regular_uoflow(5,1,2),
                              bh.axis.regular_noflow(6,2,3),
                              bh.axis.circular(8,3,4),
                              storage=storage)
@@ -53,8 +53,8 @@ def test_make_any_hist(storage):
 
 def test_make_any_hist_storage():
 
-    assert float != type(bh.make_histogram(bh.axis.regular(5,1,2), storage=bh.storage.int()).at(0))
-    assert float == type(bh.make_histogram(bh.axis.regular(5,1,2), storage=bh.storage.double()).at(0))
+    assert float != type(bh.make_histogram(bh.axis.regular_uoflow(5,1,2), storage=bh.storage.int()).at(0))
+    assert float == type(bh.make_histogram(bh.axis.regular_uoflow(5,1,2), storage=bh.storage.double()).at(0))
 
 def test_issue_axis_bin_swan():
     hist = bh.make_histogram(bh.axis.regular_sqrt(10,0,10, metadata='x'),

--- a/tests/test_public_axis.py
+++ b/tests/test_public_axis.py
@@ -4,7 +4,7 @@ from pytest import approx
 from boost.histogram.axis import (regular_uoflow, regular_noflow,
                                   regular_log, regular_sqrt,
                                   regular_pow, circular,
-                                  variable, integer,
+                                  variable, integer_uoflow,
                                   integer_noflow, integer_growth,
                                   category_int as category)
 
@@ -418,38 +418,38 @@ class TestVariable(Axis):
 class TestInteger:
 
     def test_init(self):
-        integer(-1, 2)
+        integer_uoflow(-1, 2)
         integer_noflow(-1, 2)
         integer_growth(-1, 2)
         with pytest.raises(TypeError):
-            integer()
+            integer_uoflow()
         with pytest.raises(TypeError):
-            integer(1)
+            integer_uoflow(1)
         with pytest.raises(TypeError):
-            integer("1", 2)
+            integer_uoflow("1", 2)
         with pytest.raises(ValueError):
-            integer(2, -1)
+            integer_uoflow(2, -1)
 
         # CLASSIC: Used to fail
-        integer(1, 2, 3)
+        integer_uoflow(1, 2, 3)
 
-        assert integer(-1, 2) == integer(-1, 2)
-        assert integer(-1, 2) != integer(-1, 2, metadata="Other")
-        assert integer_noflow(-1, 2) != integer(-1, 2)
+        assert integer_uoflow(-1, 2) == integer_uoflow(-1, 2)
+        assert integer_uoflow(-1, 2) != integer_uoflow(-1, 2, metadata="Other")
+        assert integer_noflow(-1, 2) != integer_uoflow(-1, 2)
 
     def test_len(self):
-        assert integer(-1, 3).size() ==  4
-        assert integer(-1, 3).size(flow=True) ==  6
+        assert integer_uoflow(-1, 3).size() ==  4
+        assert integer_uoflow(-1, 3).size(flow=True) ==  6
         assert integer_noflow(-1, 3).size() ==  4
         assert integer_noflow(-1, 3).size(flow=True) ==  4
         assert integer_growth(-1, 3).size() ==  4
         assert integer_growth(-1, 3).size(flow=True) ==  4
 
     def test_repr(self):
-        a = integer(-1, 1)
+        a = integer_uoflow(-1, 1)
         assert repr(a) == 'integer(-1, 1, options=underflow | overflow)'
 
-        a = integer(-1, 1, metadata="hi")
+        a = integer_uoflow(-1, 1, metadata="hi")
         assert repr(a) == 'integer(-1, 1, metadata="hi", options=underflow | overflow)'
 
         a = integer_noflow(-1, 1)
@@ -459,14 +459,14 @@ class TestInteger:
         assert repr(a) == 'integer(-1, 1, options=growth)'
 
     def test_label(self):
-        a = integer(-1, 2, metadata="foo")
+        a = integer_uoflow(-1, 2, metadata="foo")
         assert a.metadata == "foo"
         a.metadata = "bar"
         assert a.metadata == "bar"
 
     def test_getitem(self):
         v = [-1, 0, 1, 2, 3]
-        a = integer(-1, 3)
+        a = integer_uoflow(-1, 3)
         for i in range(5):
             assert a.bin(i) == v[i]
         assert a.bin(-1) == -2 ** 31
@@ -474,11 +474,11 @@ class TestInteger:
 
     def test_iter(self):
         v = np.array([-1, 0, 1, 2])
-        a = integer(-1, 3)
+        a = integer_uoflow(-1, 3)
         assert (a.bins() == v).all()
 
     def test_index(self):
-        a = integer(-1, 3)
+        a = integer_uoflow(-1, 3)
         assert a.index(-3) == -1
         assert a.index(-2) == -1
         assert a.index(-1) == 0

--- a/tests/test_public_axis.py
+++ b/tests/test_public_axis.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest import approx
 
-from boost.histogram.axis import (regular, regular_noflow,
+from boost.histogram.axis import (regular_uoflow, regular_noflow,
                                   regular_log, regular_sqrt,
                                   regular_pow, circular,
                                   variable, integer,
@@ -17,6 +17,7 @@ import abc
 ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
 
 # histogram -> boost.histogram
+# regular(..., noflow=False) -> regular_ouflow(...)
 # regular(..., noflow=True) -> regular_noflow(...)
 # label -> metadata
 # len(ax) -> ax.size(flow=False)
@@ -57,8 +58,8 @@ class TestRegular(Axis):
 
     def test_init(self):
         # Should not throw
-        regular(1, 1.0, 2.0)
-        regular(1, 1.0, 2.0, metadata="ra")
+        regular_uoflow(1, 1.0, 2.0)
+        regular_uoflow(1, 1.0, 2.0, metadata="ra")
         regular_noflow(1, 1.0, 2.0)
         regular_noflow(1, 1.0, 2.0, metadata="ra")
         regular_log(1, 1.0, 2.0)
@@ -66,46 +67,46 @@ class TestRegular(Axis):
         regular_pow(1, 1.0, 2.0, 1.5)
 
         with pytest.raises(TypeError):
-            regular()
+            regular_uoflow()
         with pytest.raises(TypeError):
-            regular()
+            regular_uoflow()
         with pytest.raises(TypeError):
-            regular(1)
+            regular_uoflow(1)
         with pytest.raises(TypeError):
-            regular(1, 1.0)
+            regular_uoflow(1, 1.0)
         with pytest.raises(ValueError):
-            regular(0, 1.0, 2.0)
+            regular_uoflow(0, 1.0, 2.0)
         with pytest.raises(TypeError):
-            regular("1", 1.0, 2.0)
+            regular_uoflow("1", 1.0, 2.0)
         with pytest.raises(Exception):
-            regular(-1, 1.0, 2.0)
+            regular_uoflow(-1, 1.0, 2.0)
         # CLASSIC
         #with pytest.raises(ValueError):
-        regular(1, 2.0, 1.0)
+        regular_uoflow(1, 2.0, 1.0)
 
         with pytest.raises(ValueError):
-            regular(1, 1.0, 1.0)
+            regular_uoflow(1, 1.0, 1.0)
 
         # CLASSIC: this was not allowed. Now it is.
         # with pytest.raises(TypeError):
-        regular(1, 1.0, 2.0, metadata=0)
+        regular_uoflow(1, 1.0, 2.0, metadata=0)
 
 
 
         with pytest.raises(TypeError):
-            regular(1, 1.0, 2.0, bad_keyword="ra")
+            regular_uoflow(1, 1.0, 2.0, bad_keyword="ra")
         with pytest.raises(TypeError):
             regular_pow(1, 1.0, 2.0)
 
-        a = regular(4, 1.0, 2.0)
-        assert a == regular(4, 1.0, 2.0)
-        assert a != regular(3, 1.0, 2.0)
-        assert a != regular(4, 1.1, 2.0)
-        assert a != regular(4, 1.0, 2.1)
+        a = regular_uoflow(4, 1.0, 2.0)
+        assert a == regular_uoflow(4, 1.0, 2.0)
+        assert a != regular_uoflow(3, 1.0, 2.0)
+        assert a != regular_uoflow(4, 1.1, 2.0)
+        assert a != regular_uoflow(4, 1.0, 2.1)
 
 
     def test_len(self):
-        a = regular(4, 1.0, 2.0)
+        a = regular_uoflow(4, 1.0, 2.0)
         # CLASSIC: Not explicit
         # assert len(a) == 4
 
@@ -113,10 +114,10 @@ class TestRegular(Axis):
         assert a.size(flow=True) == 6
 
     def test_repr(self):
-        ax = regular(4, 1.1, 2.2)
+        ax = regular_uoflow(4, 1.1, 2.2)
         assert repr(ax) == "regular(4, 1.1, 2.2, options=underflow | overflow)"
 
-        ax = regular(4, 1.1, 2.2, metadata='ra')
+        ax = regular_uoflow(4, 1.1, 2.2, metadata='ra')
         assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra", options=underflow | overflow)'
 
         ax = regular_noflow(4, 1.1, 2.2)
@@ -137,7 +138,7 @@ class TestRegular(Axis):
 
     def test_getitem(self):
         v = [1.0, 1.25, 1.5, 1.75, 2.0]
-        a = regular(4, 1.0, 2.0)
+        a = regular_uoflow(4, 1.0, 2.0)
         for i in range(4):
             a.bin(i).lower() == approx(v[i])
             a.bin(i).upper() == approx(v[i+1])
@@ -157,14 +158,14 @@ class TestRegular(Axis):
 
     def test_iter(self):
         v = np.array([1.0, 1.25, 1.5, 1.75, 2.0])
-        a = regular(4, 1.0, 2.0)
+        a = regular_uoflow(4, 1.0, 2.0)
         assert np.all(a.edges() == v)
 
         c = (v[:-1] + v[1:])/2
         assert np.all(a.centers() == approx(c))
 
     def test_index(self):
-        a = regular(4, 1.0, 2.0)
+        a = regular_uoflow(4, 1.0, 2.0)
 
         assert a.index(-1) == -1
         assert a.index(0.99) == -1
@@ -180,7 +181,7 @@ class TestRegular(Axis):
         assert a.index(20) == 4
 
     def test_reversed_index(self):
-        a = regular(4, 2.0, 1.0)
+        a = regular_uoflow(4, 2.0, 1.0)
 
         assert a.index(-1) == 4
         assert a.index(0.99) == 4

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -3,7 +3,7 @@ from pytest import approx
 
 
 from boost.histogram import make_histogram as histogram
-from boost.histogram.axis import (regular, regular_noflow,
+from boost.histogram.axis import (regular_uoflow, regular_noflow,
                                   regular_log, regular_sqrt,
                                   regular_pow, circular,
                                   variable, integer,
@@ -27,9 +27,9 @@ def test_init():
     with pytest.raises(RuntimeError):
         histogram([])
     with pytest.raises(RuntimeError):
-        histogram(regular)
+        histogram(regular_uoflow)
     with pytest.raises(TypeError):
-        histogram(regular())
+        histogram(regular_uoflow())
     with pytest.raises(RuntimeError):
         histogram([integer(-1, 1)])
      # TODO: Should fail
@@ -41,7 +41,7 @@ def test_init():
     assert h.axis(0) == integer(-1, 2)
     assert h.axis(0).size(flow=True) == 5
     assert h.axis(0).size() == 3
-    assert h != histogram(regular(1, -1, 1))
+    assert h != histogram(regular_uoflow(1, -1, 1))
     assert h != histogram(integer(-1, 1, metadata="ia"))
 
 
@@ -94,7 +94,7 @@ def test_fill_int_1d():
 
 @pytest.mark.parametrize("flow", [True, False])
 def test_fill_1d(flow):
-    h = histogram(regular(3, -1, 2) if flow else regular_noflow(3, -1, 2))
+    h = histogram(regular_uoflow(3, -1, 2) if flow else regular_noflow(3, -1, 2))
     with pytest.raises(ValueError):
         h()
     with pytest.raises(ValueError):
@@ -145,7 +145,7 @@ def test_growth():
 @pytest.mark.parametrize("flow", [True, False])
 def test_fill_2d(flow):
     h = histogram((integer if flow else integer_noflow)(-1, 2),
-                  (regular if flow else regular_noflow)(4, -2, 2))
+                  (regular_uoflow if flow else regular_noflow)(4, -2, 2))
     h(-1, -2)
     h(-1, -1)
     h(0, 0)
@@ -175,7 +175,7 @@ def test_fill_2d(flow):
 @pytest.mark.parametrize("flow", [True, False])
 def test_add_2d(flow):
     h = histogram((integer if flow else integer_noflow)(-1, 2),
-                  (regular if flow else regular_noflow)(4, -2, 2))
+                  (regular_uoflow if flow else regular_noflow)(4, -2, 2))
     h(-1, -2)
     h(-1, -1)
     h(0, 0)
@@ -198,7 +198,7 @@ def test_add_2d(flow):
 
 def test_add_2d_bad():
     a = histogram(integer(-1, 1))
-    b = histogram(regular(3, -1, 1))
+    b = histogram(regular_uoflow(3, -1, 1))
 
     with pytest.raises(TypeError):
         a += b
@@ -209,7 +209,7 @@ def test_add_2d_bad():
 @pytest.mark.parametrize("flow", [True, False])
 def test_add_2d_w(flow):
     h = histogram((integer if flow else integer_noflow)(-1, 2),
-                  (regular if flow else regular_noflow)(4, -2, 2))
+                  (regular_uoflow if flow else regular_noflow)(4, -2, 2))
     h(-1, -2)
     h(-1, -1)
     h(0, 0)
@@ -225,7 +225,7 @@ def test_add_2d_w(flow):
          [0, 0, 0, 0, 0, 0]]
 
     h2 = histogram((integer if flow else integer_noflow)(-1, 2),
-                  (regular if flow else regular_noflow)(4, -2, 2))
+                  (regular_uoflow if flow else regular_noflow)(4, -2, 2))
     h2(0, 0, weight=0)
 
     h2 += h
@@ -238,7 +238,7 @@ def test_add_2d_w(flow):
             assert h.at(i, j) == 2 * m[i][j]
 
 def test_repr():
-    h = histogram(regular(10, 0, 1), integer(0, 1))
+    h = histogram(regular_uoflow(10, 0, 1), integer(0, 1))
     hr = repr(h)
     assert hr == '''histogram(
   regular(10, 0, 1, options=underflow | overflow),
@@ -246,7 +246,7 @@ def test_repr():
 )'''
 
 def test_axis():
-    axes = (regular(10, 0, 1), integer(0, 1))
+    axes = (regular_uoflow(10, 0, 1), integer(0, 1))
     h = histogram(*axes)
     for i, a in enumerate(axes):
         assert h.axis(i) == a
@@ -260,11 +260,11 @@ def test_axis():
 # CLASSIC: This used to only fail when accessing, now fails in creation
 def test_overflow():
     with pytest.raises(RuntimeError):
-        h = histogram(*[regular(1, 0, 1) for i in range(50)])
+        h = histogram(*[regular_uoflow(1, 0, 1) for i in range(50)])
 
 
 def test_out_of_range():
-    h = histogram(regular(3, 0, 1))
+    h = histogram(regular_uoflow(3, 0, 1))
     h(-1)
     h(2)
     assert h.at(-1) == 1
@@ -290,7 +290,7 @@ def test_operators():
     assert h.at(1) == 0
     assert (h + h).at(0) == (h * 2).at(0)
     assert (h + h).at(0) == (2 * h).at(0)
-    h2 = histogram(regular(2, 0, 2))
+    h2 = histogram(regular_uoflow(2, 0, 2))
     with pytest.raises(TypeError):
         h + h2
 
@@ -515,7 +515,7 @@ def test_numpy_conversion_5():
 
 def test_numpy_conversion_6():
     a = integer(0, 2)
-    b = regular(2, 0, 2)
+    b = regular_uoflow(2, 0, 2)
     c = variable([0, 1, 2])
     ref = np.array((0., 1., 2.))
     assert_array_equal(a.bins(), [0, 1])

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -6,7 +6,7 @@ from boost.histogram import make_histogram as histogram
 from boost.histogram.axis import (regular_uoflow, regular_noflow,
                                   regular_log, regular_sqrt,
                                   regular_pow, circular,
-                                  variable, integer,
+                                  variable, integer_uoflow,
                                   integer_noflow, integer_growth,
                                   category_int as category)
 
@@ -19,7 +19,7 @@ from numpy.testing import assert_array_equal
 
 def test_init():
     histogram()
-    histogram(integer(-1, 1))
+    histogram(integer_uoflow(-1, 1))
     with pytest.raises(RuntimeError):
         histogram(1)
     with pytest.raises(RuntimeError):
@@ -31,25 +31,25 @@ def test_init():
     with pytest.raises(TypeError):
         histogram(regular_uoflow())
     with pytest.raises(RuntimeError):
-        histogram([integer(-1, 1)])
+        histogram([integer_uoflow(-1, 1)])
      # TODO: Should fail
      # CLASSIC: with pytest.raises(ValueError):
-    histogram(integer(-1, 1), unknown_keyword="nh")
+    histogram(integer_uoflow(-1, 1), unknown_keyword="nh")
 
-    h = histogram(integer(-1, 2))
+    h = histogram(integer_uoflow(-1, 2))
     assert h.rank() == 1
-    assert h.axis(0) == integer(-1, 2)
+    assert h.axis(0) == integer_uoflow(-1, 2)
     assert h.axis(0).size(flow=True) == 5
     assert h.axis(0).size() == 3
     assert h != histogram(regular_uoflow(1, -1, 1))
-    assert h != histogram(integer(-1, 1, metadata="ia"))
+    assert h != histogram(integer_uoflow(-1, 1, metadata="ia"))
 
 
 # CLASSIC
 # TEST COPY: DISABLED UNTIL SERIALIZE IS SUPPORTED
 @pytest.mark.skip()
 def test_copy():
-    a = histogram(integer(-1, 1))
+    a = histogram(integer_uoflow(-1, 1))
     import copy
     b = copy.copy(a)
     assert a == b
@@ -62,7 +62,7 @@ def test_copy():
 
 def test_fill_int_1d():
 
-    h = histogram(integer(-1, 2))
+    h = histogram(integer_uoflow(-1, 2))
     with pytest.raises(ValueError):
         h()
     with pytest.raises(ValueError):
@@ -126,7 +126,7 @@ def test_fill_1d(flow):
         assert get(h, 3) == 1
 
 def test_growth():
-    h = histogram(integer(-1, 2))
+    h = histogram(integer_uoflow(-1, 2))
     h(-1)
     h(1)
     h(1)
@@ -144,7 +144,7 @@ def test_growth():
 
 @pytest.mark.parametrize("flow", [True, False])
 def test_fill_2d(flow):
-    h = histogram((integer if flow else integer_noflow)(-1, 2),
+    h = histogram((integer_uoflow if flow else integer_noflow)(-1, 2),
                   (regular_uoflow if flow else regular_noflow)(4, -2, 2))
     h(-1, -2)
     h(-1, -1)
@@ -174,7 +174,7 @@ def test_fill_2d(flow):
 
 @pytest.mark.parametrize("flow", [True, False])
 def test_add_2d(flow):
-    h = histogram((integer if flow else integer_noflow)(-1, 2),
+    h = histogram((integer_uoflow if flow else integer_noflow)(-1, 2),
                   (regular_uoflow if flow else regular_noflow)(4, -2, 2))
     h(-1, -2)
     h(-1, -1)
@@ -197,7 +197,7 @@ def test_add_2d(flow):
             assert h.at(i, j) == 2 * m[i][j]
 
 def test_add_2d_bad():
-    a = histogram(integer(-1, 1))
+    a = histogram(integer_uoflow(-1, 1))
     b = histogram(regular_uoflow(3, -1, 1))
 
     with pytest.raises(TypeError):
@@ -208,7 +208,7 @@ def test_add_2d_bad():
 @pytest.mark.skip()
 @pytest.mark.parametrize("flow", [True, False])
 def test_add_2d_w(flow):
-    h = histogram((integer if flow else integer_noflow)(-1, 2),
+    h = histogram((integer_uoflow if flow else integer_noflow)(-1, 2),
                   (regular_uoflow if flow else regular_noflow)(4, -2, 2))
     h(-1, -2)
     h(-1, -1)
@@ -224,7 +224,7 @@ def test_add_2d_w(flow):
          [0, 1, 0, 0, 0, 0],
          [0, 0, 0, 0, 0, 0]]
 
-    h2 = histogram((integer if flow else integer_noflow)(-1, 2),
+    h2 = histogram((integer_uoflow if flow else integer_noflow)(-1, 2),
                   (regular_uoflow if flow else regular_noflow)(4, -2, 2))
     h2(0, 0, weight=0)
 
@@ -238,7 +238,7 @@ def test_add_2d_w(flow):
             assert h.at(i, j) == 2 * m[i][j]
 
 def test_repr():
-    h = histogram(regular_uoflow(10, 0, 1), integer(0, 1))
+    h = histogram(regular_uoflow(10, 0, 1), integer_uoflow(0, 1))
     hr = repr(h)
     assert hr == '''histogram(
   regular(10, 0, 1, options=underflow | overflow),
@@ -246,7 +246,7 @@ def test_repr():
 )'''
 
 def test_axis():
-    axes = (regular_uoflow(10, 0, 1), integer(0, 1))
+    axes = (regular_uoflow(10, 0, 1), integer_uoflow(0, 1))
     h = histogram(*axes)
     for i, a in enumerate(axes):
         assert h.axis(i) == a
@@ -280,7 +280,7 @@ def test_out_of_range():
 
 # CLASSIC: This used to have variance
 def test_operators():
-    h = histogram(integer(0, 2))
+    h = histogram(integer_uoflow(0, 2))
     h(0)
     h += h
     assert h.at(0) == 2
@@ -297,19 +297,19 @@ def test_operators():
 # CLASSIC: reduce is not yet supported
 @pytest.mark.skip(message="Reductions not yet supported")
 def test_reduce_to(self):
-    h = histogram(integer(0, 2), integer(1, 4))
+    h = histogram(integer_uoflow(0, 2), integer_uoflow(1, 4))
     h(0, 1)
     h(0, 2)
     h(1, 3)
 
     h0 = h.reduce_to(0)
     assert h0.rank() == 1
-    assert h0.axis() == integer(0, 2)
+    assert h0.axis() == integer_uoflow(0, 2)
     assert [h0.at(i) for i in range(2)] == [2, 1]
 
     h1 = h.reduce_to(1)
     assert h1.rank() == 1
-    assert h1.axis() == integer(1, 4)
+    assert h1.axis() == integer_uoflow(1, 4)
     assert [h1.at(i) for i in range(3)] == [1, 1, 1]
 
     with pytest.raises(ValueError):
@@ -323,7 +323,7 @@ def test_reduce_to(self):
 @pytest.mark.skip(message="Pickle not yet supported")
 def test_pickle_0():
     a = histogram(category([0, 1, 2]),
-                  integer(0, 20, metadata='ia'),
+                  integer_uoflow(0, 20, metadata='ia'),
                   regular_noflow(20, 0.0, 20.0),
                   variable([0.0, 1.0, 2.0]),
                   circular(4, metadata='pa'))
@@ -357,7 +357,7 @@ def test_pickle_0():
 @pytest.mark.skip(message="Pickle not yet supported")
 def test_pickle_1():
     a = histogram(category([0, 1, 2]),
-                  integer(0, 3, metadata='ia'),
+                  integer_uoflow(0, 3, metadata='ia'),
                   regular_noflow(4, 0.0, 4.0),
                   variable([0.0, 1.0, 2.0]))
 
@@ -415,7 +415,7 @@ def test_numpy_conversion_0():
 
 @pytest.mark.skip(message="Requires weighted fills / type")
 def test_numpy_conversion_1():
-    a = histogram(integer(0, 3))
+    a = histogram(integer_uoflow(0, 3))
     for i in range(10):
         a(1, weight=3)
     c = np.array(a)  # a copy
@@ -452,9 +452,9 @@ def test_numpy_conversion_2():
 
 @pytest.mark.skip(message="Requires weighted fills / type")
 def test_numpy_conversion_3():
-    a = histogram(integer(0, 2),
-                  integer(0, 3),
-                  integer(0, 4))
+    a = histogram(integer_uoflow(0, 2),
+                  integer_uoflow(0, 3),
+                  integer_uoflow(0, 4))
     r = np.zeros((2, 4, 5, 6))
     for i in range(a.axis(0).size(flow=True)):
         for j in range(a.axis(1).size(flow=True)):
@@ -514,7 +514,7 @@ def test_numpy_conversion_5():
     assert a1[2, 1] == 5
 
 def test_numpy_conversion_6():
-    a = integer(0, 2)
+    a = integer_uoflow(0, 2)
     b = regular_uoflow(2, 0, 2)
     c = variable([0, 1, 2])
     ref = np.array((0., 1., 2.))
@@ -580,7 +580,7 @@ def test_fill_with_numpy_array_0():
 def test_fill_with_numpy_array_1():
     def ar(*args):
         return np.array(args, dtype=float)
-    a = histogram(integer(0, 3))
+    a = histogram(integer_uoflow(0, 3))
     v = ar(-1, 0, 1, 2, 3, 4)
     w = ar( 2, 3, 4, 5, 6, 7)  # noqa
     a(v, weight=w)


### PR DESCRIPTION
This:
* fixes a few warnings
* Allows "make_regular" function shortcut (name may change to "regular" at some point)
* Renames regular and integer to `*_uoflow` versions.
* CMake defaults to "release" mode