### PR TITLE
Drop overloads

### DIFF
--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -105,12 +105,5 @@ using regular = std::vector<axis::regular_uoflow>;
 // Specialization for some speed improvement
 using regular_noflow = std::vector<axis::regular_noflow>;
 
-// Specializations for maximum speed!
-using regular_1D = std::tuple<axis::regular_uoflow>;
-using regular_2D = std::tuple<axis::regular_uoflow, axis::regular_uoflow>;
-
-using regular_noflow_1D = std::tuple<axis::regular_noflow>;
-using regular_noflow_2D = std::tuple<axis::regular_noflow, axis::regular_noflow>;
-
 
 } // namespace axes

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -163,53 +163,6 @@ void register_histogram(py::module& m) {
     
     py::module hist = m.def_submodule("hist");
 
-    // Fast specializations: Fixed number of axis (may be removed if above versions are fast enough)
-    // Mostly targeting histogram styles supported by numpy for these max performance versions.
-
-    register_histogram_by_type<axes::regular_1D, storage::int_>(hist,
-         "regular_int_1d",
-         "1-dimensional histogram for int valued data.");
-
-    m.def("make_histogram", [](axis::regular_uoflow& ax1, storage::int_){
-        return bh::make_histogram_with(storage::int_(), ax1);
-    }, "axis"_a, "storage"_a=storage::int_(), "Make a 1D histogram of integers");
-
-
-    auto regular_atomic_int_1d = register_histogram_by_type<axes::regular_1D, storage::atomic_int>(hist,
-        "regular_atomic_int_1d",
-        "1-dimensional histogram for int valued data (atomic).");
-    add_atomic_fill(regular_atomic_int_1d);
-    
-    m.def("make_histogram", [](axis::regular_uoflow& ax1, storage::atomic_int){
-        return bh::make_histogram_with(storage::atomic_int(), ax1);
-    }, "axis"_a, "storage"_a=storage::atomic_int(), "Make a 1D histogram of atomic integers");
-    
-    register_histogram_by_type<axes::regular_2D, storage::int_>(hist,
-        "regular_int_2d",
-        "2-dimensional histogram for int valued data.");
-
-    m.def("make_histogram", [](axis::regular_uoflow& ax1, axis::regular_uoflow& ax2, storage::int_){
-        return bh::make_histogram_with(storage::int_(), ax1, ax2);
-    }, "axis1"_a, "axis2"_a, "storage"_a=storage::int_(), "Make a 2D histogram of integers");
-
-
-    register_histogram_by_type<axes::regular_noflow_1D, storage::int_>(hist,
-        "regular_noflow_int_1d",
-        "1-dimensional histogram for int valued data.");
-
-    m.def("make_histogram", [](axis::regular_noflow& ax1, storage::int_){
-        return bh::make_histogram_with(storage::int_(), ax1);
-    }, "axis"_a, "storage"_a=storage::int_(), "Make a 1D histogram of integers without overflow");
-
-
-    register_histogram_by_type<axes::regular_noflow_2D, storage::int_>(hist,
-        "regular_noflow_int_2d",
-        "2-dimensional histogram for int valued data.");
-
-    m.def("make_histogram", [](axis::regular_noflow& ax1, axis::regular_noflow& ax2, storage::int_){
-        return bh::make_histogram_with(storage::int_(), ax1, ax2);
-    }, "axis1"_a, "axis2"_a, "storage"_a=storage::int_(), "Make a 2D histogram of integers without overflow");
-
 
     // Fast specializations - uniform types
 

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -132,16 +132,9 @@ py::class_<bh::histogram<A, S>> register_histogram_by_type(py::module& m, const 
     }, "axis"_a, "lower"_a, "upper"_a, "merge"_a, "Shrink an axis and rebin. You must select an axis.")
     */
     
-    /* Broken: Requires non static axes
-    .def("project", [](const histogram_t &self, unsigned value){
-        std::vector<unsigned> values = {value};
-        return bh::algorithm::project(self, values);
-    }, "value"_a, "Project out an axes from the histogram")
-    
-    .def("project", [](const histogram_t &self, const std::vector<unsigned> &values){
-        return bh::algorithm::project(self, values);
-    }, "values"_a, "Project out a list of axes from the histogram")
-    */
+    .def("project", [](const histogram_t &self, py::args values){
+        return bh::algorithm::project(self, py::cast<std::vector<unsigned>>(values));
+    }, "Project to a single axis or several axes on a multidiminsional histogram")
     
     ;
 

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -154,6 +154,24 @@ def test_numpy_compare():
     assert_allclose(E1, nE1)
     assert_allclose(E2, nE2)
 
+def test_project():
+    h = bh.hist.regular_int([bh.axis.regular_uoflow(10,0,1), bh.axis.regular_uoflow(5,0,1)])
+    h0 = bh.hist.regular_int([bh.axis.regular_uoflow(10,0,1)])
+    h1 = bh.hist.regular_int([bh.axis.regular_uoflow(5,0,1)])
+
+    for x,y in ((.3,.3),(.7,.7),(.5,.6),(.23,.92),(.15,.32),(.43,.54)):
+        h(x,y)
+        h0(x)
+        h1(y)
+
+    assert h.project(0, 1) == h
+    assert h.project(0) == h0
+    assert h.project(1) == h1
+
+    assert_array_equal(h.project(0, 1), h)
+    assert_array_equal(h.project(0), h0)
+    assert_array_equal(h.project(1), h1)
+
 def test_int_cat_hist():
     h = bh.hist.any_int([bh.axis.category_int([1,2,3])])
 

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -20,7 +20,7 @@ methods = [
     bh.hist.any_int,
 ]
 
-@pytest.mark.parametrize("hist_func", methods + [bh.hist.regular_int_1d])
+@pytest.mark.parametrize("hist_func", methods)
 def test_1D_fill_int(hist_func):
     bins = 10
     ranges = (0, 1)
@@ -40,7 +40,7 @@ def test_1D_fill_int(hist_func):
     assert hist.axis(0).size() == bins
     assert hist.axis(0).size(flow=True) == bins + 2
 
-@pytest.mark.parametrize("hist_func", methods + [bh.hist.regular_int_2d])
+@pytest.mark.parametrize("hist_func", methods)
 def test_2D_fill_int(hist_func):
     bins = (10, 15)
     ranges = ((0, 3), (0, 2))
@@ -110,7 +110,7 @@ def test_growing_histogram():
     assert hist.size() == 15
 
 def test_numpy_flow():
-    h = bh.hist.regular_int_2d([bh.axis.regular_uoflow(10,0,1), bh.axis.regular_uoflow(5,0,1)])
+    h = bh.hist.regular_int([bh.axis.regular_uoflow(10,0,1), bh.axis.regular_uoflow(5,0,1)])
 
     for i in range(10):
         for j in range(5):
@@ -133,7 +133,7 @@ def test_numpy_flow():
 
 
 def test_numpy_compare():
-    h = bh.hist.regular_int_2d([bh.axis.regular_uoflow(10,0,1), bh.axis.regular_uoflow(5,0,1)])
+    h = bh.hist.regular_int([bh.axis.regular_uoflow(10,0,1), bh.axis.regular_uoflow(5,0,1)])
 
     xs = []
     ys = []

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -200,7 +200,7 @@ def test_add_2d_bad():
     a = histogram(integer_uoflow(-1, 1))
     b = histogram(regular_uoflow(3, -1, 1))
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         a += b
 
 # WEIGHTED FILLS NOT SUPPORTED YET
@@ -291,7 +291,7 @@ def test_operators():
     assert (h + h).at(0) == (h * 2).at(0)
     assert (h + h).at(0) == (2 * h).at(0)
     h2 = histogram(regular_uoflow(2, 0, 2))
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         h + h2
 
 # CLASSIC: reduce is not yet supported


### PR DESCRIPTION
This drops the special 1D and 2D overloads, since they were not providing much in the way of performance, and adds ND projections (since those need non-tuple axes collections).

Todo:
- [ ] Make sure `make_histogram` picks specializations
- [ ] Update profile script and notebooks