### PR TITLE
Henryiii pickle

### DIFF
--- a/include/boost/histogram/python/histogram.hpp
+++ b/include/boost/histogram/python/histogram.hpp
@@ -7,6 +7,7 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
+#include <boost/histogram/python/copyable_atomic.hpp>
 #include <boost/histogram.hpp>
 
 #include <vector>

--- a/include/boost/histogram/python/pickle.hpp
+++ b/include/boost/histogram/python/pickle.hpp
@@ -54,7 +54,7 @@ struct OutToTuple {
     
     template<typename T, std::enable_if_t<!bh::has_method_serialize<T>::value && !bh::has_function_serialize<T>::value>* = nullptr>
     OutToTuple& operator& (T&& arg) {
-        tuple = tuple + py::make_tuple(arg);
+        tuple = tuple + py::make_tuple<py::return_value_policy::reference>(arg);
         return *this;
     }
 };

--- a/include/boost/histogram/python/pickle.hpp
+++ b/include/boost/histogram/python/pickle.hpp
@@ -27,13 +27,13 @@
 
 #include <type_traits>
 
-
 struct OutToTuple {
     py::tuple tuple;
     
-    template<typename... Args>
-    void operator()(Args&&... args) {
-        tuple = tuple + py::make_tuple(std::forward<Args>(args)...);
+    template<typename T>
+    OutToTuple& operator& (T&& arg) {
+        tuple = tuple + py::make_tuple(arg);
+        return *this;
     }
 };
 
@@ -43,19 +43,22 @@ struct InFromTuple {
     
     InFromTuple(const py::tuple& tuple_) : tuple(tuple_) {}
     
-    template<typename T, typename... Args>
-    void operator()(T&& arg, Args&&... args) {
+    template<typename T>
+    InFromTuple& operator& (T&& arg) {
         using Tbase = std::decay_t<T>;
         arg = py::cast<Tbase>(tuple[current++]);
-        operator()(std::forward<Args>(args)...);
+        return *this;
     }
-    
-    void operator()() {}
 };
+
+namespace boost { namespace histogram {
+    BOOST_HISTOGRAM_DETECT(has_method_serialize, (std::declval<T&>().serialize(std::declval<OutToTuple&>(), 0)));
+    BOOST_HISTOGRAM_DETECT(has_function_serialize, (serialize(std::declval<T&>(), std::declval<OutToTuple&>(), 0)));
+}}
 
 /// Convert "serialize" to something usable for Python
 template<typename T>
-py::tuple to_py_tuple(const T& p) {
+py::tuple to_py_tuple(std::true_type, const T& p) {
     OutToTuple out;
     const_cast<T&>(p).serialize(out,0);
     return out.tuple;
@@ -63,10 +66,30 @@ py::tuple to_py_tuple(const T& p) {
 
 /// Convert "serialize" to something usable for Python
 template<typename T>
-T from_py_tuple(const py::tuple& t) {
+py::tuple to_py_tuple(std::false_type, const T& p) {
+    using namespace boost::histogram;
+    OutToTuple out;
+    serialize(out, const_cast<T&>(p), 0);
+    return out.tuple;
+}
+
+
+/// Convert "serialize" to something usable for Python
+template<typename T>
+T from_py_tuple(std::true_type, const py::tuple& t) {
     InFromTuple in{t};
     T p;
     p.serialize(in, 0);
+    return p;
+}
+
+/// Convert "serialize" to something usable for Python
+template<typename T>
+T from_py_tuple(std::false_type, const py::tuple& t) {
+    using namespace boost::histogram;
+    InFromTuple in{t};
+    T p;
+    serialize(in, p, 0);
     return p;
 }
 
@@ -74,8 +97,9 @@ T from_py_tuple(const py::tuple& t) {
 template<typename T>
 decltype(auto) make_pickle() {
     return py::pickle(
-        [](const T &p){ return to_py_tuple(p); },
-        [](py::tuple t){return from_py_tuple<T>(t); });
+        [](const T &p){
+            return to_py_tuple(bh::has_method_serialize<T>{}, p); },
+        [](py::tuple t){return from_py_tuple<T>(bh::has_method_serialize<T>{}, t); });
 }
 
 // Note that this is just designed this way to make accessing private members easy.
@@ -89,28 +113,28 @@ namespace accumulators {
 template <class RealType>
 template <class Archive>
 void sum<RealType>::serialize(Archive& ar, unsigned /* version */) {
-    ar(large_, small_);
+    ar & large_ & small_;
 }
 
 template <class RealType>
 template <class Archive>
 void weighted_sum<RealType>::serialize(Archive& ar, unsigned /* version */) {
-    ar(sum_of_weights_, sum_of_weights_squared_);
+    ar & sum_of_weights_ & sum_of_weights_squared_;
 }
 
 template <class RealType>
 template <class Archive>
 void mean<RealType>::serialize(Archive& ar, unsigned /* version */) {
-    ar(sum_, mean_, sum_of_deltas_squared_);
+    ar & sum_ & mean_ & sum_of_deltas_squared_;
 }
 
 template <class RealType>
 template <class Archive>
 void weighted_mean<RealType>::serialize(Archive& ar, unsigned /* version */) {
-    ar(sum_of_weights_,
-                        sum_of_weights_squared_,
-                        weighted_mean_,
-                        sum_of_weighted_deltas_squared_);
+    ar & sum_of_weights_
+       & sum_of_weights_squared_
+       & weighted_mean_
+       & sum_of_weighted_deltas_squared_;
 }
 } // namespace accumulators
 
@@ -128,7 +152,7 @@ void serialize(Archive&, sqrt&, unsigned /* version */) {}
 
 template <class Archive>
 void serialize(Archive& ar, pow& t, unsigned /* version */) {
-  ar(t.power);
+  ar & t.power;
 }
 } // namespace transform
 
@@ -139,97 +163,88 @@ template <class T, class Tr, class M, class O>
 template <class Archive>
 void regular<T, Tr, M, O>::serialize(Archive& ar, unsigned /* version */) {
   transform::serialize(ar, static_cast<transform_type&>(*this), 0);
-  ar(size_meta_.first(), size_meta_.second(), min_, delta_);
+  ar & size_meta_.first() & size_meta_.second() & min_ & delta_;
 }
 
 template <class T, class M, class O>
 template <class Archive>
 void integer<T, M, O>::serialize(Archive& ar, unsigned /* version */) {
-  ar(size_meta_.first());
-  ar(size_meta_.second());
-  ar(min_);
+  ar & size_meta_.first() & size_meta_.second() & min_;
 }
 
 template <class T, class M, class O, class A>
 template <class Archive>
 void variable<T, M, O, A>::serialize(Archive& ar, unsigned /* version */) {
-  ar(vec_meta_.first());
-  ar(vec_meta_.second());
+  ar & vec_meta_.first() & vec_meta_.second();
 }
 
 template <class T, class M, class O, class A>
 template <class Archive>
 void category<T, M, O, A>::serialize(Archive& ar, unsigned /* version */) {
-  ar(vec_meta_.first());
-  ar(vec_meta_.second());
+  ar & vec_meta_.first() & vec_meta_.second();
 }
 
 template <class... Ts>
 template <class Archive>
 void variant<Ts...>::serialize(Archive& ar, unsigned /* version */) {
-  ar(impl);
+  ar & impl;
 }
 } // namespace axis
-//
-//namespace detail {
-//template <class Archive, class T>
-//void serialize(Archive& ar, vector_impl<T>& impl, unsigned /* version */) {
-//  ar& cereal::make_nvp("vector", static_cast<T&>(impl));
-//}
-//
-//template <class Archive, class T>
-//void serialize(Archive& ar, array_impl<T>& impl, unsigned /* version */) {
-//  ar& cereal::make_nvp("size", impl.size_);
-//  ar& cereal::make_nvp("array", impl);
-//                       // cereal::binary_data(&impl.front(), impl.size_));
-//}
-//
-//template <class Archive, class T>
-//void serialize(Archive& ar, map_impl<T>& impl, unsigned /* version */) {
-//  ar& cereal::make_nvp("size", impl.size_);
-//  ar& cereal::make_nvp("map", static_cast<T&>(impl));
-//}
-//
-//template <class Archive, class Allocator>
-//void serialize(Archive& ar, mp_int<Allocator>& x, unsigned /* version */) {
-//  ar& cereal::make_nvp("data", x.data);
-//}
-//} // namespace detail
-//
-//template <class Archive, class T>
-//void serialize(Archive& ar, storage_adaptor<T>& s, unsigned /* version */) {
-//  ar& cereal::make_nvp("impl", static_cast<detail::storage_adaptor_impl<T>&>(s));
-//}
-//
-//template <class A>
-//template <class Archive>
-//void unlimited_storage<A>::serialize(Archive& ar, unsigned /* version */) {
-//  if (Archive::is_loading::value) {
-//    buffer_type dummy(buffer.alloc);
-//    std::size_t size;
-//    ar& cereal::make_nvp("type", dummy.type);
-//    ar& cereal::make_nvp("size", size);
-//    dummy.apply([this, size](auto* tp) {
-//      BOOST_ASSERT(tp == nullptr);
-//      using T = detail::remove_cvref_t<decltype(*tp)>;
-//      buffer.template make<T>(size);
-//    });
-//  } else {
-//    ar& cereal::make_nvp("type", buffer.type);
-//    ar& cereal::make_nvp("size", buffer.size);
-//  }
-//  buffer.apply([this, &ar](auto* tp) {
-//    using T = detail::remove_cvref_t<decltype(*tp)>;
-//    ar& cereal::make_nvp("buffer", buffer);
-//        //cereal::binary_data(reinterpret_cast<T*>(buffer.ptr), buffer.size));
-//  });
-//}
-//
-//template <class Archive, class A, class S>
-//void serialize(Archive& ar, histogram<A, S>& h, unsigned /* version */) {
-//  ar& cereal::make_nvp("axes", unsafe_access::axes(h));
-//  ar& cereal::make_nvp("storage", unsafe_access::storage(h));
-//}
+
+namespace detail {
+template <class Archive, class T>
+void serialize(Archive& ar, vector_impl<T>& impl, unsigned /* version */) {
+  ar & static_cast<T&>(impl);
+}
+
+template <class Archive, class T>
+void serialize(Archive& ar, array_impl<T>& impl, unsigned /* version */) {
+  ar & impl.size_ & impl;
+}
+
+template <class Archive, class T>
+void serialize(Archive& ar, map_impl<T>& impl, unsigned /* version */) {
+  ar & impl.size_ & static_cast<T&>(impl);
+}
+
+template <class Archive, class Allocator>
+void serialize(Archive& ar, mp_int<Allocator>& x, unsigned /* version */) {
+  ar & x.data;
+}
+} // namespace detail
+
+template <class Archive, class T>
+void serialize(Archive& ar, storage_adaptor<T>& s, unsigned /* version */) {
+  serialize(ar, static_cast<detail::storage_adaptor_impl<T>&>(s), 0);
+}
+
+template <class A>
+template <class Archive>
+void unlimited_storage<A>::serialize(Archive& ar, unsigned /* version */) {
+  if (Archive::is_loading::value) {
+    buffer_type dummy(buffer.alloc);
+    std::size_t size;
+      
+    ar & dummy.type & size;
+      
+    dummy.apply([this, size](auto* tp) {
+      BOOST_ASSERT(tp == nullptr);
+      using T = detail::remove_cvref_t<decltype(*tp)>;
+      buffer.template make<T>(size);
+    });
+  } else {
+    ar & buffer.type & buffer.size;
+  }
+    
+  buffer.apply([this, &ar](auto* tp) {
+    ar & buffer;
+  });
+}
+
+template <class Archive, class A, class S>
+void serialize(Archive& ar, histogram<A, S>& h, unsigned /* version */) {
+  ar & unsafe_access::axes(h) & unsafe_access::storage(h);
+}
 
 } // namespace histogram
 } // namespace boost

--- a/include/boost/histogram/python/pickle.hpp
+++ b/include/boost/histogram/python/pickle.hpp
@@ -1,0 +1,237 @@
+// Copyright 2015-2019 Hans Dembinski and Henry Schreiner
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_HISTOGRAM_PICKLE_HPP
+#define BOOST_HISTOGRAM_PICKLE_HPP
+
+#include <boost/assert.hpp>
+#include <boost/histogram/accumulators/mean.hpp>
+#include <boost/histogram/accumulators/sum.hpp>
+#include <boost/histogram/accumulators/weighted_mean.hpp>
+#include <boost/histogram/accumulators/weighted_sum.hpp>
+#include <boost/histogram/axis/category.hpp>
+#include <boost/histogram/axis/integer.hpp>
+#include <boost/histogram/axis/regular.hpp>
+#include <boost/histogram/axis/variable.hpp>
+#include <boost/histogram/axis/variant.hpp>
+#include <boost/histogram/histogram.hpp>
+#include <boost/histogram/storage_adaptor.hpp>
+#include <boost/histogram/unlimited_storage.hpp>
+#include <boost/histogram/unsafe_access.hpp>
+#include <boost/mp11/tuple.hpp>
+
+#include <boost/histogram/python/pybind11.hpp>
+
+#include <type_traits>
+
+
+struct OutToTuple {
+    py::tuple tuple;
+    
+    template<typename... Args>
+    void operator()(Args&&... args) {
+        tuple = tuple + py::make_tuple(std::forward<Args>(args)...);
+    }
+};
+
+struct InFromTuple {
+    const py::tuple& tuple;
+    size_t current = 0;
+    
+    InFromTuple(const py::tuple& tuple_) : tuple(tuple_) {}
+    
+    template<typename T, typename... Args>
+    void operator()(T&& arg, Args&&... args) {
+        using Tbase = std::decay_t<T>;
+        arg = py::cast<Tbase>(tuple[current++]);
+        operator()(std::forward<Args>(args)...);
+    }
+    
+    void operator()() {}
+};
+
+/// Convert "serialize" to something usable for Python
+template<typename T>
+py::tuple to_py_tuple(const T& p) {
+    OutToTuple out;
+    const_cast<T&>(p).serialize(out,0);
+    return out.tuple;
+}
+
+/// Convert "serialize" to something usable for Python
+template<typename T>
+T from_py_tuple(const py::tuple& t) {
+    InFromTuple in{t};
+    T p;
+    p.serialize(in, 0);
+    return p;
+}
+
+/// Make a pickle serializer with a given type
+template<typename T>
+decltype(auto) make_pickle() {
+    return py::pickle(
+        [](const T &p){ return to_py_tuple(p); },
+        [](py::tuple t){return from_py_tuple<T>(t); });
+}
+
+// Note that this is just designed this way to make accessing private members easy.
+// Python does all the serialization.
+
+namespace boost {
+namespace histogram {
+
+namespace accumulators {
+
+template <class RealType>
+template <class Archive>
+void sum<RealType>::serialize(Archive& ar, unsigned /* version */) {
+    ar(large_, small_);
+}
+
+template <class RealType>
+template <class Archive>
+void weighted_sum<RealType>::serialize(Archive& ar, unsigned /* version */) {
+    ar(sum_of_weights_, sum_of_weights_squared_);
+}
+
+template <class RealType>
+template <class Archive>
+void mean<RealType>::serialize(Archive& ar, unsigned /* version */) {
+    ar(sum_, mean_, sum_of_deltas_squared_);
+}
+
+template <class RealType>
+template <class Archive>
+void weighted_mean<RealType>::serialize(Archive& ar, unsigned /* version */) {
+    ar(sum_of_weights_,
+                        sum_of_weights_squared_,
+                        weighted_mean_,
+                        sum_of_weighted_deltas_squared_);
+}
+} // namespace accumulators
+
+namespace axis {
+
+namespace transform {
+template <class Archive>
+void serialize(Archive&, id&, unsigned /* version */) {}
+
+template <class Archive>
+void serialize(Archive&, log&, unsigned /* version */) {}
+
+template <class Archive>
+void serialize(Archive&, sqrt&, unsigned /* version */) {}
+
+template <class Archive>
+void serialize(Archive& ar, pow& t, unsigned /* version */) {
+  ar(t.power);
+}
+} // namespace transform
+
+template <class Archive>
+void serialize(Archive&, null_type&, unsigned /* version */) {}
+
+template <class T, class Tr, class M, class O>
+template <class Archive>
+void regular<T, Tr, M, O>::serialize(Archive& ar, unsigned /* version */) {
+  transform::serialize(ar, static_cast<transform_type&>(*this), 0);
+  ar(size_meta_.first(), size_meta_.second(), min_, delta_);
+}
+
+template <class T, class M, class O>
+template <class Archive>
+void integer<T, M, O>::serialize(Archive& ar, unsigned /* version */) {
+  ar(size_meta_.first());
+  ar(size_meta_.second());
+  ar(min_);
+}
+
+template <class T, class M, class O, class A>
+template <class Archive>
+void variable<T, M, O, A>::serialize(Archive& ar, unsigned /* version */) {
+  ar(vec_meta_.first());
+  ar(vec_meta_.second());
+}
+
+template <class T, class M, class O, class A>
+template <class Archive>
+void category<T, M, O, A>::serialize(Archive& ar, unsigned /* version */) {
+  ar(vec_meta_.first());
+  ar(vec_meta_.second());
+}
+
+template <class... Ts>
+template <class Archive>
+void variant<Ts...>::serialize(Archive& ar, unsigned /* version */) {
+  ar(impl);
+}
+} // namespace axis
+//
+//namespace detail {
+//template <class Archive, class T>
+//void serialize(Archive& ar, vector_impl<T>& impl, unsigned /* version */) {
+//  ar& cereal::make_nvp("vector", static_cast<T&>(impl));
+//}
+//
+//template <class Archive, class T>
+//void serialize(Archive& ar, array_impl<T>& impl, unsigned /* version */) {
+//  ar& cereal::make_nvp("size", impl.size_);
+//  ar& cereal::make_nvp("array", impl);
+//                       // cereal::binary_data(&impl.front(), impl.size_));
+//}
+//
+//template <class Archive, class T>
+//void serialize(Archive& ar, map_impl<T>& impl, unsigned /* version */) {
+//  ar& cereal::make_nvp("size", impl.size_);
+//  ar& cereal::make_nvp("map", static_cast<T&>(impl));
+//}
+//
+//template <class Archive, class Allocator>
+//void serialize(Archive& ar, mp_int<Allocator>& x, unsigned /* version */) {
+//  ar& cereal::make_nvp("data", x.data);
+//}
+//} // namespace detail
+//
+//template <class Archive, class T>
+//void serialize(Archive& ar, storage_adaptor<T>& s, unsigned /* version */) {
+//  ar& cereal::make_nvp("impl", static_cast<detail::storage_adaptor_impl<T>&>(s));
+//}
+//
+//template <class A>
+//template <class Archive>
+//void unlimited_storage<A>::serialize(Archive& ar, unsigned /* version */) {
+//  if (Archive::is_loading::value) {
+//    buffer_type dummy(buffer.alloc);
+//    std::size_t size;
+//    ar& cereal::make_nvp("type", dummy.type);
+//    ar& cereal::make_nvp("size", size);
+//    dummy.apply([this, size](auto* tp) {
+//      BOOST_ASSERT(tp == nullptr);
+//      using T = detail::remove_cvref_t<decltype(*tp)>;
+//      buffer.template make<T>(size);
+//    });
+//  } else {
+//    ar& cereal::make_nvp("type", buffer.type);
+//    ar& cereal::make_nvp("size", buffer.size);
+//  }
+//  buffer.apply([this, &ar](auto* tp) {
+//    using T = detail::remove_cvref_t<decltype(*tp)>;
+//    ar& cereal::make_nvp("buffer", buffer);
+//        //cereal::binary_data(reinterpret_cast<T*>(buffer.ptr), buffer.size));
+//  });
+//}
+//
+//template <class Archive, class A, class S>
+//void serialize(Archive& ar, histogram<A, S>& h, unsigned /* version */) {
+//  ar& cereal::make_nvp("axes", unsafe_access::axes(h));
+//  ar& cereal::make_nvp("storage", unsafe_access::storage(h));
+//}
+
+} // namespace histogram
+} // namespace boost
+
+#endif

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ ext_modules = [
         ['src/module.cpp',
          'src/histogram/axis.cpp',
          'src/histogram/histogram.cpp',
+         'src/histogram/make_histogram.cpp',
          'src/histogram/storage.cpp',
          'src/histogram/accumulators.cpp',
         ],

--- a/src/histogram/accumulators.cpp
+++ b/src/histogram/accumulators.cpp
@@ -16,13 +16,13 @@
 #include <boost/histogram/accumulators/ostream.hpp>
 
 
-void register_accumulators(py::module &m) {
+py::module register_accumulators(py::module &m) {
     
-    py::module accumulator = m.def_submodule("accumulator");
+    py::module accumulators = m.def_submodule("accumulators");
 
     using weighted_sum = bh::accumulators::weighted_sum<double>;
     
-    py::class_<weighted_sum>(accumulator, "weighted_sum")
+    py::class_<weighted_sum>(accumulators, "weighted_sum")
         .def(py::init<>())
         .def(py::init<const double&>(), "value"_a)
         .def(py::init<const double&, const double&>(), "value"_a, "variance"_a)
@@ -53,7 +53,7 @@ void register_accumulators(py::module &m) {
 
     using weighted_mean = bh::accumulators::weighted_mean<double>;
 
-    py::class_<weighted_mean>(accumulator, "weighted_mean")
+    py::class_<weighted_mean>(accumulators, "weighted_mean")
         .def(py::init<>())
         .def(py::init<const double&, const double&, const double&, const double&>(),
              "wsum"_a, "wsum2"_a, "mean"_a, "variance"_a)
@@ -85,7 +85,7 @@ void register_accumulators(py::module &m) {
     
     using mean = bh::accumulators::mean<double>;
     
-    py::class_<mean>(accumulator, "mean")
+    py::class_<mean>(accumulators, "mean")
         .def(py::init<>())
         .def(py::init<std::size_t, const double&, const double&>(),
              "value"_a, "mean"_a, "variance"_a)
@@ -111,7 +111,7 @@ void register_accumulators(py::module &m) {
     
     using sum = bh::accumulators::sum<double>;
     
-    py::class_<sum>(accumulator, "sum")
+    py::class_<sum>(accumulators, "sum")
         .def(py::init<>())
         .def(py::init<const double&>(), "value"_a)
     
@@ -135,4 +135,5 @@ void register_accumulators(py::module &m) {
         .def(make_pickle<sum>())
     ;
 
+    return accumulators;
 }

--- a/src/histogram/accumulators.cpp
+++ b/src/histogram/accumulators.cpp
@@ -6,6 +6,8 @@
 #include <boost/histogram/python/pybind11.hpp>
 #include <pybind11/operators.h>
 
+#include <boost/histogram/python/pickle.hpp>
+
 #include <boost/histogram.hpp>
 #include <boost/histogram/accumulators/weighted_sum.hpp>
 #include <boost/histogram/accumulators/weighted_mean.hpp>
@@ -45,6 +47,8 @@ void register_accumulators(py::module &m) {
         }), "values"_a, "variances"_a)
     
         .def("__repr__", shift_to_string<weighted_sum>())
+    
+        .def(make_pickle<weighted_sum>())
     ;
 
     using weighted_mean = bh::accumulators::weighted_mean<double>;
@@ -75,6 +79,7 @@ void register_accumulators(py::module &m) {
 
       .def("__repr__", shift_to_string<weighted_mean>())
     
+      .def(make_pickle<weighted_mean>())
       ;
 
     
@@ -100,6 +105,8 @@ void register_accumulators(py::module &m) {
         }), "value"_a)
     
         .def("__repr__", shift_to_string<mean>())
+    
+        .def(make_pickle<mean>())
     ;
     
     using sum = bh::accumulators::sum<double>;
@@ -124,6 +131,8 @@ void register_accumulators(py::module &m) {
         .def_property_readonly("large", &sum::large)
     
         .def("__repr__", shift_to_string<sum>())
+    
+        .def(make_pickle<sum>())
     ;
 
 }

--- a/src/histogram/accumulators.cpp
+++ b/src/histogram/accumulators.cpp
@@ -16,14 +16,32 @@
 #include <boost/histogram/accumulators/ostream.hpp>
 
 
+template<typename A, typename... Args>
+py::class_<A> add_accumulator(py::module acc, Args&&... args) {
+    
+    return py::class_<A>(acc, std::forward<Args>(args)...)
+        .def(py::init<>())
+    
+        .def(py::self += py::self)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+    
+        .def("__repr__", shift_to_string<A>())
+    
+        .def("__copy__", [](const A& self){return A(self);})
+        .def("__deepcopy__", [](const A& self, py::object){return A(self);})
+    
+        .def(make_pickle<A>())
+    ;
+}
+
 py::module register_accumulators(py::module &m) {
     
     py::module accumulators = m.def_submodule("accumulators");
 
     using weighted_sum = bh::accumulators::weighted_sum<double>;
     
-    py::class_<weighted_sum>(accumulators, "weighted_sum")
-        .def(py::init<>())
+    add_accumulator<weighted_sum>(accumulators, "weighted_sum")
         .def(py::init<const double&>(), "value"_a)
         .def(py::init<const double&, const double&>(), "value"_a, "variance"_a)
     
@@ -33,8 +51,6 @@ py::module register_accumulators(py::module &m) {
         .def(py::self += double())
         .def(py::self += py::self)
         .def(py::self *= double())
-        .def(py::self == py::self)
-        .def(py::self != py::self)
     
         .def("__call__", py::vectorize([](weighted_sum& self, double value){
             self += value;
@@ -45,16 +61,11 @@ py::module register_accumulators(py::module &m) {
             self += weighted_sum(value, variance);
             return self.value(); 
         }), "values"_a, "variances"_a)
-    
-        .def("__repr__", shift_to_string<weighted_sum>())
-    
-        .def(make_pickle<weighted_sum>())
     ;
 
     using weighted_mean = bh::accumulators::weighted_mean<double>;
 
-    py::class_<weighted_mean>(accumulators, "weighted_mean")
-        .def(py::init<>())
+    add_accumulator<weighted_mean>(accumulators, "weighted_mean")
         .def(py::init<const double&, const double&, const double&, const double&>(),
              "wsum"_a, "wsum2"_a, "mean"_a, "variance"_a)
 
@@ -63,10 +74,7 @@ py::module register_accumulators(py::module &m) {
         .def_property_readonly("variance", &weighted_mean::variance)
         .def_property_readonly("value", &weighted_mean::value)
 
-        .def(py::self += py::self)
         .def(py::self *= double())
-        .def(py::self == py::self)
-        .def(py::self != py::self)
     
         .def("__call__", py::vectorize([](weighted_mean& self, double value){
             self(value);
@@ -76,17 +84,13 @@ py::module register_accumulators(py::module &m) {
            self(weight, value);
            return self.value();
        }), "weight"_a, "value"_a)
-
-      .def("__repr__", shift_to_string<weighted_mean>())
     
-      .def(make_pickle<weighted_mean>())
       ;
 
     
     using mean = bh::accumulators::mean<double>;
     
-    py::class_<mean>(accumulators, "mean")
-        .def(py::init<>())
+    add_accumulator<mean>(accumulators, "mean")
         .def(py::init<std::size_t, const double&, const double&>(),
              "value"_a, "mean"_a, "variance"_a)
     
@@ -94,33 +98,23 @@ py::module register_accumulators(py::module &m) {
         .def_property_readonly("variance", &mean::variance)
         .def_property_readonly("value", &mean::value)
     
-        .def(py::self += py::self)
         .def(py::self *= double())
-        .def(py::self == py::self)
-        .def(py::self != py::self)
     
         .def("__call__", py::vectorize([](mean& self, double value){
             self(value);
             return self.value();
         }), "value"_a)
-    
-        .def("__repr__", shift_to_string<mean>())
-    
-        .def(make_pickle<mean>())
     ;
     
     using sum = bh::accumulators::sum<double>;
     
-    py::class_<sum>(accumulators, "sum")
-        .def(py::init<>())
+    add_accumulator<sum>(accumulators, "sum")
         .def(py::init<const double&>(), "value"_a)
     
         .def_property("value", &sum::operator double, [](sum& s, double v){s = v;})
     
         .def(py::self += double())
         .def(py::self *= double())
-        .def(py::self == py::self)
-        .def(py::self != py::self)
     
         .def("__call__", py::vectorize([](sum& self, double value){
             self += value;
@@ -130,9 +124,6 @@ py::module register_accumulators(py::module &m) {
         .def_property_readonly("small", &sum::small)
         .def_property_readonly("large", &sum::large)
     
-        .def("__repr__", shift_to_string<sum>())
-    
-        .def(make_pickle<sum>())
     ;
 
     return accumulators;

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -88,6 +88,9 @@ py::class_<A> register_axis_by_type(py::module& m, Args&&... args) {
                   [](const A& self){return self.metadata();},
                   [](A& self, const metadata_t& label){self.metadata() = label;},
                   "Set the axis label")
+    
+    .def("__copy__", [](const A& self){return A(self);})
+    .def("__deepcopy__", [](const A& self, py::object){return A(self);})
 
     ;
 

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -10,6 +10,7 @@
 #include <pybind11/eval.h>
 
 #include <boost/histogram/python/axis.hpp>
+#include <boost/histogram/python/pickle.hpp>
 
 #include <boost/histogram/axis/ostream.hpp>
 #include <boost/histogram.hpp>
@@ -95,6 +96,8 @@ py::class_<A> register_axis_by_type(py::module& m, Args&&... args) {
 
     // This is a replacement for constexpr if
     add_to_axis<A>(axis, std::integral_constant<bool, std::is_reference<Result>::value || std::is_integral<Result>::value>{});
+
+    axis.def(make_pickle<A>());
 
     return axis;
 }

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -90,7 +90,12 @@ py::class_<A> register_axis_by_type(py::module& m, Args&&... args) {
                   "Set the axis label")
     
     .def("__copy__", [](const A& self){return A(self);})
-    .def("__deepcopy__", [](const A& self, py::object){return A(self);})
+    .def("__deepcopy__", [](const A& self, py::object memo){
+        A* a = new A(self);
+        py::module copy = py::module::import("copy");
+        a->metadata() = copy.attr("deepcopy")(a->metadata(), memo);
+        return a;
+    })
 
     ;
 

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -86,7 +86,7 @@ py::class_<A> register_axis_by_type(py::module& m, Args&&... args) {
     .def_static("options", &A::options, "Return the options associated to the axis")
     .def_property("metadata",
                   [](const A& self){return self.metadata();},
-                  [](A& self, metadata_t label){self.metadata() = label;},
+                  [](A& self, const metadata_t& label){self.metadata() = label;},
                   "Set the axis label")
 
     ;
@@ -126,7 +126,7 @@ py::class_<bh::axis::interval_view<A>> register_axis_iv_by_type(py::module& m, c
 struct regular_type {};
 
 
-void register_axis(py::module &m) {
+py::module register_axis(py::module &m) {
 
     py::module ax = m.def_submodule("axis");
 
@@ -248,4 +248,5 @@ void register_axis(py::module &m) {
     .def(py::init<>())
     ;
 
+    return ax;
 }

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -48,7 +48,14 @@ py::class_<bh::histogram<A, S>> register_histogram_by_type(py::module& m, const 
          "Reset bin counters to zero")
     
     .def("__copy__", [](const histogram_t& self){return histogram_t(self);})
-    .def("__deepcopy__", [](const histogram_t& self, py::object){return histogram_t(self);})
+    .def("__deepcopy__", [](const histogram_t& self, py::object memo){
+        histogram_t* a = new histogram_t(self);
+        py::module copy = py::module::import("copy");
+        for(int i=0; i<a->rank(); i++) {
+            bh::unsafe_access::axis(*a, i).metadata() = copy.attr("deepcopy")(a->axis(i).metadata(), memo);
+        }
+        return a;
+    })
 
     .def(py::self + py::self)
     .def(py::self == py::self)

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -12,7 +12,7 @@
 #include <boost/histogram/python/histogram_fill.hpp>
 #include <boost/histogram/python/histogram_atomic.hpp>
 #include <boost/histogram/python/histogram_threaded.hpp>
-#include <boost/histogram/python/try_cast.hpp>
+#include <boost/histogram/python/pickle.hpp>
 
 #include <boost/histogram.hpp>
 #include <boost/histogram/axis/ostream.hpp>
@@ -22,11 +22,9 @@
 
 #include <boost/mp11.hpp>
 
-#include <cassert>
 #include <vector>
 #include <sstream>
 #include <tuple>
-#include <cmath>
 
 
 template<typename A, typename S>
@@ -137,6 +135,8 @@ py::class_<bh::histogram<A, S>> register_histogram_by_type(py::module& m, const 
         return bh::algorithm::project(self, py::cast<std::vector<unsigned>>(values));
     }, "Project to a single axis or several axes on a multidiminsional histogram")
     
+    .def(make_pickle<histogram_t>())
+    
     ;
 
     return hist;
@@ -151,7 +151,7 @@ void add_atomic_fill(py::class_<bh::histogram<A, S>>& hist) {
     ;
 }
 
-void register_histogram(py::module& m) {
+py::module register_histogram(py::module& m) {
     
     m.attr("BOOST_HISTOGRAM_DETAIL_AXES_LIMIT") = BOOST_HISTOGRAM_DETAIL_AXES_LIMIT;
     
@@ -200,51 +200,6 @@ void register_histogram(py::module& m) {
         "any_weight",
         "N-dimensional histogram for weighted data with any axis types.");
 
-    m.def("make_histogram", [](py::args args, py::kwargs kwargs) -> py::object {
-
-        py::object storage = kwargs.contains("storage") ?
-          kwargs["storage"] : py::cast(storage::int_());
-
-        // We try each possible axes type that has high-performance single-type overloads.
-
-        try {
-          return try_cast<
-            storage::int_,
-            storage::atomic_int,
-            storage::unlimited
-          >(storage, [&args](auto&& storage) {
-            auto reg = py::cast<axes::regular>(args);
-            return py::cast(bh::make_histogram_with(storage, reg),
-                            py::return_value_policy::move);
-          });
-        } catch(const py::cast_error&) {}
-
-        try {
-          return try_cast<
-            storage::int_
-          >(storage, [&args](auto&& storage) {
-            auto reg = py::cast<axes::regular_noflow>(args);
-            return py::cast(bh::make_histogram_with(storage, reg),
-                            py::return_value_policy::move);
-          });
-        } catch(const py::cast_error&) {}
-
-        // fallback to slower generic implementation
-        auto axes = py::cast<axes::any>(args);
-
-        return try_cast<
-          storage::int_,
-          storage::double_,
-          storage::unlimited,
-          storage::weight,
-          storage::atomic_int
-        >(storage, [&axes](auto&& storage) {
-          return py::cast(bh::make_histogram_with(storage, axes),
-                          py::return_value_policy::move);
-        });
-
-    }, "Make any histogram");
-
     // register_histogram_by_type<axes::any, bh::profile_storage>(hist,
     //    "any_profile",
     //    "N-dimensional histogram for sampled data with any axis types.");
@@ -252,20 +207,8 @@ void register_histogram(py::module& m) {
     // register_histogram_by_type<axes::any, bh::weighted_profile_storage>(hist,
     //    "any_weighted_profile",
     //    "N-dimensional histogram for weighted and sampled data with any axis types.");
-
-    // This factory makes a class that can be used to create histograms and also be used in is_instance
-    py::object factory_meta_py = py::module::import("boost.histogram_utils").attr("FactoryMeta");
     
-    m.attr("histogram") = factory_meta_py(m.attr("make_histogram"),
-                                          py::make_tuple(hist.attr("regular_unlimited"),
-                                                         hist.attr("regular_int"),
-                                                         hist.attr("regular_atomic_int"),
-                                                         hist.attr("regular_noflow_int"),
-                                                         hist.attr("any_int"),
-                                                         hist.attr("any_atomic_int"),
-                                                         hist.attr("any_double"),
-                                                         hist.attr("any_unlimited"),
-                                                         hist.attr("any_weight")
-                                                         ));
+    return hist;
+
 }
 

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -46,6 +46,9 @@ py::class_<bh::histogram<A, S>> register_histogram_by_type(py::module& m, const 
          "Total number of bins in the histogram (including underflow/overflow)" )
     .def("reset", &histogram_t::reset,
          "Reset bin counters to zero")
+    
+    .def("__copy__", [](const histogram_t& self){return histogram_t(self);})
+    .def("__deepcopy__", [](const histogram_t& self, py::object){return histogram_t(self);})
 
     .def(py::self + py::self)
     .def(py::self == py::self)

--- a/src/histogram/make_histogram.cpp
+++ b/src/histogram/make_histogram.cpp
@@ -1,0 +1,83 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#include <boost/histogram/python/pybind11.hpp>
+#include <pybind11/operators.h>
+
+#include <boost/histogram/python/histogram.hpp>
+#include <boost/histogram/python/storage.hpp>
+#include <boost/histogram/python/try_cast.hpp>
+#include <boost/histogram/python/axis.hpp>
+
+#include <boost/histogram.hpp>
+
+#include <boost/mp11.hpp>
+
+#include <vector>
+
+void register_make_histogram(py::module& m, py::module& hist) {
+    
+    
+    m.def("make_histogram", [](py::args args, py::kwargs kwargs) -> py::object {
+        
+        py::object storage = kwargs.contains("storage") ?
+        kwargs["storage"] : py::cast(storage::int_());
+        
+        // We try each possible axes type that has high-performance single-type overloads.
+        
+        try {
+            return try_cast<
+            storage::int_,
+            storage::atomic_int,
+            storage::unlimited
+            >(storage, [&args](auto&& storage) {
+                auto reg = py::cast<axes::regular>(args);
+                return py::cast(bh::make_histogram_with(storage, reg),
+                                py::return_value_policy::move);
+            });
+        } catch(const py::cast_error&) {}
+        
+        try {
+            return try_cast<
+            storage::int_
+            >(storage, [&args](auto&& storage) {
+                auto reg = py::cast<axes::regular_noflow>(args);
+                return py::cast(bh::make_histogram_with(storage, reg),
+                                py::return_value_policy::move);
+            });
+        } catch(const py::cast_error&) {}
+        
+        // fallback to slower generic implementation
+        auto axes = py::cast<axes::any>(args);
+        
+        return try_cast<
+        storage::int_,
+        storage::double_,
+        storage::unlimited,
+        storage::weight,
+        storage::atomic_int
+        >(storage, [&axes](auto&& storage) {
+            return py::cast(bh::make_histogram_with(storage, axes),
+                            py::return_value_policy::move);
+        });
+        
+    }, "Make any histogram");
+    
+    // This factory makes a class that can be used to create histograms and also be used in is_instance
+    py::object factory_meta_py = py::module::import("boost.histogram_utils").attr("FactoryMeta");
+    
+    m.attr("histogram") = factory_meta_py(m.attr("make_histogram"),
+                                          py::make_tuple(hist.attr("regular_unlimited"),
+                                                         hist.attr("regular_int"),
+                                                         hist.attr("regular_atomic_int"),
+                                                         hist.attr("regular_noflow_int"),
+                                                         hist.attr("any_int"),
+                                                         hist.attr("any_atomic_int"),
+                                                         hist.attr("any_double"),
+                                                         hist.attr("any_unlimited"),
+                                                         hist.attr("any_weight")
+                                                         ));
+}
+

--- a/src/histogram/storage.cpp
+++ b/src/histogram/storage.cpp
@@ -6,6 +6,8 @@
 #include <boost/histogram/python/pybind11.hpp>
 
 #include <boost/histogram/python/storage.hpp>
+#include <boost/histogram/python/pickle.hpp>
+#include <pybind11/operators.h>
 
 #include <boost/histogram.hpp>
 #include <boost/histogram/storage_adaptor.hpp>
@@ -17,16 +19,32 @@
 #include <utility>
 #include <vector>
 
+/// Add helpers common to all storage types
+template<typename A, typename T>
+py::class_<A> register_storage_by_type(py::module& m, const char* name, const char* desc) {
+    py::class_<A> storage(m, name, desc);
+    
+    storage
+    .def(py::init<>())
+    .def("__getitem__", [](A& self, size_t ind){return self.at(ind);})
+    .def("__setitem__", [](A& self, size_t ind, T val){self.at(ind) = val;})
+    .def("push_back", [](A& self, T val){self.push_back(val);})
+    .def(py::self == py::self)
+    .def(py::self != py::self)
+    .def(make_pickle<A>())
+    ;
+    
+    return storage;
+}
 
-void register_storage(py::module &m) {
+
+py::module register_storage(py::module &m) {
 
     py::module storage = m.def_submodule("storage");
 
     // Fast storages
 
-    py::class_<storage::int_>(storage, "int", "Integers in vectors storage type")
-    .def(py::init<>())
-    ;
+    register_storage_by_type<storage::int_, unsigned>(storage, "int", "Integers in vectors storage type");
 
     py::class_<storage::double_>(storage, "double", "Weighted storage without variance type (fast but simple)")
     .def(py::init<>())
@@ -54,4 +72,5 @@ void register_storage(py::module &m) {
     .def(py::init<>())
     ;
 
+    return storage;
 }

--- a/src/histogram/storage.cpp
+++ b/src/histogram/storage.cpp
@@ -32,6 +32,8 @@ py::class_<A> register_storage_by_type(py::module& m, const char* name, const ch
     .def(py::self == py::self)
     .def(py::self != py::self)
     .def(make_pickle<A>())
+    .def("__copy__", [](const A& self){return A(self);})
+    .def("__deepcopy__", [](const A& self, py::object){return A(self);})
     ;
     
     return storage;

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -5,14 +5,16 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
-void register_axis(py::module &);
-void register_histogram(py::module &);
-void register_storage(py::module &);
-void register_accumulators(py::module &);
+py::module register_storage(py::module &);
+py::module register_axis(py::module &);
+py::module register_histogram(py::module &);
+void register_make_histogram(py::module &, py::module &);
+py::module register_accumulators(py::module &);
 
 PYBIND11_MODULE(histogram, m) {
     register_storage(m);
     register_axis(m);
-    register_histogram(m);
+    py::module hist = register_histogram(m);
+    register_make_histogram(m, hist);
     register_accumulators(m);
 }

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 def test_weighted_sum():
-    v = bh.accumulator.weighted_sum(1.5, 2.5)
+    v = bh.accumulators.weighted_sum(1.5, 2.5)
 
     assert v.value == 1.5
     assert v.variance == 2.5
@@ -16,7 +16,7 @@ def test_weighted_sum():
     assert v.value == 3.0
     assert v.variance == 4.75
 
-    v = bh.accumulator.weighted_sum()
+    v = bh.accumulators.weighted_sum()
     v([1,2,3], [4,5,6])
 
     assert v.value == 6
@@ -25,7 +25,7 @@ def test_weighted_sum():
 
 
 def test_weighted_mean():
-    v = bh.accumulator.weighted_mean()
+    v = bh.accumulators.weighted_mean()
     v(1,4)
     v(2,1)
 
@@ -33,7 +33,7 @@ def test_weighted_mean():
     assert v.variance == 4.5
     assert v.value == 2.0
 
-    v = bh.accumulator.weighted_mean()
+    v = bh.accumulators.weighted_mean()
     v([1,2],[4,1])
 
     assert v.sum_of_weights == 3.0
@@ -43,7 +43,7 @@ def test_weighted_mean():
 
 
 def test_mean():
-    v = bh.accumulator.mean()
+    v = bh.accumulators.mean()
     v(1)
     v(2)
     v(3)
@@ -52,7 +52,7 @@ def test_mean():
     assert v.variance == 1
     assert v.value == 2
 
-    v = bh.accumulator.mean()
+    v = bh.accumulators.mean()
     v([1,2,3])
 
     assert v.count == 3
@@ -61,14 +61,14 @@ def test_mean():
 
 
 def test_sum():
-    v = bh.accumulator.sum()
+    v = bh.accumulators.sum()
     v += 1
     v += 2
     v += 3
 
     assert v.value == 6
 
-    v = bh.accumulator.sum()
+    v = bh.accumulators.sum()
     v([1,2,3])
     assert v.value == 6
 

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -9,24 +9,24 @@ except ImportError:
 import boost.histogram as bh
 
 
-class TestAccumulator:
+class TestAccumulators:
     def test_sum(self):
-        orig = bh.accumulator.sum(12)
+        orig = bh.accumulators.sum(12)
         new = loads(dumps(orig))
         assert new == orig
 
     def test_weighted_sum(self):
-        orig = bh.accumulator.weighted_sum(1.5, 2.5)
+        orig = bh.accumulators.weighted_sum(1.5, 2.5)
         new = loads(dumps(orig))
         assert new == orig
 
     def test_mean(self):
-        orig = bh.accumulator.mean(5, 1.5, 2.5)
+        orig = bh.accumulators.mean(5, 1.5, 2.5)
         new = loads(dumps(orig))
         assert new == orig
 
     def test_weighted_mean(self):
-        orig = bh.accumulator.weighted_mean(1.5, 2.5, 3.5, 4.5)
+        orig = bh.accumulators.weighted_mean(1.5, 2.5, 3.5, 4.5)
         new = loads(dumps(orig))
         assert new == orig
 
@@ -69,17 +69,42 @@ def test_metadata_any(axis, args):
     assert new.metadata == orig.metadata
     new.metadata = orig.metadata
     assert new == orig
-#
-#
-#	def test_storage_int():
-#	    storage = bh.storage.int()
-#	    storage.push_back(1)
-#	    storage.push_back(3)
-#	    storage.push_back(2)
-#
-#	    assert storage[0] == 1
-#	    assert storage[1] == 3
-#	    assert storage[2] == 2
-#
-#	    # new = loads(dumps(storage))
-#	    # assert storage == new
+
+
+def test_storage_int():
+    storage = bh.storage.int()
+    storage.push_back(1)
+    storage.push_back(3)
+    storage.push_back(2)
+
+    assert storage[0] == 1
+    assert storage[1] == 3
+    assert storage[2] == 2
+
+    new = loads(dumps(storage))
+    assert storage == new
+
+def test_histogram_regular():
+    hist = bh.histogram(bh.axis.regular(4,1,2), bh.axis.regular(8,3,6))
+
+    new = loads(dumps(hist))
+    assert hist == new
+
+
+def test_histogram_fancy():
+    hist = bh.histogram(bh.axis.regular_noflow(4,1,2), bh.axis.integer_uoflow(0, 6))
+
+    new = loads(dumps(hist))
+    assert hist == new
+
+def test_histogram_metadata():
+
+    hist = bh.histogram(bh.axis.regular(4,1,2, metadata="This"))
+    new = loads(dumps(hist))
+    assert hist.axis(0).metadata == new.axis(0).metadata
+
+    hist = bh.histogram(bh.axis.regular(4,1,2, metadata=(1,2,3)))
+    new = loads(dumps(hist))
+    assert hist.axis(0).metadata == new.axis(0).metadata
+
+    # Note that == directly will not work since it is "is" in Python

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     from pickle import loads, dumps
 
+import copy
+
 import boost.histogram as bh
 
 modes = [2,-1]
@@ -17,20 +19,32 @@ class TestAccumulators:
         new = loads(dumps(orig, mode))
         assert new == orig
 
+        new = copy.copy(orig)
+        assert new == orgin
+
     def test_weighted_sum(self, mode):
         orig = bh.accumulators.weighted_sum(1.5, 2.5)
         new = loads(dumps(orig, mode))
         assert new == orig
+
+        new = copy.copy(orig)
+        assert new == orgin
 
     def test_mean(self, mode):
         orig = bh.accumulators.mean(5, 1.5, 2.5)
         new = loads(dumps(orig, mode))
         assert new == orig
 
+        new = copy.copy(orig)
+        assert new == orgin
+
     def test_weighted_mean(self, mode):
         orig = bh.accumulators.weighted_mean(1.5, 2.5, 3.5, 4.5)
         new = loads(dumps(orig, mode))
         assert new == orig
+
+        new = copy.copy(orig)
+        assert new == orgin
 
 
 axes_creations = (
@@ -54,6 +68,12 @@ axes_creations = (
 def test_axes(axis, args, mode):
     orig = axis(*args)
     new = loads(dumps(orig, mode))
+    assert new == orig
+
+@pytest.mark.parametrize("axis,args", axes_creations)
+def test_axes_copy(axis, args)
+    orig = axis(*args)
+    new = copy.copy(orig)
     assert new == orig
 
 

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -70,7 +70,15 @@ def test_metadata_str(axis, args, copy_fn):
     assert new == orig
 
 # Special test: Deepcopy should change metadata id, copy should not
-# TODO
+@pytest.mark.parametrize("metadata", ({1:2}, [1,2,3]))
+def test_compare_copy(metadata):
+    orig = bh.axis.regular_noflow(4,0,2, metadata=metadata)
+    new = copy.copy(orig)
+    dnew = copy.deepcopy(orig)
+
+    assert orig.metadata is new.metadata
+    assert orig.metadata == dnew.metadata
+    assert orig.metadata is not dnew.metadata
 
 @pytest.mark.parametrize("copy_fn", copies)
 @pytest.mark.parametrize("axis,args", axes_creations)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -8,26 +8,28 @@ except ImportError:
 
 import boost.histogram as bh
 
+modes = [2,-1]
 
+@pytest.mark.parametrize("mode", modes)
 class TestAccumulators:
-    def test_sum(self):
+    def test_sum(self, mode):
         orig = bh.accumulators.sum(12)
-        new = loads(dumps(orig))
+        new = loads(dumps(orig, mode))
         assert new == orig
 
-    def test_weighted_sum(self):
+    def test_weighted_sum(self, mode):
         orig = bh.accumulators.weighted_sum(1.5, 2.5)
-        new = loads(dumps(orig))
+        new = loads(dumps(orig, mode))
         assert new == orig
 
-    def test_mean(self):
+    def test_mean(self, mode):
         orig = bh.accumulators.mean(5, 1.5, 2.5)
-        new = loads(dumps(orig))
+        new = loads(dumps(orig, mode))
         assert new == orig
 
-    def test_weighted_mean(self):
+    def test_weighted_mean(self, mode):
         orig = bh.accumulators.weighted_mean(1.5, 2.5, 3.5, 4.5)
-        new = loads(dumps(orig))
+        new = loads(dumps(orig, mode))
         assert new == orig
 
 
@@ -47,31 +49,34 @@ axes_creations = (
         (bh.axis.category_str_growth, (["1", "2", "3"],)),
         )
 
+@pytest.mark.parametrize("mode", modes)
 @pytest.mark.parametrize("axis,args", axes_creations)
-def test_axes(axis, args):
+def test_axes(axis, args, mode):
     orig = axis(*args)
-    new = loads(dumps(orig))
+    new = loads(dumps(orig, mode))
     assert new == orig
 
 
+@pytest.mark.parametrize("mode", modes)
 @pytest.mark.parametrize("axis,args", axes_creations)
-def test_metadata_str(axis, args):
+def test_metadata_str(axis, args, mode):
     orig = axis(*args, metadata="hi")
-    new = loads(dumps(orig))
+    new = loads(dumps(orig, mode))
     assert new.metadata == orig.metadata
     new.metadata = orig.metadata
     assert new == orig
 
+@pytest.mark.parametrize("mode", modes)
 @pytest.mark.parametrize("axis,args", axes_creations)
-def test_metadata_any(axis, args):
+def test_metadata_any(axis, args, mode):
     orig = axis(*args, metadata=(1,2,3))
-    new = loads(dumps(orig))
+    new = loads(dumps(orig, mode))
     assert new.metadata == orig.metadata
     new.metadata = orig.metadata
     assert new == orig
 
-
-def test_storage_int():
+@pytest.mark.parametrize("mode", modes)
+def test_storage_int(mode):
     storage = bh.storage.int()
     storage.push_back(1)
     storage.push_back(3)
@@ -81,30 +86,33 @@ def test_storage_int():
     assert storage[1] == 3
     assert storage[2] == 2
 
-    new = loads(dumps(storage))
+    new = loads(dumps(storage, mode))
     assert storage == new
 
-def test_histogram_regular():
+@pytest.mark.parametrize("mode", modes)
+def test_histogram_regular(mode):
     hist = bh.histogram(bh.axis.regular(4,1,2), bh.axis.regular(8,3,6))
 
-    new = loads(dumps(hist))
+    new = loads(dumps(hist, mode))
     assert hist == new
 
 
-def test_histogram_fancy():
+@pytest.mark.parametrize("mode", modes)
+def test_histogram_fancy(mode):
     hist = bh.histogram(bh.axis.regular_noflow(4,1,2), bh.axis.integer_uoflow(0, 6))
 
-    new = loads(dumps(hist))
+    new = loads(dumps(hist, mode))
     assert hist == new
 
-def test_histogram_metadata():
+@pytest.mark.parametrize("mode", modes)
+def test_histogram_metadata(mode):
 
     hist = bh.histogram(bh.axis.regular(4,1,2, metadata="This"))
-    new = loads(dumps(hist))
+    new = loads(dumps(hist, mode))
     assert hist.axis(0).metadata == new.axis(0).metadata
 
     hist = bh.histogram(bh.axis.regular(4,1,2, metadata=(1,2,3)))
-    new = loads(dumps(hist))
+    new = loads(dumps(hist, mode))
     assert hist.axis(0).metadata == new.axis(0).metadata
 
     # Note that == directly will not work since it is "is" in Python

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -71,7 +71,7 @@ def test_metadata_str(axis, args, copy_fn):
 
 # Special test: Deepcopy should change metadata id, copy should not
 @pytest.mark.parametrize("metadata", ({1:2}, [1,2,3]))
-def test_compare_copy(metadata):
+def test_compare_copy_axis(metadata):
     orig = bh.axis.regular_noflow(4,0,2, metadata=metadata)
     new = copy.copy(orig)
     dnew = copy.deepcopy(orig)
@@ -80,8 +80,19 @@ def test_compare_copy(metadata):
     assert orig.metadata == dnew.metadata
     assert orig.metadata is not dnew.metadata
 
-@pytest.mark.parametrize("copy_fn", copies)
+# Special test: Deepcopy should change metadata id, copy should not
+@pytest.mark.parametrize("metadata", ({1:2}, [1,2,3]))
+def test_compare_copy_hist(metadata):
+    orig = bh.make_histogram(bh.axis.regular_noflow(4,0,2, metadata=metadata))
+    new = copy.copy(orig)
+    dnew = copy.deepcopy(orig)
+
+    assert orig.axis(0).metadata is new.axis(0).metadata
+    assert orig.axis(0).metadata == dnew.axis(0).metadata
+    assert orig.axis(0).metadata is not dnew.axis(0).metadata
+
 @pytest.mark.parametrize("axis,args", axes_creations)
+@pytest.mark.parametrize("copy_fn", copies)
 def test_metadata_any(axis, args, copy_fn):
     orig = axis(*args, metadata=(1,2,3))
     new = copy_fn(orig)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,85 @@
+import pytest
+
+try:
+    # Python 2
+    from cPickle import loads, dumps
+except ImportError:
+    from pickle import loads, dumps
+
+import boost.histogram as bh
+
+
+class TestAccumulator:
+    def test_sum(self):
+        orig = bh.accumulator.sum(12)
+        new = loads(dumps(orig))
+        assert new == orig
+
+    def test_weighted_sum(self):
+        orig = bh.accumulator.weighted_sum(1.5, 2.5)
+        new = loads(dumps(orig))
+        assert new == orig
+
+    def test_mean(self):
+        orig = bh.accumulator.mean(5, 1.5, 2.5)
+        new = loads(dumps(orig))
+        assert new == orig
+
+    def test_weighted_mean(self):
+        orig = bh.accumulator.weighted_mean(1.5, 2.5, 3.5, 4.5)
+        new = loads(dumps(orig))
+        assert new == orig
+
+
+axes_creations = (
+        (bh.axis.regular_uoflow,      (4, 2, 4)),
+        (bh.axis.regular_growth,      (4, 2, 4)),
+        (bh.axis.regular_noflow,      (4, 2, 4)),
+        (bh.axis.regular_log,         (4, 2, 4)),
+        (bh.axis.regular_sqrt,        (4, 2, 4)),
+        (bh.axis.regular_pow,         (4, 2, 4, 0.5)),
+        (bh.axis.circular,            (4, 2, 4)),
+        (bh.axis.variable,            ([1, 2, 3, 4],)),
+        (bh.axis.integer_uoflow,      (1, 4)),
+        (bh.axis.category_int,        ([1, 2, 3],)),
+        (bh.axis.category_int_growth, ([1, 2, 3],)),
+        (bh.axis.category_str,        (["1", "2", "3"],)),
+        (bh.axis.category_str_growth, (["1", "2", "3"],)),
+        )
+
+@pytest.mark.parametrize("axis,args", axes_creations)
+def test_axes(axis, args):
+    orig = axis(*args)
+    new = loads(dumps(orig))
+    assert new == orig
+
+
+@pytest.mark.parametrize("axis,args", axes_creations)
+def test_metadata_str(axis, args):
+    orig = axis(*args, metadata="hi")
+    new = loads(dumps(orig))
+    assert new.metadata == orig.metadata
+    new.metadata = orig.metadata
+    assert new == orig
+
+@pytest.mark.parametrize("axis,args", axes_creations)
+def test_metadata_any(axis, args):
+    orig = axis(*args, metadata=(1,2,3))
+    new = loads(dumps(orig))
+    assert new.metadata == orig.metadata
+    new.metadata = orig.metadata
+    assert new == orig
+#
+#
+#	def test_storage_int():
+#	    storage = bh.storage.int()
+#	    storage.push_back(1)
+#	    storage.push_back(3)
+#	    storage.push_back(2)
+#
+#	    assert storage[0] == 1
+#	    assert storage[1] == 3
+#	    assert storage[2] == 2
+#
+#	    # new = loads(dumps(storage))
+#	    # assert storage == new

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -13,7 +13,11 @@ import boost.histogram as bh
 
 import numpy as np
 from numpy.testing import assert_array_equal
-import pickle
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 
 # histogram -> boost.histogram
 # histogram -> make_histogram

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -13,6 +13,7 @@ import boost.histogram as bh
 
 import numpy as np
 from numpy.testing import assert_array_equal
+import pickle
 
 # histogram -> boost.histogram
 # histogram -> make_histogram
@@ -46,9 +47,6 @@ def test_init():
     assert h != histogram(integer_uoflow(-1, 1, metadata="ia"))
 
 
-# CLASSIC
-# TEST COPY: DISABLED UNTIL SERIALIZE IS SUPPORTED
-@pytest.mark.skip()
 def test_copy():
     a = histogram(integer_uoflow(-1, 1))
     import copy
@@ -325,14 +323,13 @@ def test_reduce_to(self):
         h.reduce_to(2, 1)
 
 
-# CLASSIC: pickle is not yet supported
-@pytest.mark.skip(message="Pickle not yet supported")
+# CLASSIC: This used to have metadata too, but that does not compare equal
 def test_pickle_0():
     a = histogram(category([0, 1, 2]),
-                  integer_uoflow(0, 20, metadata='ia'),
+                  integer_uoflow(0, 20),
                   regular_noflow(20, 0.0, 20.0),
                   variable([0.0, 1.0, 2.0]),
-                  circular(4, metadata='pa'))
+                  circular(4, 2*np.pi))
     for i in range(a.axis(0).size(flow=True)):
         a(i, 0, 0, 0, 0)
         for j in range(a.axis(1).size(flow=True)):
@@ -342,12 +339,10 @@ def test_pickle_0():
                 for l in range(a.axis(3).size(flow=True)):
                     a(i, j, k, l, 0)
                     for m in range(a.axis(4).size(flow=True)):
-                        a(i, j, k, l, m * 0.5 * pi)
+                        a(i, j, k, l, m * 0.5 * np.pi)
 
-    io = BytesIO()
-    pickle.dump(a, io)
-    io.seek(0)
-    b = pickle.load(io)
+    io = pickle.dumps(a)
+    b = pickle.loads(io)
 
     assert id(a) != id(b)
     assert a.rank() == b.rank()
@@ -359,15 +354,14 @@ def test_pickle_0():
     assert a.sum() == b.sum()
     assert a == b
 
-# CLASSIC: pickle is not yet supported
-@pytest.mark.skip(message="Pickle not yet supported")
+@pytest.mark.skip(message="Requires weighted fills / type")
 def test_pickle_1():
     a = histogram(category([0, 1, 2]),
                   integer_uoflow(0, 3, metadata='ia'),
                   regular_noflow(4, 0.0, 4.0),
                   variable([0.0, 1.0, 2.0]))
-    assert isinstance(h, bh.hist.any_int)
-    assert isinstance(h, histogram)
+    assert isinstance(a, bh.hist.any_int)
+    assert isinstance(a, histogram)
 
     for i in range(a.axis(0).size(flow=True)):
         a(i, 0, 0, 0, weight=3)

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -345,7 +345,7 @@ def test_pickle_0():
                     for m in range(a.axis(4).size(flow=True)):
                         a(i, j, k, l, m * 0.5 * np.pi)
 
-    io = pickle.dumps(a)
+    io = pickle.dumps(a,-1)
     b = pickle.loads(io)
 
     assert id(a) != id(b)


### PR DESCRIPTION
This uses built-in pickle support, combined with Python types, to do serialization.  Standard PyBind11 caveats for picking in Python 2 apply (must be cPickle, must use a reasonably high pickle protocol).

Also provides high quality copy machinery. TODO: add proper deep copy support for histograms (plain axis already fixed). 