### PR TITLE
SDist and Wheels

### DIFF
--- a/.ci/azure-cmake-steps.yml
+++ b/.ci/azure-cmake-steps.yml
@@ -1,9 +1,5 @@
 steps:
 
-- checkout: self
-  fetchDepth: 50
-  submodules: true
-
 - task: UsePythonVersion@0
   inputs:
     versionSpec: '$(python.version)'

--- a/.ci/azure-cmake-steps.yml
+++ b/.ci/azure-cmake-steps.yml
@@ -1,8 +1,9 @@
 steps:
 
-- task: CMake@1
-  inputs:
-    cmakeArgs: .. -DCMAKE_BUILD_TYPE=Debug -DBOOST_HISTOGRAM_ERRORS=ON -DPYTHON_EXECUTABLE="$(python.executable)"
+- script:
+    mkdir -p build
+    cd build
+    cmake .. -DCMAKE_BUILD_TYPE=Debug -DBOOST_HISTOGRAM_ERRORS=ON -DPYTHON_EXECUTABLE="$(python.executable)"
   displayName: 'Configure'
 
 - script: cmake --build . -j

--- a/.ci/azure-cmake-steps.yml
+++ b/.ci/azure-cmake-steps.yml
@@ -1,16 +1,5 @@
 steps:
 
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: '$(python.version)'
-    architecture: 'x64'
-
-- script: |
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade pytest
-    python -m pip install numpy pytest-benchmark 'futures; python_version<"3.4"'
-  displayName: 'Install dependencies'
-
 - task: CMake@1
   inputs:
     cmakeArgs: .. -DCMAKE_BUILD_TYPE=Debug -DBOOST_HISTOGRAM_ERRORS=ON -DPYTHON_EXECUTABLE="`which python`"

--- a/.ci/azure-cmake-steps.yml
+++ b/.ci/azure-cmake-steps.yml
@@ -2,7 +2,7 @@ steps:
 
 - task: CMake@1
   inputs:
-    cmakeArgs: .. -DCMAKE_BUILD_TYPE=Debug -DBOOST_HISTOGRAM_ERRORS=ON -DPYTHON_EXECUTABLE="`which python`"
+    cmakeArgs: .. -DCMAKE_BUILD_TYPE=Debug -DBOOST_HISTOGRAM_ERRORS=ON -DPYTHON_EXECUTABLE="$(python.executable)"
   displayName: 'Configure'
 
 - script: cmake --build . -j

--- a/.ci/azure-cmake-steps.yml
+++ b/.ci/azure-cmake-steps.yml
@@ -13,7 +13,7 @@ steps:
 
 - task: CMake@1
   inputs:
-    cmakeArgs: .. -DCMAKE_BUILD_TYPE=Debug -DBOOST_HISTOGRAM_ERRORS=ON
+    cmakeArgs: .. -DCMAKE_BUILD_TYPE=Debug -DBOOST_HISTOGRAM_ERRORS=ON -DPYTHON_EXECUTABLE="`which python`"
   displayName: 'Configure'
 
 - script: cmake --build . -j

--- a/.ci/azure-cmake-steps.yml
+++ b/.ci/azure-cmake-steps.yml
@@ -1,9 +1,9 @@
 steps:
 
-- script:
+- script: |
     mkdir -p build
     cd build
-    cmake .. -DCMAKE_BUILD_TYPE=Debug -DBOOST_HISTOGRAM_ERRORS=ON -DPYTHON_EXECUTABLE="$(python.executable)"
+    cmake .. -DCMAKE_BUILD_TYPE=Debug -DBOOST_HISTOGRAM_ERRORS=ON -DPYTHON_EXECUTABLE="$(which python)"
   displayName: 'Configure'
 
 - script: cmake --build . -j

--- a/.ci/azure-cmake-steps.yml
+++ b/.ci/azure-cmake-steps.yml
@@ -14,3 +14,13 @@ steps:
   displayName: 'Test'
   workingDirectory: build
 
+- script: |
+    python -m pytest --junitxml=junit/test-results.xml ../tests
+  workingDirectory: build
+  displayName: 'Test with pytest'
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: '**/test-*.xml'
+    testRunTitle: 'Publish test results for Python $(python.version)'
+  condition: succeededOrFailed()

--- a/.ci/azure-macos-setup.yml
+++ b/.ci/azure-macos-setup.yml
@@ -1,0 +1,14 @@
+# This is special for macOS because "UsePythonVersion"
+# does not use the official Python.org installers.
+
+steps:
+
+- script: .ci/macos-install-python.sh '$(python.version)'
+  displayName: Install Python.org Python
+
+- script: |
+    python -m pip install --upgrade pip
+    python -m pip install --upgrade pytest wheel twine
+    python -m pip install -r dev-requirements.txt
+  displayName: 'Install dependencies'
+

--- a/.ci/azure-publish-dist.yml
+++ b/.ci/azure-publish-dist.yml
@@ -4,5 +4,5 @@ steps:
     python -m pip install twine
     python -m twine upload --repository-url https://test.pypi.org/legacy/ --username $(TWINE_USERNAME) --password $(TWINE_PASSWORD) dist/*
   displayName: "Publish to PyPI"
-  # condition: and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'))
+  condition: and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'))
 

--- a/.ci/azure-publish-dist.yml
+++ b/.ci/azure-publish-dist.yml
@@ -2,7 +2,10 @@
 steps:
 - script: |
     python -m pip install twine
-    python -m twine upload --repository-url https://test.pypi.org/legacy/ --username $(TWINE_USERNAME) --password $(TWINE_PASSWORD) dist/*
+    python -m twine upload --repository-url $(TWINE_REPOSITORY_URL) \
+                           --username $(TWINE_USERNAME) \
+                           --password $(TWINE_PASSWORD) \
+                           dist/*
   displayName: "Publish to PyPI"
   condition: and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'))
 

--- a/.ci/azure-publish-dist.yml
+++ b/.ci/azure-publish-dist.yml
@@ -1,0 +1,8 @@
+
+steps:
+- script: |
+    python -m -pip install twine
+    python -m twine upload --repository-url https://test.pypi.org/legacy/ --username $(TWINE_USERNAME) --password $(TWINE_PASSWORD) dist/*
+  displayName: "Publish to test PyPI"
+  # condition: and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'))
+

--- a/.ci/azure-publish-dist.yml
+++ b/.ci/azure-publish-dist.yml
@@ -1,8 +1,8 @@
 
 steps:
 - script: |
-    python -m -pip install twine
+    python -m pip install twine
     python -m twine upload --repository-url https://test.pypi.org/legacy/ --username $(TWINE_USERNAME) --password $(TWINE_PASSWORD) dist/*
-  displayName: "Publish to test PyPI"
+  displayName: "Publish to PyPI"
   # condition: and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'))
 

--- a/.ci/azure-setup.yml
+++ b/.ci/azure-setup.yml
@@ -1,0 +1,13 @@
+steps:
+
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(python.version)'
+    architecture: '$(python.architecture)'
+
+- script: |
+    python -m pip install --upgrade pip
+    python -m pip install --upgrade pytest wheel
+    python -m pip install -f dev-requirements.txt
+  displayName: 'Install dependencies'
+

--- a/.ci/azure-setup.yml
+++ b/.ci/azure-setup.yml
@@ -9,5 +9,6 @@ steps:
     python -m pip install --upgrade pip
     python -m pip install --upgrade pytest wheel twine
     python -m pip install -r dev-requirements.txt
+    mkdir -p dist
   displayName: 'Install dependencies'
 

--- a/.ci/azure-setup.yml
+++ b/.ci/azure-setup.yml
@@ -7,7 +7,7 @@ steps:
 
 - script: |
     python -m pip install --upgrade pip
-    python -m pip install --upgrade pytest wheel
-    python -m pip install -f dev-requirements.txt
+    python -m pip install --upgrade pytest wheel twine
+    python -m pip install -r dev-requirements.txt
   displayName: 'Install dependencies'
 

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -1,22 +1,12 @@
 steps:
 
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: '$(python.version)'
-    architecture: 'x64'
-
-- script: |
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade pytest wheel
-  displayName: 'Install distribution tools for Python'
-
 - script: |
     python -m pip wheel . -w wheelhouse/
     ls -lh wheelhouse
   displayName: 'Build wheel'
 
 - script: |
-    python -m pip install boost_histogram[test] --no-index -f wheelhouse
+    python -m pip install boost_histogram --no-index -f wheelhouse
   displayName: 'Install wheel'
 
 - script: |

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -12,5 +12,6 @@ steps:
   displayName: 'Install wheel'
 
 - script: |
-    python -m pytest tests
+    python -m pytest
+  workingDirectory: tests
   displayName: 'Test with pytest'

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -14,6 +14,12 @@ steps:
   displayName: 'Install wheel'
 
 - script: |
-    python -m pytest
+    python -m pytest --junitxml=junit/test-results.xml
   workingDirectory: tests
   displayName: 'Test with pytest'
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: '**/test-*.xml'
+    testRunTitle: 'Publish test results for Python $(python.version)'
+  condition: succeededOrFailed()

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -5,6 +5,8 @@ steps:
   displayName: 'Build wheel'
 - script: |
     ls -lh wheelhouse
+    mkdir -p dist
+    cp wheelhouse/boost* dist/.
   displayName: 'Show wheelhouse'
 
 - script: |

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -2,8 +2,10 @@ steps:
 
 - script: |
     python -m pip wheel . -w wheelhouse/
-    ls -lh wheelhouse
   displayName: 'Build wheel'
+- script: |
+    ls -lh wheelhouse
+  displayName: 'Show wheelhouse'
 
 - script: |
     python -m pip install boost_histogram --no-index -f wheelhouse

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -7,12 +7,17 @@ steps:
 
 - script: |
     python -m pip install --upgrade pip
-    python -m pip install --upgrade pytest
-  displayName: 'Install dependencies'
+    python -m pip install --upgrade pytest wheel
+  displayName: 'Install distribution tools for Python'
 
 - script: |
-    python -m pip install --verbose -e .[test]
-  displayName: 'Build and install package'
+    python -m pip wheel . -w wheelhouse/
+    ls -lh wheelhouse
+  displayName: 'Build wheel'
+
+- script: |
+    python -m pip install boost_histogram[test] --no-index -f wheelhouse
+  displayName: 'Install wheel'
 
 - script: |
     python -m pytest tests

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -5,10 +5,6 @@ steps:
     versionSpec: '$(python.version)'
     architecture: 'x64'
 
-- checkout: self
-  fetchDepth: 50
-  submodules: true
-
 - script: |
     python -m pip install --upgrade pip
     python -m pip install --upgrade pytest

--- a/.ci/azure-submodules.yml
+++ b/.ci/azure-submodules.yml
@@ -1,0 +1,4 @@
+steps:
+- checkout: self
+  fetchDepth: 50
+  submodules: true

--- a/.ci/azure-upload.yml
+++ b/.ci/azure-upload.yml
@@ -1,5 +1,0 @@
-steps:
-
-- script: |
-    python -m twine upload wheelhouse/boost_histogram*.whl
-  displayName: 'Upload to PyPi'

--- a/.ci/azure-upload.yml
+++ b/.ci/azure-upload.yml
@@ -1,0 +1,5 @@
+steps:
+
+- script: |
+    python -m twine upload wheelhouse/boost_histogram*.whl
+  displayName: 'Upload to PyPi'

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -8,12 +8,12 @@ for PYBIN in /opt/python/*/bin; do
 done
 
 # Bundle external shared libraries into the wheels
-for whl in wheelhouse/*.whl; do
+for whl in wheelhouse/boost_histogram-*.whl; do
     auditwheel repair "$whl" -w /io/wheelhouse/
 done
 
 # Install packages and test
 for PYBIN in /opt/python/*/bin/; do
-    "${PYBIN}/pip" install python-manylinux-demo --no-index -f /io/wheelhouse
-    (cd "$HOME"; "${PYBIN}/python" -m pytest pymanylinuxdemo)
+    "${PYBIN}/pip" install boost_histogram --no-index -f /io/wheelhouse
+    (cd /io/tests && "${PYBIN}/python" -m pytest)
 done

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -17,7 +17,7 @@ done
 
 # Bundle external shared libraries into the wheels
 for whl in wheelhouse/boost_histogram-*.whl; do
-    auditwheel repair "$whl" -w /io/wheelhouse/
+    auditwheel repair --plat $PLAT "$whl" -w /io/wheelhouse/
 done
 
 # Install packages and test

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -22,6 +22,6 @@ done
 
 # Install packages and test
 for PYBIN in "${pys[@]}"; do
-    "${PYBIN}/pip" install boost_histogram --no-index -f /io/wheelhouse
-    (cd /io/tests && "${PYBIN}/python" -m pytest)
+    "${PYBIN}/python" -m pip install boost_histogram --no-index -f /io/wheelhouse
+    "${PYBIN}/pytest" /io/tests
 done

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e -x
 
+export NPY_NUM_BUILD_JOBS=4
+
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     "${PYBIN}/pip" install -r /io/dev-requirements.txt

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -3,8 +3,14 @@ set -e -x
 
 export NPY_NUM_BUILD_JOBS=4
 
+# Collect the pythons
+pys=(/opt/python/*/bin)
+
+# Filter out Python 3.4
+pys=(${pys[@]//*34*/})
+
 # Compile wheels
-for PYBIN in /opt/python/*/bin; do
+for PYBIN in "${pys[@]}"; do
     "${PYBIN}/pip" install -r /io/dev-requirements.txt
     "${PYBIN}/pip" wheel /io/ -w wheelhouse/
 done
@@ -15,7 +21,7 @@ for whl in wheelhouse/boost_histogram-*.whl; do
 done
 
 # Install packages and test
-for PYBIN in /opt/python/*/bin/; do
+for PYBIN in "${pys[@]}"; do
     "${PYBIN}/pip" install boost_histogram --no-index -f /io/wheelhouse
     (cd /io/tests && "${PYBIN}/python" -m pytest)
 done

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e -x
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    "${PYBIN}/pip" install -r /io/dev-requirements.txt
+    "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/
+done
+
+# Install packages and test
+for PYBIN in /opt/python/*/bin/; do
+    "${PYBIN}/pip" install python-manylinux-demo --no-index -f /io/wheelhouse
+    (cd "$HOME"; "${PYBIN}/python" -m pytest pymanylinuxdemo)
+done

--- a/.ci/macos-install-python.sh
+++ b/.ci/macos-install-python.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+PYTHON_VERSION="$1"
+
+case $PYTHON_VERSION in
+2.7)
+  FULL_VERSION=2.7.16
+  ;;
+3.6)
+  FULL_VERSION=3.6.8
+  ;;
+3.7)
+  FULL_VERSION=3.7.3
+  ;;
+esac
+
+INSTALLER_NAME=python-$FULL_VERSION-macosx10.9.pkg
+URL=https://www.python.org/ftp/python/$FULL_VERSION/$INSTALLER_NAME
+
+PY_PREFIX=/Library/Frameworks/Python.framework/Versions
+
+set -e -x
+
+curl $URL > $INSTALLER_NAME
+
+sudo installer -pkg $INSTALLER_NAME -target /
+
+sudo rm /usr/local/bin/python
+sudo ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
+
+which python
+python --version
+python -m ensurepip
+python -m pip install setuptools twine wheel numpy

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@
 *.env
 *.egg-info
 .ipynb_checkpoints
+/wheelhouse/*

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@
 *.egg-info
 .ipynb_checkpoints
 /wheelhouse/*
+/dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@
 *.app
 
 # Build directories
-*build*
+/*build*
 
 # Python binary files
 *.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,30 @@
+graft boost
+graft include
+graft scripts
+graft src
+graft tests
+
+graft extern/assert/include
+graft extern/callable_traits/include
+graft extern/config/include
+graft extern/container_hash/include
+graft extern/core/include
+graft extern/detail/include
+graft extern/histogram/include
+graft extern/integer/include
+graft extern/iterator/include
+graft extern/move/include
+graft extern/mp11/include
+graft extern/mpl/include
+graft extern/preprocessor/include
+graft extern/static_assert/include
+graft extern/throw_exception/include
+graft extern/type_index/include
+graft extern/type_traits/include
+graft extern/utility/include
+graft extern/variant/include
+
+graft extern/pybind11
+
+global-exclude .git*
+include CMakeLists.txt LICENSE README.md setup.py dev-requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,7 +24,14 @@ graft extern/type_traits/include
 graft extern/utility/include
 graft extern/variant/include
 
-graft extern/pybind11
+graft extern/pybind11/include
+graft extern/pybind11/tools
+include extern/pybind11/CMakeLists.txt
 
 global-exclude .git*
+global-exclude .pytest_cache
+global-exclude .DS_Store
+global-exclude *.py[co]
+global-exclude __pycache__
 include CMakeLists.txt LICENSE README.md setup.py dev-requirements.txt
+recursive-include extern LICENSE

--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ end
 
 </details>
 
+## Talks and other documentation/tutorial sources
+
+* [2019-4-15 IRIS-HEP Topical meeting](https://indico.cern.ch/event/803122/)
+
 [gitter-badge]: https://badges.gitter.im/HSF/PyHEP-histogramming.svg
 [gitter-link]:  https://gitter.im/HSF/PyHEP-histogramming?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
 [azure-badge]:  https://dev.azure.com/scikit-hep/boost-histogram/_apis/build/status/scikit-hep.boost-histogram?branchName=develop

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,12 +13,10 @@ jobs:
         docker run --rm -v `pwd`:/io skhep/manylinuxgcc-x86_64 /io/.ci/build-wheels.sh
         ls -lh wheelhouse/
       displayName: Build wheels
-    - template: .ci/azure-upload.yml
-    - script: |
-        python -m pip install twine
-        python setup.py sdist
-        python -m twine upload dist/*
-      displayName: Upload source
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: 'ManyLinux64'
+        targetPath: 'wheelhouse'
 
 - job: ManyLinux32
   pool:
@@ -29,7 +27,10 @@ jobs:
         docker run --rm -v `pwd`:/io skhep/manylinuxgcc-i686 /io/.ci/build-wheels.sh
         ls -lh wheelhouse/
       displayName: Build wheels
-    - template: .ci/azure-upload.yml
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: 'ManyLinux32'
+        targetPath: 'wheelhouse'
 
 - job: LinuxCMake
   strategy:
@@ -67,7 +68,10 @@ jobs:
     - template: .ci/azure-submodules.yml
     - template: .ci/azure-setup.yml
     - template: .ci/azure-steps.yml
-    - template: .ci/azure-upload.yml
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: 'macOS'
+        targetPath: 'dist'
 
 - job: Windows
   strategy:
@@ -86,4 +90,7 @@ jobs:
     - template: .ci/azure-submodules.yml
     - template: .ci/azure-setup.yml
     - template: .ci/azure-steps.yml
-    - template: .ci/azure-upload.yml
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: 'Windows64'
+        targetPath: 'dist'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,9 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
+  - checkout: self
+    fetchDepth: 50
+    submodules: true
   - script: |
       docker run --rm -v `pwd`:/io skhep/manylinuxgcc-x86_64 /io/.ci/build-wheels.sh
       PRECMD=linux32 docker run --rm -v `pwd`:/io skhep/manylinuxgcc-i686 /io/.ci/build-wheels.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ trigger:
 jobs:
 
 - job: LinuxSDist
-  # condition: contains(variables['Build.SourceBranch'], 'refs/tags/') 
+  condition: contains(variables['Build.SourceBranch'], 'refs/tags/') 
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
@@ -22,7 +22,7 @@ jobs:
     - template: .ci/azure-publish-dist.yml
 
 - job: ManyLinux
-  # condition: contains(variables['Build.SourceBranch'], 'refs/tags/')
+  condition: contains(variables['Build.SourceBranch'], 'refs/tags/')
   strategy:
     matrix:
       64Bit2010:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,10 @@ jobs:
         ls -lh wheelhouse/
       displayName: Build wheels
     - template: .ci/azure-upload.yml
+    - script: |
+        python setup.py sdist
+        python -m twine upload dist/*
+      displayName: Upload source
 
 - job: ManyLinux32
   pool:
@@ -56,6 +60,8 @@ jobs:
         python.architecture: 'x64'
   pool:
     vmImage: 'macOS-10.13'
+  variables:
+    MACOSX_DEPLOYMENT_TARGET: '10.9'
   steps:
     - template: .ci/azure-submodules.yml
     - template: .ci/azure-setup.yml
@@ -74,16 +80,15 @@ jobs:
       Python37:
         python.version: '3.7'
         python.architecture: 'x64'
-      Python27:
-        python.version: '2.7'
-        python.architecture: 'x64'
+      # This requires VS9, but that's too old
+      # Look up workaround
+      # Python27:
+      #  python.version: '2.7'
+      #   python.architecture: 'x64'
   pool:
     vmImage: 'vs2017-win2016'
   steps:
     - template: .ci/azure-submodules.yml
     - template: .ci/azure-setup.yml
     - template: .ci/azure-steps.yml
-    - script: |
-        python setup.py sdist
-        python -m twine upload dist/*
     - template: .ci/azure-upload.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,3 +46,13 @@ jobs:
     vmImage: 'ubuntu-16.04'
   steps:
     - template: .ci/azure-cmake-steps.yml
+
+- job: ManyLinux
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - script: |
+      docker run --rm -v `pwd`:/io -it skhep/manylinuxgcc-x86_64 /io/.ci/build-wheels.sh
+      PRECMD=linux32 docker run --rm -v `pwd`:/io -it skhep/manylinuxgcc-i686 /io/.ci/build-wheels.sh
+      ls wheelhouse/
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,13 +9,19 @@ trigger:
 
 jobs:
 
-- job: ManyLinux64
+- job: ManyLinux
+  strategy:
+    matrix:
+      ManyLinux64:
+        arch: x86_64
+      ManyLinux32:
+        arch: i686
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
     - template: .ci/azure-submodules.yml
     - script: |
-        docker run --rm -v `pwd`:/io skhep/manylinuxgcc-x86_64 /io/.ci/build-wheels.sh
+        docker run --rm -v `pwd`:/io skhep/manylinuxgcc-$(arch) /io/.ci/build-wheels.sh
         ls -lh wheelhouse/
         mkdir -p dist
         cp wheelhouse/boost*.whl dist/.
@@ -23,20 +29,6 @@ jobs:
     - script: |
         python -m pip install setuptools
         python setup.py sdist
-    - template: .ci/azure-publish-dist.yml
-
-
-- job: ManyLinux32
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-    - template: .ci/azure-submodules.yml
-    - script: |
-        docker run --rm -v `pwd`:/io skhep/manylinuxgcc-i686 /io/.ci/build-wheels.sh
-        ls -lh wheelhouse/
-        mkdir -p dist
-        cp wheelhouse/boost*.whl dist/.
-      displayName: Build wheels
     - template: .ci/azure-publish-dist.yml
 
 - job: LinuxCMake

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,13 +93,20 @@ jobs:
 - job: Windows
   strategy:
     matrix:
-      # Python 3.5 and below not supported due to old VS
       Python36:
         python.version: '3.6'
         python.architecture: 'x64'
       Python37:
         python.version: '3.7'
         python.architecture: 'x64'
+      Python36_32:
+        python.version: '3.6'
+        python.architecture: 'x86'
+      Python37_32:
+        python.version: '3.7'
+        python.architecture: 'x86'
+        
+
       # Python 2.7 requires VS9, but that's too old
   pool:
     vmImage: 'vs2017-win2016'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
     vmImage: 'ubuntu-16.04'
   steps:
   - script: |
-      docker run --rm -v `pwd`:/io -it skhep/manylinuxgcc-x86_64 /io/.ci/build-wheels.sh
-      PRECMD=linux32 docker run --rm -v `pwd`:/io -it skhep/manylinuxgcc-i686 /io/.ci/build-wheels.sh
-      ls wheelhouse/
+      docker run --rm -v `pwd`:/io skhep/manylinuxgcc-x86_64 /io/.ci/build-wheels.sh
+      PRECMD=linux32 docker run --rm -v `pwd`:/io skhep/manylinuxgcc-i686 /io/.ci/build-wheels.sh
+      ls -lh wheelhouse/
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,11 @@
 trigger:
-- master
-- develop
+  tags:
+    include:
+    - v*
+  branches:
+    include:
+    - master
+    - develop
 
 jobs:
 
@@ -12,21 +17,13 @@ jobs:
     - script: |
         docker run --rm -v `pwd`:/io skhep/manylinuxgcc-x86_64 /io/.ci/build-wheels.sh
         ls -lh wheelhouse/
+        mkdir -p dist
+        cp wheelhouse/boost*.whl dist/.
       displayName: Build wheels
-    - task: PublishPipelineArtifact@0
-      inputs:
-        artifactName: 'ManyLinux_64'
-        targetPath: 'wheelhouse'
     - script: |
         python -m pip install setuptools
         python setup.py sdist
-    - task: PublishPipelineArtifact@0
-      inputs:
-        artifactName: 'SDist'
-        targetPath: 'dist'
-    - task: TwineAuthenticate@0
-      inputs:
-          artifactFeeds: 'TestArtifacts'
+    - template: .ci/azure-publish-dist.yml
 
 
 - job: ManyLinux32
@@ -37,14 +34,10 @@ jobs:
     - script: |
         docker run --rm -v `pwd`:/io skhep/manylinuxgcc-i686 /io/.ci/build-wheels.sh
         ls -lh wheelhouse/
+        mkdir -p dist
+        cp wheelhouse/boost*.whl dist/.
       displayName: Build wheels
-    - task: PublishPipelineArtifact@0
-      inputs:
-        artifactName: 'ManyLinux_32'
-        targetPath: 'wheelhouse'
-    - task: TwineAuthenticate@0
-      inputs:
-          artifactFeeds: 'TestArtifacts'
+    - template: .ci/azure-publish-dist.yml
 
 - job: LinuxCMake
   strategy:
@@ -82,13 +75,7 @@ jobs:
         /Library/Frameworks/Python.framework/Versions/$(python.version)/bin/delocate-listdeps dist/boost*.whl
         /Library/Frameworks/Python.framework/Versions/$(python.version)/bin/delocate-wheel dist/boost*.whl
       displayName: 'Delocate wheels'
-    - task: PublishPipelineArtifact@0
-      inputs:
-        artifactName: 'macOS_$(python.version)'
-        targetPath: 'dist'
-    - task: TwineAuthenticate@0
-      inputs:
-          artifactFeeds: 'TestArtifacts'
+    - template: .ci/azure-publish-dist.yml
 
 - job: Windows
   strategy:
@@ -114,10 +101,4 @@ jobs:
     - template: .ci/azure-submodules.yml
     - template: .ci/azure-setup.yml
     - template: .ci/azure-steps.yml
-    - task: PublishPipelineArtifact@0
-      inputs:
-        artifactName: 'Windows_$(python.architecture)_$(python.version)'
-        targetPath: 'dist'
-    - task: TwineAuthenticate@0
-      inputs:
-          artifactFeeds: 'TestArtifacts'
+    - template: .ci/azure-publish-dist.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,7 @@ jobs:
       displayName: Build wheels
     - template: .ci/azure-upload.yml
     - script: |
+        python -m pip install twine
         python setup.py sdist
         python -m twine upload dist/*
       displayName: Upload source
@@ -78,11 +79,7 @@ jobs:
       Python37:
         python.version: '3.7'
         python.architecture: 'x64'
-      # This requires VS9, but that's too old
-      # Look up workaround
-      # Python27:
-      #  python.version: '2.7'
-      #   python.architecture: 'x64'
+      # Python 2.7 requires VS9, but that's too old
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,17 +3,39 @@ trigger:
 - develop
 
 jobs:
-- job: Linux
+
+- job: ManyLinux64
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - template: .ci/azure-submodules.yml
+    - script: |
+        docker run --rm -v `pwd`:/io skhep/manylinuxgcc-x86_64 /io/.ci/build-wheels.sh
+        ls -lh wheelhouse/
+      displayName: Build wheels
+
+- job: ManyLinux32
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - template: .ci/azure-submodules.yml
+    - script: |
+        docker run --rm -v `pwd`:/io skhep/manylinuxgcc-i686 /io/.ci/build-wheels.sh
+        ls -lh wheelhouse/
+      displayName: Build wheels
+
+- job: LinuxCMake
   strategy:
     matrix:
       Python27:
         python.version: '2.7'
-      Python36:
-        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-    - template: .ci/azure-steps.yml
+    - template: .ci/azure-submodules.yml
+    - template: .ci/azure-cmake-steps.yml
 
 - job: macOS
   strategy:
@@ -25,6 +47,7 @@ jobs:
   pool:
     vmImage: 'macOS-10.13'
   steps:
+    - template: .ci/azure-submodules.yml
     - template: .ci/azure-steps.yml
 
 - job: Windows
@@ -35,27 +58,6 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps:
+    - template: .ci/azure-submodules.yml
     - template: .ci/azure-steps.yml
-
-- job: Linux_CMake
-  strategy:
-    matrix:
-      Python37:
-        python.version: '3.7'
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-    - template: .ci/azure-cmake-steps.yml
-
-- job: ManyLinux
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - checkout: self
-    fetchDepth: 50
-    submodules: true
-  - script: |
-      docker run --rm -v `pwd`:/io skhep/manylinuxgcc-x86_64 /io/.ci/build-wheels.sh
-      PRECMD=linux32 docker run --rm -v `pwd`:/io skhep/manylinuxgcc-i686 /io/.ci/build-wheels.sh
-      ls -lh wheelhouse/
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,10 @@ jobs:
       inputs:
         artifactName: 'SDist'
         targetPath: 'dist'
+    - task: TwineAuthenticate@0
+      inputs:
+          artifactFeeds: 'TestArtifacts'
+
 
 - job: ManyLinux32
   pool:
@@ -37,6 +41,9 @@ jobs:
       inputs:
         artifactName: 'ManyLinux32'
         targetPath: 'wheelhouse'
+    - task: TwineAuthenticate@0
+      inputs:
+          artifactFeeds: 'TestArtifacts'
 
 - job: LinuxCMake
   strategy:
@@ -78,6 +85,9 @@ jobs:
       inputs:
         artifactName: 'macOS'
         targetPath: 'wheelhouse'
+    - task: TwineAuthenticate@0
+      inputs:
+          artifactFeeds: 'TestArtifacts'
 
 - job: Windows
   strategy:
@@ -100,3 +110,6 @@ jobs:
       inputs:
         artifactName: 'Windows64'
         targetPath: 'wheelhouse'
+    - task: TwineAuthenticate@0
+      inputs:
+          artifactFeeds: 'TestArtifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,9 +15,10 @@ jobs:
       displayName: Build wheels
     - task: PublishPipelineArtifact@0
       inputs:
-        artifactName: 'ManyLinux64'
+        artifactName: 'ManyLinux_64'
         targetPath: 'wheelhouse'
     - script: |
+        python -m pip install setuptools
         python setup.py sdist
     - task: PublishPipelineArtifact@0
       inputs:
@@ -39,7 +40,7 @@ jobs:
       displayName: Build wheels
     - task: PublishPipelineArtifact@0
       inputs:
-        artifactName: 'ManyLinux32'
+        artifactName: 'ManyLinux_32'
         targetPath: 'wheelhouse'
     - task: TwineAuthenticate@0
       inputs:
@@ -83,7 +84,7 @@ jobs:
     - template: .ci/azure-steps.yml
     - task: PublishPipelineArtifact@0
       inputs:
-        artifactName: 'macOS'
+        artifactName: 'macOS_$(python.version)'
         targetPath: 'wheelhouse'
     - task: TwineAuthenticate@0
       inputs:
@@ -108,7 +109,7 @@ jobs:
     - template: .ci/azure-steps.yml
     - task: PublishPipelineArtifact@0
       inputs:
-        artifactName: 'Windows64'
+        artifactName: 'Windows_$(python.architecture)_$(python.version)'
         targetPath: 'wheelhouse'
     - task: TwineAuthenticate@0
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
     - template: .ci/azure-publish-dist.yml
 
 - job: ManyLinux
-  condition: contains(variables['Build.SourceBranch'], 'refs/tags/')
+  condition: contains(variables['Build.SourceBranch'], 'refs/tags/') 
   strategy:
     matrix:
       64Bit2010:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,12 +29,15 @@ jobs:
     matrix:
       Python27:
         python.version: '2.7'
+        python.architecture: 'x64'
       Python37:
         python.version: '3.7'
+        python.architecture: 'x64'
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
     - template: .ci/azure-submodules.yml
+    - template: .ci/azure-setup.yml
     - template: .ci/azure-cmake-steps.yml
 
 - job: macOS
@@ -42,12 +45,15 @@ jobs:
     matrix:
       Python27:
         python.version: '2.7'
+        python.architecture: 'x64'
       Python37:
         python.version: '3.7'
+        python.architecture: 'x64'
   pool:
     vmImage: 'macOS-10.13'
   steps:
     - template: .ci/azure-submodules.yml
+    - template: .ci/azure-setup.yml
     - template: .ci/azure-steps.yml
 
 - job: Windows
@@ -55,9 +61,11 @@ jobs:
     matrix:
       Python37:
         python.version: '3.7'
+        python.architecture: 'x64'
   pool:
     vmImage: 'vs2017-win2016'
   steps:
     - template: .ci/azure-submodules.yml
+    - template: .ci/azure-setup.yml
     - template: .ci/azure-steps.yml
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,12 @@ jobs:
       inputs:
         artifactName: 'ManyLinux64'
         targetPath: 'wheelhouse'
+    - script: |
+        python setup.py sdist
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: 'SDist'
+        targetPath: 'dist'
 
 - job: ManyLinux32
   pool:
@@ -71,7 +77,7 @@ jobs:
     - task: PublishPipelineArtifact@0
       inputs:
         artifactName: 'macOS'
-        targetPath: 'dist'
+        targetPath: 'wheelhouse'
 
 - job: Windows
   strategy:
@@ -93,4 +99,4 @@ jobs:
     - task: PublishPipelineArtifact@0
       inputs:
         artifactName: 'Windows64'
-        targetPath: 'dist'
+        targetPath: 'wheelhouse'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,9 +71,7 @@ jobs:
 - job: Windows
   strategy:
     matrix:
-      Python35:
-        python.version: '3.5'
-        python.architecture: 'x64'
+      # Python 3.5 and below not supported due to old VS
       Python36:
         python.version: '3.6'
         python.architecture: 'x64'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,26 +9,44 @@ trigger:
 
 jobs:
 
-- job: ManyLinux
-  strategy:
-    matrix:
-      ManyLinux64:
-        arch: x86_64
-      ManyLinux32:
-        arch: i686
+- job: LinuxSDist
+  # condition: contains(variables['Build.SourceBranch'], 'refs/tags/') 
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
     - template: .ci/azure-submodules.yml
     - script: |
-        docker run --rm -v `pwd`:/io skhep/manylinuxgcc-$(arch) /io/.ci/build-wheels.sh
+        python -m pip install setuptools
+        python setup.py sdist
+      displayName: Publish sdist
+    - template: .ci/azure-publish-dist.yml
+
+- job: ManyLinux
+  # condition: contains(variables['Build.SourceBranch'], 'refs/tags/')
+  strategy:
+    matrix:
+      64Bit2010:
+        arch: x86_64
+        plat: manylinux2010_x86_64
+        image: quay.io/pypa/manylinux2010_x86_64
+      64Bit:
+        arch: x86_64
+        plat: manylinux1_x86_64
+        image: skhep/manylinuxgcc-x86_64
+      32Bit:
+        arch: i686
+        plat: manylinux1_i686
+        image: skhep/manylinuxgcc-i686
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - template: .ci/azure-submodules.yml
+    - script: |
+        docker run -e PLAT=$(plat) --rm -v `pwd`:/io $(image) /io/.ci/build-wheels.sh
         ls -lh wheelhouse/
         mkdir -p dist
         cp wheelhouse/boost*.whl dist/.
       displayName: Build wheels
-    - script: |
-        python -m pip install setuptools
-        python setup.py sdist
     - template: .ci/azure-publish-dist.yml
 
 - job: LinuxCMake
@@ -39,6 +57,9 @@ jobs:
         python.architecture: 'x64'
       Python37:
         python.version: '3.7'
+        python.architecture: 'x64'
+      Python35:
+        python.version: '3.5'
         python.architecture: 'x64'
   pool:
     vmImage: 'ubuntu-16.04'
@@ -84,8 +105,6 @@ jobs:
       Python37_32:
         python.version: '3.7'
         python.architecture: 'x86'
-        
-
       # Python 2.7 requires VS9, but that's too old
   pool:
     vmImage: 'vs2017-win2016'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,25 +67,25 @@ jobs:
     matrix:
       Python27:
         python.version: '2.7'
-        python.architecture: 'x64'
       Python36:
         python.version: '3.6'
-        python.architecture: 'x64'
       Python37:
         python.version: '3.7'
-        python.architecture: 'x64'
   pool:
-    vmImage: 'macOS-10.13'
-  variables:
-    MACOSX_DEPLOYMENT_TARGET: '10.9'
+    vmImage: 'macOS-10.14'
   steps:
     - template: .ci/azure-submodules.yml
-    - template: .ci/azure-setup.yml
+    - template: .ci/azure-macos-setup.yml
     - template: .ci/azure-steps.yml
+    - script: |
+        python -m pip install delocate
+        /Library/Frameworks/Python.framework/Versions/$(python.version)/bin/delocate-listdeps dist/boost*.whl
+        /Library/Frameworks/Python.framework/Versions/$(python.version)/bin/delocate-wheel dist/boost*.whl
+      displayName: 'Delocate wheels'
     - task: PublishPipelineArtifact@0
       inputs:
         artifactName: 'macOS_$(python.version)'
-        targetPath: 'wheelhouse'
+        targetPath: 'dist'
     - task: TwineAuthenticate@0
       inputs:
           artifactFeeds: 'TestArtifacts'
@@ -110,7 +110,7 @@ jobs:
     - task: PublishPipelineArtifact@0
       inputs:
         artifactName: 'Windows_$(python.architecture)_$(python.version)'
-        targetPath: 'wheelhouse'
+        targetPath: 'dist'
     - task: TwineAuthenticate@0
       inputs:
           artifactFeeds: 'TestArtifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ jobs:
         docker run --rm -v `pwd`:/io skhep/manylinuxgcc-x86_64 /io/.ci/build-wheels.sh
         ls -lh wheelhouse/
       displayName: Build wheels
+    - template: .ci/azure-upload.yml
 
 - job: ManyLinux32
   pool:
@@ -23,6 +24,7 @@ jobs:
         docker run --rm -v `pwd`:/io skhep/manylinuxgcc-i686 /io/.ci/build-wheels.sh
         ls -lh wheelhouse/
       displayName: Build wheels
+    - template: .ci/azure-upload.yml
 
 - job: LinuxCMake
   strategy:
@@ -46,6 +48,9 @@ jobs:
       Python27:
         python.version: '2.7'
         python.architecture: 'x64'
+      Python36:
+        python.version: '3.6'
+        python.architecture: 'x64'
       Python37:
         python.version: '3.7'
         python.architecture: 'x64'
@@ -55,12 +60,22 @@ jobs:
     - template: .ci/azure-submodules.yml
     - template: .ci/azure-setup.yml
     - template: .ci/azure-steps.yml
+    - template: .ci/azure-upload.yml
 
 - job: Windows
   strategy:
     matrix:
+      Python35:
+        python.version: '3.5'
+        python.architecture: 'x64'
+      Python36:
+        python.version: '3.6'
+        python.architecture: 'x64'
       Python37:
         python.version: '3.7'
+        python.architecture: 'x64'
+      Python27:
+        python.version: '2.7'
         python.architecture: 'x64'
   pool:
     vmImage: 'vs2017-win2016'
@@ -68,4 +83,7 @@ jobs:
     - template: .ci/azure-submodules.yml
     - template: .ci/azure-setup.yml
     - template: .ci/azure-steps.yml
-
+    - script: |
+        python setup.py sdist
+        python -m twine upload dist/*
+    - template: .ci/azure-upload.yml

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-benchmark
+numpy
+futures; python_version < "3"

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,15 @@ import sys
 import setuptools
 from setuptools import find_packages
 
+try:
+    import numpy as np
+
+    from numpy.distutils.ccompiler import CCompiler_compile
+    import distutils.ccompiler
+    distutils.ccompiler.CCompiler.compile = CCompiler_compile
+except ImportError:
+    print("Numpy not found, parallel compile not available")
+
 __version__ = '0.0.1'
 
 ext_modules = [

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,8 @@ import sys
 import setuptools
 from setuptools import find_packages
 
+# Use -j N or set the environment variable NPY_NUM_BUILD_JOBS
 try:
-    import numpy as np
-
     from numpy.distutils.ccompiler import CCompiler_compile
     import distutils.ccompiler
     distutils.ccompiler.CCompiler.compile = CCompiler_compile

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ class BuildExt(build_ext):
     }
 
     if sys.platform == 'darwin':
-        c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
+        c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.9']
 
     def build_extensions(self):
         ct = self.compiler.compiler_type

--- a/tests/test_axis_internal.py
+++ b/tests/test_axis_internal.py
@@ -52,7 +52,7 @@ def test_axis_growth():
     assert ax.size() == 10
     assert len(ax.centers()) == 10
     assert len(ax.edges()) == 11
-    assert ax.update(1.2) == (12,-3)
+    assert ax.update(1.21) == (12,-3)
     assert ax.size() == 13
     assert len(ax.edges()) == 14
     assert len(ax.centers()) == 13


### PR DESCRIPTION
SDists can now be created, and wheels are built. They are reasonably clean (but please don't have too much extra stuff in your directory when making them). Parallel building now supported if Numpy is installed. Fixed a test that could fail in rare cases, especially on 32-bit builds.

#### Azure makes:

| System | Arch | Python versions |
|---------|-----|------------------|
| ManyLinux1 (custom GCC 8.3) | 64 & 32-bit | 2.7, 3.5, 3.6, 3.7 |
| ManyLinux2010 | 64-bit | 2.7, 3.5, 3.6, 3.7 |
| macOS 10.9+ | 64-bit | 2.7, 3.6, 3.7 |
| Windows | 64 & 32-bit | 3.6, 3.7 |

#### Notes

* Linux: I'm not supporting 3.4 because I have to build the Numpy wheels to do so.
* manylinux1: Using a custom docker container with GCC 8.3; should work but can't be called directly other compiled extensions unless they do the same thing (think that's the main caveat). Supporting 32 bits because it's there.
* manylinux2010: support made possible by https://github.com/pypa/python-manylinux-demo/pull/19 . We'll need to keep an eye on the rollout https://github.com/pypa/manylinux/issues/179 , since this is all quite new, but so far seems to be working. I wouldn't be surprised if we are the first to do this on Azure.
* MacOS: Using the dedicated 64 bit 10.9+ Python.org builds. Not supporting 3.5 because those no longer provide binaries (could add a 32+64 fat 10.6+ that really was 10.9+, but not worth it, IMO)
* Windows:  older is hard to support for now due to MSVC, could be attempted later - PyBind11 is technically supposed to be able to do it.

- [x] Remove Python 3.4 building (we are making Numpy wheel because Numpy has dropped 3.4)
- [x] Fix macOS building to make 10.9+ wheels.
- [x] Add 32 bit Windows builds
- [x] Get the wheels pushed somewhere.
- [x] Only push wheels on releases
- [x] Publish test results to Azure