### PR TITLE
Change asarray to ignore flow bins, fix warnings from tests

### DIFF
--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -38,7 +38,7 @@ py::class_<bh::histogram<A, S>> register_histogram_by_type(py::module& m, const 
     .def(py::init<const A&, S>(), "axes"_a, "storage"_a=S())
 
     .def_buffer([](bh::histogram<A, S>& h) -> py::buffer_info
-        {return make_buffer(h, true);})
+        {return make_buffer(h, false);})
 
     .def("rank", &histogram_t::rank,
          "Number of axes (dimensions) of histogram" )

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -34,8 +34,9 @@ def test_1D_fill_int(hist_func):
 
     H =  np.array([0, 1, 2, 0, 0, 0, 0, 0, 0, 0])
 
-    assert_array_equal(np.asarray(hist)[1:-1], H)
+    assert_array_equal(np.asarray(hist), H)
     assert_array_equal(hist.view(flow=False), H)
+    assert_array_equal(hist.view(flow=True)[1:-1], H)
 
     assert hist.axis(0).size() == bins
     assert hist.axis(0).size(flow=True) == bins + 2
@@ -55,7 +56,8 @@ def test_2D_fill_int(hist_func):
 
     H = np.histogram2d(*vals, bins=bins, range=ranges)[0]
 
-    assert_array_equal(np.asarray(hist)[1:-1, 1:-1], H)
+    assert_array_equal(np.asarray(hist), H)
+    assert_array_equal(hist.view(flow=True)[1:-1, 1:-1], H)
     assert_array_equal(hist.view(flow=False), H)
 
     assert hist.axis(0).size() == bins[0]
@@ -75,7 +77,7 @@ def test_edges_histogram():
     hist(vals)
 
     bins = np.asarray(hist)
-    assert_array_equal(bins, [0,0,2,2,0])
+    assert_array_equal(bins, [0,2,2])
     assert_array_equal(hist.view(flow=True), [0,0,2,2,0])
     assert_array_equal(hist.view(flow=False), [0,2,2])
 
@@ -88,7 +90,8 @@ def test_int_histogram():
     hist(vals)
 
     bins = np.asarray(hist)
-    assert_array_equal(bins, [2,1,1,1,1,3])
+    assert_array_equal(bins, [1,1,1,1])
+    assert_array_equal(hist.view(flow=False), [1,1,1,1])
     assert_array_equal(hist.view(flow=True), [2,1,1,1,1,3])
 
 

--- a/tests/test_public_axis.py
+++ b/tests/test_public_axis.py
@@ -170,10 +170,10 @@ class TestRegular(Axis):
     def test_iter(self):
         v = np.array([1.0, 1.25, 1.5, 1.75, 2.0])
         a = regular_uoflow(4, 1.0, 2.0)
-        assert np.all(a.edges() == v)
+        assert_array_equal(a.edges(), v)
 
         c = (v[:-1] + v[1:])/2
-        assert np.all(a.centers() == approx(c))
+        assert_allclose(a.centers(), c)
 
     def test_index(self):
         a = regular_uoflow(4, 1.0, 2.0)
@@ -407,10 +407,10 @@ class TestVariable(Axis):
         v = np.array([-0.1, 0.2, 0.3])
         a = variable(v)
 
-        assert np.all(a.edges() == v)
+        assert_array_equal(a.edges(), v)
 
         c = (v[:-1] + v[1:])/2
-        assert np.all(a.centers() == approx(c))
+        assert_allclose(a.centers(), c)
 
     def test_index(self):
         a = variable([-0.1, 0.2, 0.3])
@@ -486,7 +486,7 @@ class TestInteger:
     def test_iter(self):
         v = np.array([-1, 0, 1, 2])
         a = integer_uoflow(-1, 3)
-        assert (a.bins() == v).all()
+        assert_array_equal(a.bins(), v)
 
     def test_index(self):
         a = integer_uoflow(-1, 3)

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -495,6 +495,9 @@ def test_numpy_conversion_4():
     assert b1.shape == ()
     assert np.sum(b1) == 0
 
+    # Compare sum methods
+    assert b.sum() == np.asarray(b).sum()
+
 @pytest.mark.skip(message="This require multiprecision storage")
 def test_numpy_conversion_5():
     a = histogram(integer_noflow(0, 3),


### PR DESCRIPTION
This makes `np.asarray(hist).sum() == hist.sum()`.