### PR TITLE
Rename `__call__` to fill, add kwarg handlers

### DIFF
--- a/include/boost/histogram/python/kwargs.hpp
+++ b/include/boost/histogram/python/kwargs.hpp
@@ -1,0 +1,51 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/python/pybind11.hpp>
+
+
+/// Get and remove a value from a keyword argument dict
+template<typename T>
+T required_arg(py::kwargs& kwargs, const char* name) {
+    if(kwargs.contains(name)) {
+        return py::cast<T>(kwargs.attr("pop")(name));
+    } else {
+        throw py::key_error(std::string(name) + " is required");
+    }
+}
+
+/// Get and remove a value from a keyword argument dict, or return a empty pointer
+template<typename T>
+std::unique_ptr<T> optional_arg(py::kwargs& kwargs, const char* name) {
+    if(kwargs.contains(name)) {
+        return std::make_unique<T>(py::cast<T>(kwargs.attr("pop")(name)));
+    } else {
+        return std::unique_ptr<T>();
+    }
+}
+
+/// Get and remove a value from a keyword argument dict with default
+template<typename T>
+T optional_arg(py::kwargs& kwargs, const char* name, T original_value) {
+    if(kwargs.contains(name)) {
+        return py::cast<T>(kwargs[name]);
+    } else {
+        return original_value;
+    }
+}
+
+/// Run this last; it will provide an error if other keyword are still present
+inline
+void finalize_args(const py::kwargs& kwargs) {
+    if(kwargs.size() > 0) {
+        std::stringstream out;
+        for(const auto& item : kwargs) {
+            out << " " << item.first;
+        }
+        throw py::key_error("Unidentfied keywords found:" + out.str());
+    }
+}

--- a/scripts/performance_report.py
+++ b/scripts/performance_report.py
@@ -73,35 +73,35 @@ base = print_timer(setup_1d,
 
 
 print_timer(setup_1d,
-    'hist = bh.hist.any_int([bh.axis.regular_uoflow(bins, *ranges)]); hist(vals)',
+    'hist = bh.hist.any_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.fill(vals)',
     name='Any', storage='int', fill='', flow='yes', base=base)
 
 print_timer(setup_1d,
-    'hist = bh.hist.any_int([bh.axis.regular_noflow(bins, *ranges)]); hist(vals)',
+    'hist = bh.hist.any_int([bh.axis.regular_noflow(bins, *ranges)]); hist.fill(vals)',
     name='Any', storage='int', fill='', flow='no', base=base)
 
 
 print_timer(setup_1d,
-    'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins, *ranges)]); hist(vals)',
+    'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.fill(vals)',
     name='Regular', storage='int', fill='', flow='yes', base=base)
 
 print_timer(setup_1d,
-    'hist = bh.hist.regular_noflow_int([bh.axis.regular_noflow(bins, *ranges)]); hist(vals)',
+    'hist = bh.hist.regular_noflow_int([bh.axis.regular_noflow(bins, *ranges)]); hist.fill(vals)',
     name='Regular', storage='int', fill='', flow='no', base=base)
 
 
 print_timer(setup_1d,
-    'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins, *ranges)]); hist(vals)',
+    'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.fill(vals)',
     name='Regular', storage='aint', fill='', flow='yes', base=base)
 
 for fill in counts:
     print_timer(setup_1d,
-        'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.atomic_fill({fill},vals)',
+        'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.fill(vals, atomic={fill})',
         name='Regular', storage='aint', fill=fill, flow='yes', base=base)
 
 for fill in counts:
     print_timer(setup_1d,
-        'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.threaded_fill({fill},vals)',
+        'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.fill(vals, threads={fill})',
         name='Regular', storage='int', fill=fill, flow='yes', base=base)
 
 
@@ -117,32 +117,32 @@ base = print_timer(setup_2d,
     name='Numpy', storage='uint64', fill='', flow='no')
 
 print_timer(setup_2d,
-    'hist = bh.hist.any_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist(*vals)',
+    'hist = bh.hist.any_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Any', storage='int', fill='', flow='yes', base=base)
 
 print_timer(setup_2d,
-    'hist = bh.hist.any_int([bh.axis.regular_noflow(bins[0], *ranges[0]), bh.axis.regular_noflow(bins[1], *ranges[1])]); hist(*vals)',
+    'hist = bh.hist.any_int([bh.axis.regular_noflow(bins[0], *ranges[0]), bh.axis.regular_noflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Any', storage='int', fill='', flow='no', base=base)
 
 print_timer(setup_2d,
-    'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist(*vals)',
+    'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Regular', storage='int', fill='', flow='yes', base=base)
 
 print_timer(setup_2d,
-    'hist = bh.hist.regular_noflow_int([bh.axis.regular_noflow(bins[0], *ranges[0]), bh.axis.regular_noflow(bins[1], *ranges[1])]); hist(*vals)',
+    'hist = bh.hist.regular_noflow_int([bh.axis.regular_noflow(bins[0], *ranges[0]), bh.axis.regular_noflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Regular', storage='int', fill='', flow='no', base=base)
 
 
 print_timer(setup_2d,
-    'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist(*vals)',
+    'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Regular', storage='aint', fill='', flow='yes', base=base)
 
 for fill in counts:
     print_timer(setup_2d,
-        'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.atomic_fill({fill}, *vals)',
+        'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals, atomic={fill})',
         name='Regular', storage='aint', fill=fill, flow='yes', base=base)
 
 for fill in counts:
     print_timer(setup_2d,
-        'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.threaded_fill({fill}, *vals)',
+        'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals, threads={fill})',
         name='Regular', storage='int', fill=fill, flow='yes', base=base)

--- a/tests/test_atomic_fill.py
+++ b/tests/test_atomic_fill.py
@@ -15,8 +15,8 @@ def test_make_regular_1D():
 
     vals = np.random.rand(10000)
 
-    hist_linear(vals)
-    hist_atomic(vals)
+    hist_linear.fill(vals)
+    hist_atomic.fill(vals)
 
     assert_array_equal(hist_linear, hist_atomic)
 
@@ -27,11 +27,11 @@ def test_atomic_fill_1D():
 
     vals = np.random.rand(10000)
 
-    hist_linear(vals)
+    hist_linear.fill(vals)
 
     with ThreadPoolExecutor(4) as pool:
         for i in range(4):
-            pool.submit(hist_atomic, vals[i*2500:(i+1)*2500])
+            pool.submit(hist_atomic.fill, vals[i*2500:(i+1)*2500])
 
     assert_array_equal(hist_linear, hist_atomic)
 
@@ -44,8 +44,8 @@ def test_atomic_builtin(threads):
 
     vals = np.random.rand(10000)
 
-    hist_atomic1(vals)
-    hist_atomic2.atomic_fill(threads, vals)
+    hist_atomic1.fill(vals)
+    hist_atomic2.fill(vals, atomic=threads)
 
     assert_array_equal(hist_atomic1, hist_atomic2)
 
@@ -57,7 +57,7 @@ def test_threaded_builtin(threads):
 
     vals = np.random.rand(10000)
 
-    hist_atomic1(vals)
-    hist_atomic2.threaded_fill(threads, vals)
+    hist_atomic1.fill(vals)
+    hist_atomic2.fill(vals, threads=threads)
 
     assert_array_equal(hist_atomic1, hist_atomic2)

--- a/tests/test_benchmark_1d.py
+++ b/tests/test_benchmark_1d.py
@@ -25,11 +25,11 @@ def test_numpy_perf_1d(benchmark):
 def make_and_run_hist(hist, axes, vals, fill):
     histo = hist(axes)
     if fill is None:
-        histo(vals)
+        histo.fill(vals)
     elif fill < 0:
-        histo.atomic_fill(-fill, vals)
+        histo.fill(vals, atomic=-fill)
     else:
-        histo.threaded_fill(fill, vals)
+        histo.fill(vals, threads=fill)
 
     return histo.view()
 

--- a/tests/test_benchmark_2d.py
+++ b/tests/test_benchmark_2d.py
@@ -25,12 +25,13 @@ def test_numpy_perf_2d(benchmark):
 
 def make_and_run_hist(hist, axes, vals, fill):
     histo = hist(axes)
+
     if fill is None:
-        histo(*vals)
+        histo.fill(*vals)
     elif fill < 0:
-        histo.atomic_fill(-fill, *vals)
+        histo.fill(*vals, atomic=-fill)
     else:
-        histo.threaded_fill(fill, *vals)
+        histo.fill(*vals, threads=fill)
 
     return histo.view()
 

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -12,7 +12,7 @@ def test_1D_fill_unlimited():
     hist = bh.hist.regular_unlimited([
         bh.axis.regular_uoflow(bins, *ranges)
         ])
-    hist(vals)
+    hist.fill(vals)
 
 
 methods = [
@@ -30,7 +30,7 @@ def test_1D_fill_int(hist_func):
     hist = hist_func([
         bh.axis.regular_uoflow(bins, *ranges)
         ])
-    hist(vals)
+    hist.fill(vals)
 
     H =  np.array([0, 1, 2, 0, 0, 0, 0, 0, 0, 0])
 
@@ -52,7 +52,7 @@ def test_2D_fill_int(hist_func):
         bh.axis.regular_uoflow(bins[0], *ranges[0]),
         bh.axis.regular_uoflow(bins[1], *ranges[1]),
         ])
-    hist(*vals)
+    hist.fill(*vals)
 
     H = np.histogram2d(*vals, bins=bins, range=ranges)[0]
 
@@ -74,7 +74,7 @@ def test_edges_histogram():
         ])
 
     vals = (13,15,24,29)
-    hist(vals)
+    hist.fill(vals)
 
     bins = np.asarray(hist)
     assert_array_equal(bins, [0,2,2])
@@ -87,7 +87,7 @@ def test_int_histogram():
         ])
 
     vals = (1,2,3,4,5,6,7,8,9)
-    hist(vals)
+    hist.fill(vals)
 
     bins = np.asarray(hist)
     assert_array_equal(bins, [1,1,1,1])
@@ -108,7 +108,7 @@ def test_growing_histogram():
         bh.axis.regular_growth(10,0,1)
         ])
 
-    hist(1.45)
+    hist.fill(1.45)
 
     assert hist.size() == 15
 
@@ -119,7 +119,7 @@ def test_numpy_flow():
         for j in range(5):
             x,y = h.axis(0).bin(i).center(), h.axis(1).bin(j).center()
             v = i + j*10 + 1;
-            h([x]*v,[y]*v)
+            h.fill([x]*v,[y]*v)
 
     flow_true = h.to_numpy(True)[0][1:-1, 1:-1]
     flow_false = h.to_numpy(False)[0]
@@ -147,7 +147,7 @@ def test_numpy_compare():
             xs += [x]*v
             ys += [y]*v
 
-    h(xs, ys)
+    h.fill(xs, ys)
 
     H, E1, E2 = h.to_numpy()
 
@@ -163,9 +163,9 @@ def test_project():
     h1 = bh.hist.regular_int([bh.axis.regular_uoflow(5,0,1)])
 
     for x,y in ((.3,.3),(.7,.7),(.5,.6),(.23,.92),(.15,.32),(.43,.54)):
-        h(x,y)
-        h0(x)
-        h1(y)
+        h.fill(x,y)
+        h0.fill(x)
+        h1.fill(y)
 
     assert h.project(0, 1) == h
     assert h.project(0) == h0
@@ -177,7 +177,7 @@ def test_project():
 
 def test_sums():
     h = bh.histogram(bh.axis.regular_uoflow(4,0,1))
-    h([.1,.2,.3,10])
+    h.fill([.1,.2,.3,10])
 
     assert h.sum() == 3
     assert h.sum(flow=True) == 4
@@ -185,10 +185,10 @@ def test_sums():
 def test_int_cat_hist():
     h = bh.hist.any_int([bh.axis.category_int([1,2,3])])
 
-    h(1)
-    h(2)
-    h(2.2)
-    h(3)
+    h.fill(1)
+    h.fill(2)
+    h.fill(2.2)
+    h.fill(3)
 
     assert_array_equal(h.view(), [1,2,1])
     assert h.sum() == 4

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -70,11 +70,11 @@ def test_fill_int_1d():
     assert isinstance(h, histogram)
 
     with pytest.raises(ValueError):
-        h()
+        h.fill()
     with pytest.raises(ValueError):
-        h(1, 2)
+        h.fill(1, 2)
     for x in (-10, -1, -1, 0, 1, 1, 1, 10):
-        h(x)
+        h.fill(x)
     assert h.sum() == 6
     assert h.sum(flow=True) == 8
     assert h.axis(0).size(flow=True) == 5
@@ -103,11 +103,11 @@ def test_fill_int_1d():
 def test_fill_1d(flow):
     h = histogram(regular_uoflow(3, -1, 2) if flow else regular_noflow(3, -1, 2))
     with pytest.raises(ValueError):
-        h()
+        h.fill()
     with pytest.raises(ValueError):
-        h(1, 2)
+        h.fill(1, 2)
     for x in (-10, -1, -1, 0, 1, 1, 1, 10):
-        h(x)
+        h.fill(x)
 
     assert h.sum() == 6
     assert h.sum(flow=True) == 6 + 2*flow
@@ -135,14 +135,14 @@ def test_fill_1d(flow):
 
 def test_growth():
     h = histogram(integer_uoflow(-1, 2))
-    h(-1)
-    h(1)
-    h(1)
+    h.fill(-1)
+    h.fill(1)
+    h.fill(1)
     for i in range(255):
-        h(0)
-    h(0)
+        h.fill(0)
+    h.fill(0)
     for i in range(1000 - 256):
-        h(0)
+        h.fill(0)
     assert h.at(-1) == 0
     assert h.at(0) == 1
     assert h.at(1) == 1000
@@ -154,18 +154,18 @@ def test_growth():
 def test_fill_2d(flow):
     h = histogram((integer_uoflow if flow else integer_noflow)(-1, 2),
                   (regular_uoflow if flow else regular_noflow)(4, -2, 2))
-    h(-1, -2)
-    h(-1, -1)
-    h(0, 0)
-    h(0, 1)
-    h(1, 0)
-    h(3, -1)
-    h(0, -3)
+    h.fill(-1, -2)
+    h.fill(-1, -1)
+    h.fill(0, 0)
+    h.fill(0, 1)
+    h.fill(1, 0)
+    h.fill(3, -1)
+    h.fill(0, -3)
 
     with pytest.raises(Exception):
-        h(1)
+        h.fill(1)
     with pytest.raises(Exception):
-        h(1, 2, 3)
+        h.fill(1, 2, 3)
 
     m = [[1, 1, 0, 0, 0, 0],
          [0, 0, 1, 1, 0, 1],
@@ -186,13 +186,13 @@ def test_add_2d(flow):
                   (regular_uoflow if flow else regular_noflow)(4, -2, 2))
     assert isinstance(h, histogram)
 
-    h(-1, -2)
-    h(-1, -1)
-    h(0, 0)
-    h(0, 1)
-    h(1, 0)
-    h(3, -1)
-    h(0, -3)
+    h.fill(-1, -2)
+    h.fill(-1, -1)
+    h.fill(0, 0)
+    h.fill(0, 1)
+    h.fill(1, 0)
+    h.fill(3, -1)
+    h.fill(0, -3)
 
     m = [[1, 1, 0, 0, 0, 0],
          [0, 0, 1, 1, 0, 1],
@@ -220,13 +220,13 @@ def test_add_2d_bad():
 def test_add_2d_w(flow):
     h = histogram((integer_uoflow if flow else integer_noflow)(-1, 2),
                   (regular_uoflow if flow else regular_noflow)(4, -2, 2))
-    h(-1, -2)
-    h(-1, -1)
-    h(0, 0)
-    h(0, 1)
-    h(1, 0)
-    h(3, -1)
-    h(0, -3)
+    h.fill(-1, -2)
+    h.fill(-1, -1)
+    h.fill(0, 0)
+    h.fill(0, 1)
+    h.fill(1, 0)
+    h.fill(3, -1)
+    h.fill(0, -3)
 
     m = [[1, 1, 0, 0, 0, 0],
          [0, 0, 1, 1, 0, 1],
@@ -275,8 +275,8 @@ def test_overflow():
 
 def test_out_of_range():
     h = histogram(regular_uoflow(3, 0, 1))
-    h(-1)
-    h(2)
+    h.fill(-1)
+    h.fill(2)
     assert h.at(-1) == 1
     assert h.at(3) == 1
     with pytest.raises(IndexError):
@@ -291,7 +291,7 @@ def test_out_of_range():
 # CLASSIC: This used to have variance
 def test_operators():
     h = histogram(integer_uoflow(0, 2))
-    h(0)
+    h.fill(0)
     h += h
     assert h.at(0) == 2
     assert h.at(1) == 0
@@ -308,9 +308,9 @@ def test_operators():
 @pytest.mark.skip(message="Reductions not yet supported")
 def test_reduce_to(self):
     h = histogram(integer_uoflow(0, 2), integer_uoflow(1, 4))
-    h(0, 1)
-    h(0, 2)
-    h(1, 3)
+    h.fill(0, 1)
+    h.fill(0, 2)
+    h.fill(1, 3)
 
     h0 = h.reduce_to(0)
     assert h0.rank() == 1
@@ -337,15 +337,15 @@ def test_pickle_0():
                   variable([0.0, 1.0, 2.0]),
                   circular(4, 2*np.pi))
     for i in range(a.axis(0).size(flow=True)):
-        a(i, 0, 0, 0, 0)
+        a.fill(i, 0, 0, 0, 0)
         for j in range(a.axis(1).size(flow=True)):
-            a(i, j, 0, 0, 0)
+            a.fill(i, j, 0, 0, 0)
             for k in range(a.axis(2).size(flow=True)):
-                a(i, j, k, 0, 0)
+                a.fill(i, j, k, 0, 0)
                 for l in range(a.axis(3).size(flow=True)):
-                    a(i, j, k, l, 0)
+                    a.fill(i, j, k, l, 0)
                     for m in range(a.axis(4).size(flow=True)):
-                        a(i, j, k, l, m * 0.5 * np.pi)
+                        a.fill(i, j, k, l, m * 0.5 * np.pi)
 
     io = pickle.dumps(a,-1)
     b = pickle.loads(io)
@@ -370,13 +370,13 @@ def test_pickle_1():
     assert isinstance(a, histogram)
 
     for i in range(a.axis(0).size(flow=True)):
-        a(i, 0, 0, 0, weight=3)
+        a.fill(i, 0, 0, 0, weight=3)
         for j in range(a.axis(1).size(flow=True)):
-            a(i, j, 0, 0, weight=10)
+            a.fill(i, j, 0, 0, weight=10)
             for k in range(a.axis(2).size(flow=True)):
-                a(i, j, k, 0, weight=2)
+                a.fill(i, j, k, 0, weight=2)
                 for l in range(a.axis(3).size(flow=True)):
-                    a(i, j, k, l, weight=5)
+                    a.fill(i, j, k, l, weight=5)
 
     io = BytesIO()
     pickle.dump(a, io)
@@ -396,9 +396,9 @@ def test_pickle_1():
 
 def test_numpy_conversion_0():
     a = histogram(integer_noflow(0, 3))
-    a(0)
+    a.fill(0)
     for i in range(5):
-        a(1)
+        a.fill(1)
     c = np.array(a)  # a copy
     v = np.asarray(a)  # a view
 
@@ -407,13 +407,13 @@ def test_numpy_conversion_0():
         assert_array_equal(t, (1, 5, 0))
 
     for i in range(10):
-        a(2)
+        a.fill(2)
     # copy does not change, but view does
     assert_array_equal(c, (1, 5, 0))
     assert_array_equal(v, (1, 5, 10))
 
     for i in range(255):
-        a(1)
+        a.fill(1)
     c = np.array(a)
 
     assert c.dtype == np.uint64 # CLASSIC: np.uint16
@@ -425,7 +425,7 @@ def test_numpy_conversion_0():
 def test_numpy_conversion_1():
     a = histogram(integer_uoflow(0, 3))
     for i in range(10):
-        a(1, weight=3)
+        a.fill(1, weight=3)
     c = np.array(a)  # a copy
     v = np.asarray(a)  # a view
     assert c.dtype == np.float64
@@ -441,7 +441,7 @@ def test_numpy_conversion_2():
         for j in range(a.axis(1).size(flow=True)):
             for k in range(a.axis(2).size(flow=True)):
                 for m in range(i + j + k):
-                    a(i, j, k)
+                    a.fill(i, j, k)
                 r[i, j, k] = i + j + k
 
     d = np.zeros((2, 3, 4), dtype=np.int8)
@@ -467,7 +467,7 @@ def test_numpy_conversion_3():
     for i in range(a.axis(0).size(flow=True)):
         for j in range(a.axis(1).size(flow=True)):
             for k in range(a.axis(2).size(flow=True)):
-                a(i, j, k, weight=i + j + k)
+                a.fill(i, j, k, weight=i + j + k)
                 r[0, i, j, k] = i + j + k
                 r[1, i, j, k] = (i + j + k)**2
     c = np.array(a)  # a copy
@@ -502,19 +502,19 @@ def test_numpy_conversion_4():
 def test_numpy_conversion_5():
     a = histogram(integer_noflow(0, 3),
                   integer_noflow(0, 2))
-    a(0, 0)
+    a.fill(0, 0)
     for i in range(80):
         a = a + a
     # a now holds a multiprecision type
-    a(1, 0)
+    a.fill(1, 0)
     for i in range(2):
-        a(2, 0)
+        a.fill(2, 0)
     for i in range(3):
-        a(0, 1)
+        a.fill(0, 1)
     for i in range(4):
-        a(1, 1)
+        a.fill(1, 1)
     for i in range(5):
-        a(2, 1)
+        a.fill(2, 1)
     a1 = np.asarray(a)
     assert a1.shape == (3, 2)
     assert a1[0, 0] == float(2 ** 80)
@@ -545,27 +545,27 @@ def test_fill_with_numpy_array_0():
     def ar(*args):
         return np.array(args, dtype=float)
     a = histogram(integer_noflow(0, 3))
-    a(ar(-1, 0, 1, 2, 1))
-    a((4, -1, 0, 1, 2))
+    a.fill(ar(-1, 0, 1, 2, 1))
+    a.fill((4, -1, 0, 1, 2))
     assert a.at(0) == 2
     assert a.at(1) == 3
     assert a.at(2) == 2
 
     with pytest.raises(ValueError):
-        a(np.empty((2, 2)))
+        a.fill(np.empty((2, 2)))
     with pytest.raises(ValueError):
-        a(np.empty(2), 1)
+        a.fill(np.empty(2), 1)
     with pytest.raises(ValueError):
-        a(np.empty(2), np.empty(3))
+        a.fill(np.empty(2), np.empty(3))
     with pytest.raises(ValueError):
-        a("abc")
+        a.fill("abc")
 
     with pytest.raises(ValueError):
         a.at(1, 2)
 
     a = histogram(integer_noflow(0, 2),
                   regular_noflow(2, 0, 2))
-    a(ar(-1, 0, 1), ar(-1., 1., 0.1))
+    a.fill(ar(-1, 0, 1), ar(-1., 1., 0.1))
     assert a.at(0, 0) == 0
     assert a.at(0, 1) == 1
     assert a.at(1, 0) == 1
@@ -573,16 +573,16 @@ def test_fill_with_numpy_array_0():
     # we don't support: assert a.at([1, 1]).value, 0
 
     with pytest.raises(ValueError):
-        a(1)
+        a.fill(1)
     with pytest.raises(ValueError):
-        a([1, 0], [1])
+        a.fill([1, 0], [1])
     with pytest.raises(ValueError):
         a.at(1)
     with pytest.raises(ValueError):
         a.at(1, 2, 3)
 
     a = histogram(integer_noflow(0, 3))
-    a(ar(0, 0, 1, 2, 1, 0, 2, 2))
+    a.fill(ar(0, 0, 1, 2, 1, 0, 2, 2))
     assert a.at(0) == 3
     assert a.at(1) == 2
     assert a.at(2) == 3
@@ -594,8 +594,8 @@ def test_fill_with_numpy_array_1():
     a = histogram(integer_uoflow(0, 3))
     v = ar(-1, 0, 1, 2, 3, 4)
     w = ar( 2, 3, 4, 5, 6, 7)  # noqa
-    a(v, weight=w)
-    a((0, 1), weight=(2, 3))
+    a.fill(v, weight=w)
+    a.fill((0, 1), weight=(2, 3))
     assert a.at(-1) == 2
     assert a.at(0) == 5
     assert a.at(1) == 7
@@ -605,33 +605,33 @@ def test_fill_with_numpy_array_1():
     # assert a.at(1).variance == 25
     # assert a.at(2).variance == 25
 
-    a((1, 2), weight=1)
-    a(0, weight=(1, 2))
+    a.fill((1, 2), weight=1)
+    a.fill(0, weight=(1, 2))
     assert a.at(0) == 8
     assert a.at(1) == 8
     assert a.at(2) == 6
 
     with pytest.raises(ValueError):
-        a((1, 2), foo=(1, 1))
+        a.fill((1, 2), foo=(1, 1))
     with pytest.raises(ValueError):
-        a((1, 2), weight=(1,))
+        a.fill((1, 2), weight=(1,))
     with pytest.raises(ValueError):
-        a((1, 2), weight="ab")
+        a.fill((1, 2), weight="ab")
     with pytest.raises(ValueError):
-        a((1, 2), weight=(1, 1), foo=1)
+        a.fill((1, 2), weight=(1, 1), foo=1)
     with pytest.raises(ValueError):
-        a((1, 2), weight=([1, 1], [2, 2]))
+        a.fill((1, 2), weight=([1, 1], [2, 2]))
 
     a = histogram(integer_noflow(0, 2),
                   regular_noflow(2, 0, 2))
-    a((-1, 0, 1), (-1, 1, 0.1))
+    a.fill((-1, 0, 1), (-1, 1, 0.1))
     assert a.at(0, 0) == 0
     assert a.at(0, 1) == 1
     assert a.at(1, 0) == 1
     assert a.at(1, 1) == 0
     a = histogram(integer_noflow(0, 3))
-    a((0, 0, 1, 2))
-    a((1, 0, 2, 2))
+    a.fill((0, 0, 1, 2))
+    a.fill((1, 0, 2, 2))
     assert a.at(0) == 3
     assert a.at(1) == 2
     assert a.at(2) == 3


### PR DESCRIPTION
This is more clever in handing kwargs, so that fill(, **kwarg) can be supported. Signatures will still need to be carefully done by hand.

This renames `__call__` to fill. A simpler `__call__` could be added eventually which mimics C++, but probably not at the cost of compile time.