### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,101 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+#  SplitEmptyFunctionBody: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+# ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+...
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,13 @@ trigger:
 
 jobs:
 
+- job: ClangFormat
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - script: scripts/check_style_docker.sh
+      displayName: Check format
+
 - job: LinuxSDist
   condition: contains(variables['Build.SourceBranch'], 'refs/tags/') 
   pool:

--- a/examples/guide_mixed_cpp_python.cpp
+++ b/examples/guide_mixed_cpp_python.cpp
@@ -7,9 +7,10 @@ namespace bh = boost::histogram;
 namespace bp = boost::python;
 
 // function that runs in C++ and accepts reference to dynamic histogram
-void process(bh::histogram<>& h) {
-  // fill histogram, in reality this would be arbitrarily complex code
-  for (int i = 0; i < 4; ++i) h(0.25 * i, i);
+void process(bh::histogram<> &h) {
+    // fill histogram, in reality this would be arbitrarily complex code
+    for(int i = 0; i < 4; ++i)
+        h(0.25 * i, i);
 }
 
 // a minimal Python module, which exposes the process function to Python

--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -12,29 +12,29 @@
 #include <tuple>
 #include <vector>
 
-
 /// Register bh::axis::variant as a variant for PyBind11
-namespace pybind11 { namespace detail {
-    template <typename... Ts>
-    struct type_caster<bh::axis::variant<Ts...>> : variant_caster<bh::axis::variant<Ts...>> {};
-}} // namespace pybind11::detail
-
+namespace pybind11 {
+namespace detail {
+template <typename... Ts>
+struct type_caster<bh::axis::variant<Ts...>> : variant_caster<bh::axis::variant<Ts...>> {};
+} // namespace detail
+} // namespace pybind11
 
 /// Utility to convert an axis to edges array
-template<typename A>
-py::array_t<double> axis_to_edges(const A& ax, bool flow) {
-    unsigned overflow = flow && (bh::axis::traits::options(ax) & bh::axis::option::underflow);
+template <typename A>
+py::array_t<double> axis_to_edges(const A &ax, bool flow) {
+    unsigned overflow  = flow && (bh::axis::traits::options(ax) & bh::axis::option::underflow);
     unsigned underflow = flow && (bh::axis::traits::options(ax) & bh::axis::option::overflow);
 
-    py::array_t<double> edges((unsigned) ax.size() + 1u + overflow + underflow);
+    py::array_t<double> edges((unsigned)ax.size() + 1u + overflow + underflow);
 
     if(underflow)
         edges.mutable_at(0u) = ax.bin(-1).lower();
 
     edges.mutable_at(0u + underflow) = ax.bin(0).lower();
 
-    std::transform(ax.begin(), ax.end(), edges.mutable_data() + 1u + underflow,
-                   [](const auto& bin){return bin.upper();});
+    std::transform(
+        ax.begin(), ax.end(), edges.mutable_data() + 1u + underflow, [](const auto &bin) { return bin.upper(); });
 
     if(overflow)
         edges.mutable_at(edges.size() - 1) = ax.bin(ax.size()).upper();
@@ -42,30 +42,28 @@ py::array_t<double> axis_to_edges(const A& ax, bool flow) {
     return edges;
 }
 
-template<typename A>
-decltype(auto) axis_to_bins(const A& self, bool flow) {
+template <typename A>
+decltype(auto) axis_to_bins(const A &self, bool flow) {
     std::vector<bh::detail::remove_cvref_t<decltype(self.bin(0))>> out;
-    bool overflow = flow && (bh::axis::traits::options(self) & bh::axis::option::underflow);
+    bool overflow  = flow && (bh::axis::traits::options(self) & bh::axis::option::underflow);
     bool underflow = flow && (bh::axis::traits::options(self) & bh::axis::option::overflow);
 
-    out.reserve((size_t) bh::axis::traits::extent(self));
+    out.reserve((size_t)bh::axis::traits::extent(self));
 
-    for(int i = 0 - underflow ; i<self.size() + overflow; i++)
+    for(int i = 0 - underflow; i < self.size() + overflow; i++)
         out.emplace_back(self.bin(i));
 
     return out;
 }
 
-inline bool PyObject_Check(void* value) {
-    return value != nullptr;
-}
+inline bool PyObject_Check(void *value) { return value != nullptr; }
 
 #if PY_MAJOR_VERSION < 3
 
-extern PyThreadState * _PyThreadState_Current;
+extern PyThreadState *_PyThreadState_Current;
 
 inline int PyGILState_Check(void) {
-    PyThreadState * tstate = _PyThreadState_Current;
+    PyThreadState *tstate = _PyThreadState_Current;
     return tstate && (tstate == PyGILState_GetThisThreadState());
 }
 #endif
@@ -73,7 +71,7 @@ inline int PyGILState_Check(void) {
 class metadata_t : public py::object {
     PYBIND11_OBJECT_DEFAULT(metadata_t, object, PyObject_Check);
 
-    bool operator==(const metadata_t& other) const {
+    bool operator==(const metadata_t &other) const {
         if(PyGILState_Check()) {
             return py::cast<bool>(this->attr("__eq__")(other));
         } else {
@@ -81,7 +79,7 @@ class metadata_t : public py::object {
             return py::cast<bool>(this->attr("__eq__")(other));
         }
     }
-    bool operator!=(const metadata_t& other) const {
+    bool operator!=(const metadata_t &other) const {
         if(PyGILState_Check()) {
             return py::cast<bool>(this->attr("__ne__")(other));
         } else {
@@ -91,24 +89,23 @@ class metadata_t : public py::object {
     }
 };
 
-
 namespace axis {
 
 // These match the Python names
-using regular_uoflow = bh::axis::regular<double, bh::use_default, metadata_t>;
-using regular_noflow = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::none_t>;
-using regular_growth = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::growth_t>;
-using circular = bh::axis::circular<double, metadata_t>;
-using regular_log = bh::axis::regular<double, bh::axis::transform::log, metadata_t>;
-using regular_sqrt = bh::axis::regular<double, bh::axis::transform::sqrt, metadata_t>;
-using regular_pow = bh::axis::regular<double, bh::axis::transform::pow, metadata_t>;
-using variable = bh::axis::variable<double, metadata_t>;
-using integer_uoflow = bh::axis::integer<int, metadata_t>;
-using integer_noflow = bh::axis::integer<int, metadata_t, bh::axis::option::none_t>;
-using integer_growth = bh::axis::integer<int, metadata_t, bh::axis::option::growth_t>;
-using category_int = bh::axis::category<int, metadata_t>;
+using regular_uoflow      = bh::axis::regular<double, bh::use_default, metadata_t>;
+using regular_noflow      = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::none_t>;
+using regular_growth      = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::growth_t>;
+using circular            = bh::axis::circular<double, metadata_t>;
+using regular_log         = bh::axis::regular<double, bh::axis::transform::log, metadata_t>;
+using regular_sqrt        = bh::axis::regular<double, bh::axis::transform::sqrt, metadata_t>;
+using regular_pow         = bh::axis::regular<double, bh::axis::transform::pow, metadata_t>;
+using variable            = bh::axis::variable<double, metadata_t>;
+using integer_uoflow      = bh::axis::integer<int, metadata_t>;
+using integer_noflow      = bh::axis::integer<int, metadata_t, bh::axis::option::none_t>;
+using integer_growth      = bh::axis::integer<int, metadata_t, bh::axis::option::growth_t>;
+using category_int        = bh::axis::category<int, metadata_t>;
 using category_int_growth = bh::axis::category<int, metadata_t, bh::axis::option::growth_t>;
-using category_str = bh::axis::category<std::string, metadata_t>;
+using category_str        = bh::axis::category<std::string, metadata_t>;
 using category_str_growth = bh::axis::category<std::string, metadata_t, bh::axis::option::growth_t>;
 
 } // namespace axis
@@ -130,14 +127,12 @@ using any = std::vector<bh::axis::variant<axis::regular_uoflow,
                                           axis::category_int,
                                           axis::category_int_growth,
                                           axis::category_str,
-                                          axis::category_str_growth
-                                          >>;
+                                          axis::category_str_growth>>;
 
 // Specialization for some speed improvement
 using regular = std::vector<axis::regular_uoflow>;
 
 // Specialization for some speed improvement
 using regular_noflow = std::vector<axis::regular_noflow>;
-
 
 } // namespace axes

--- a/include/boost/histogram/python/copyable_atomic.hpp
+++ b/include/boost/histogram/python/copyable_atomic.hpp
@@ -9,21 +9,27 @@
 
 template <typename T>
 class copyable_atomic : public std::atomic<T> {
-public:
+  public:
     using std::atomic<T>::atomic;
-    
+
     // zero-initialize the atomic T
-    copyable_atomic() noexcept : std::atomic<T>(T()) {}
-    
+    copyable_atomic() noexcept
+        : std::atomic<T>(T()) {}
+
     // this is potentially not thread-safe, see below
-    copyable_atomic(const copyable_atomic& rhs) : std::atomic<T>() { this->operator=(rhs); }
-    
+    copyable_atomic(const copyable_atomic &rhs)
+        : std::atomic<T>() {
+        this->operator=(rhs);
+    }
+
     // this is potentially not thread-safe, see below
-    copyable_atomic& operator=(const copyable_atomic& rhs) {
-        if (this != &rhs) { std::atomic<T>::store(rhs.load()); }
+    copyable_atomic &operator=(const copyable_atomic &rhs) {
+        if(this != &rhs) {
+            std::atomic<T>::store(rhs.load());
+        }
         return *this;
     }
-    
+
     // Default to relaxed memory order
     T operator++() noexcept {
         return this->fetch_add(T(1), std::memory_order_relaxed); // Should return +1 but result unused

--- a/include/boost/histogram/python/histogram.hpp
+++ b/include/boost/histogram/python/histogram.hpp
@@ -7,42 +7,40 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
-#include <boost/histogram/python/copyable_atomic.hpp>
 #include <boost/histogram.hpp>
+#include <boost/histogram/python/copyable_atomic.hpp>
 
 #include <vector>
 
-
-template<typename T>
+template <typename T>
 struct remove_atomic {
     using type = T;
 };
 
-template<>
+template <>
 struct remove_atomic<copyable_atomic<uint64_t>> {
     using type = std::uint64_t;
 };
 
-
 /// Build and return a buffer over the current data.
 /// Could be optimized using array and maximum number of dims.
 /// Flow controls whether under/over flow bins are present
-template<typename A, typename S>
-py::buffer_info make_buffer(bh::histogram<A, S>& h, bool flow) {
-    using in_storage_t = typename bh::histogram<A, S>::value_type;
+template <typename A, typename S>
+py::buffer_info make_buffer(bh::histogram<A, S> &h, bool flow) {
+    using in_storage_t       = typename bh::histogram<A, S>::value_type;
     using in_storage_value_t = typename remove_atomic<in_storage_t>::type;
 
     auto rank = h.rank();
     std::vector<ssize_t> diminsions, strides;
     ssize_t factor = 1;
 
-    ssize_t start = 0;
+    ssize_t start   = 0;
     ssize_t size_of = sizeof(in_storage_t);
 
-    for (unsigned i=0; i<rank; i++) {
-        bool underflow = bh::axis::traits::options(h.axis(i)) & bh::axis::option::underflow;
+    for(unsigned i = 0; i < rank; i++) {
+        bool underflow     = bh::axis::traits::options(h.axis(i)) & bh::axis::option::underflow;
         ssize_t extent_dim = bh::axis::traits::extent(h.axis(i));
-        ssize_t size_dim = h.axis(i).size();
+        ssize_t size_dim   = h.axis(i).size();
         if(!flow && underflow)
             start += factor;
         diminsions.push_back(flow ? extent_dim : size_dim);
@@ -50,18 +48,17 @@ py::buffer_info make_buffer(bh::histogram<A, S>& h, bool flow) {
         factor *= extent_dim;
     }
 
-    return py::buffer_info(
-                           &(*h.begin()) + start,                         // Pointer to buffer
-                           sizeof(in_storage_t),                          // Size of one scalar
+    return py::buffer_info(&(*h.begin()) + start,                               // Pointer to buffer
+                           sizeof(in_storage_t),                                // Size of one scalar
                            py::format_descriptor<in_storage_value_t>::format(), // Python struct-style format descriptor
-                           rank,                                          // Number of dimensions
-                           diminsions,                                    // Buffer dimensions
-                           strides                                        // Strides (in bytes) for each index
-                           );
+                           rank,                                                // Number of dimensions
+                           diminsions,                                          // Buffer dimensions
+                           strides                                              // Strides (in bytes) for each index
+    );
 }
 
 /// Unlimited storage does not support buffer access
-template<typename A>
-py::buffer_info make_buffer(bh::histogram<A, bh::default_storage>&, bool) {
+template <typename A>
+py::buffer_info make_buffer(bh::histogram<A, bh::default_storage> &, bool) {
     return py::buffer_info();
 }

--- a/include/boost/histogram/python/histogram_atomic.hpp
+++ b/include/boost/histogram/python/histogram_atomic.hpp
@@ -12,58 +12,59 @@
 #include <boost/mp11.hpp>
 
 #include <cassert>
-#include <vector>
-#include <tuple>
 #include <cmath>
+#include <tuple>
+#include <vector>
 
 #include <thread>
 
 template <class Histogram>
 struct [[gnu::visibility("hidden")]] fill_helper_atomic {
-    fill_helper_atomic(Histogram& h, py::args args, size_t threads) : hist(h) , threads_(threads){
+    fill_helper_atomic(Histogram & h, py::args args, size_t threads)
+        : hist(h)
+        , threads_(threads) {
         size_t dim = args.size();
-        if (dim == 0)
+        if(dim == 0)
             throw std::invalid_argument("at least one argument required");
-        
+
         arrs.reserve(dim);
-        for (size_t i = 0; i < dim; ++i) {
+        for(size_t i = 0; i < dim; ++i) {
             auto a = py::cast<py::array_t<double>>(args[i]);
-            if (a.ndim() > 1)
+            if(a.ndim() > 1)
                 throw std::invalid_argument("array dim must be 0 or 1");
             arrs.emplace_back(a, a.data());
         }
-        
-        
+
         ssize_t ssize = arrs[0].first.size();
-        for (size_t i = 1; i < dim; ++i)
-            if (arrs[i].first.size() != ssize)
+        for(size_t i = 1; i < dim; ++i)
+            if(arrs[i].first.size() != ssize)
                 throw std::invalid_argument("arrays must have same length");
-        if (ssize == 0) // handle scalars by setting size to 1
+        if(ssize == 0) // handle scalars by setting size to 1
             ++ssize;
-        
-        size = (size_t) ssize;
+
+        size = (size_t)ssize;
     }
-    
+
     // keep function small to minimize code bloat, it is instantiated 32 times :(
     // TODO: solve this more efficiently on the lower Boost::Histogram level
     template <class N>
     void operator()(N) {
         using namespace boost::mp11;
         // N is a compile-time number with N == arrs.size()
-        
+
         py::gil_scoped_release gil;
-        
+
         size_t threads = threads_ == 0 ? std::thread::hardware_concurrency() : threads_;
-        
+
         std::vector<std::thread> threadpool;
-        for(size_t i=0; i<threads; i++) {
-            size_t start = i * size/threads;
-            size_t stop = (i+1==threads) ? size : (i+1)*size/threads;
-            threadpool.emplace_back([start, stop, this](){
+        for(size_t i = 0; i < threads; i++) {
+            size_t start = i * size / threads;
+            size_t stop  = (i + 1 == threads) ? size : (i + 1) * size / threads;
+            threadpool.emplace_back([start, stop, this]() {
                 // Type: tuple<double, ..., double> (N times)
                 mp_repeat<std::tuple<double>, N> tp;
-                
-                for (std::size_t i = start; i < stop; ++i) {
+
+                for(std::size_t i = start; i < stop; ++i) {
                     mp_for_each<mp_iota<N>>([&](auto I) {
                         // I is mp_size_t<0>, mp_size_t<1>, ..., mp_size_t<N-1>
                         std::get<I>(tp) = arrs[I].second[i];
@@ -72,49 +73,45 @@ struct [[gnu::visibility("hidden")]] fill_helper_atomic {
                 }
             });
         }
-        
-        for(auto& thread : threadpool)
+
+        for(auto &thread : threadpool)
             thread.join();
     }
-    
+
     // specialization for N=0 to prevent compile-time error in histogram
-    void operator()(boost::mp11::mp_size_t<0>) {
-        throw std::invalid_argument("at least one argument required");
-    }
-    
+    void operator()(boost::mp11::mp_size_t<0>) { throw std::invalid_argument("at least one argument required"); }
+
     // specialization for N=1, implement potential optimizations here
     void operator()(boost::mp11::mp_size_t<1>) {
         // compilers often emit faster code for range-based for loops
         struct span {
-            const double* begin() const { return start; }
-            const double* end() const { return stop; }
-            const double* start;
-            const double* stop;
+            const double *begin() const { return start; }
+            const double *end() const { return stop; }
+            const double *start;
+            const double *stop;
         };
-        
+
         // Note that splitting and filling from multiple threads is only supported with atomics
         py::gil_scoped_release gil;
-        
+
         size_t threads = threads_ == 0 ? std::thread::hardware_concurrency() : threads_;
-        
+
         std::vector<std::thread> threadpool;
-        for(size_t i=0; i<threads; i++) {
-            size_t start = i * (size/threads);
-            size_t stop = (i+1==threads) ? size : (i+1)*(size/threads);
-            threadpool.emplace_back([start, stop, this](){
-                for (double xi : span{arrs.front().second + start, arrs.front().second + stop})
+        for(size_t i = 0; i < threads; i++) {
+            size_t start = i * (size / threads);
+            size_t stop  = (i + 1 == threads) ? size : (i + 1) * (size / threads);
+            threadpool.emplace_back([start, stop, this]() {
+                for(double xi : span{arrs.front().second + start, arrs.front().second + stop})
                     hist(xi); // throws invalid_argument if hist.rank() != 1
             });
-
         }
-        
-        for(auto& thread : threadpool)
+
+        for(auto &thread : threadpool)
             thread.join();
-        
     }
-    
-    Histogram& hist;
-    std::vector<std::pair<py::array_t<double>, const double*>> arrs;
+
+    Histogram &hist;
+    std::vector<std::pair<py::array_t<double>, const double *>> arrs;
     size_t size;
     size_t threads_;
 };

--- a/include/boost/histogram/python/histogram_fill.hpp
+++ b/include/boost/histogram/python/histogram_fill.hpp
@@ -12,34 +12,34 @@
 #include <boost/mp11.hpp>
 
 #include <cassert>
-#include <vector>
-#include <tuple>
 #include <cmath>
-
+#include <tuple>
+#include <vector>
 
 template <class Histogram>
 struct [[gnu::visibility("hidden")]] fill_helper {
-    fill_helper(Histogram& h, py::args args) : hist(h) {
+    fill_helper(Histogram & h, py::args args)
+        : hist(h) {
         size_t dim = args.size();
-        if (dim == 0)
+        if(dim == 0)
             throw std::invalid_argument("at least one argument required");
-        
+
         arrs.reserve(dim);
-        for (size_t i = 0; i < dim; ++i) {
+        for(size_t i = 0; i < dim; ++i) {
             auto a = py::cast<py::array_t<double>>(args[i]);
-            if (a.ndim() > 1)
+            if(a.ndim() > 1)
                 throw std::invalid_argument("array dim must be 0 or 1");
             arrs.emplace_back(a, a.data());
         }
-        
+
         size = arrs[0].first.size();
-        for (size_t i = 1; i < dim; ++i)
-            if (arrs[i].first.size() != size)
+        for(size_t i = 1; i < dim; ++i)
+            if(arrs[i].first.size() != size)
                 throw std::invalid_argument("arrays must have same length");
-        if (size == 0) // handle scalars by setting size to 1
+        if(size == 0) // handle scalars by setting size to 1
             ++size;
     }
-    
+
     // keep function small to minimize code bloat, it is instantiated 32 times :(
     // TODO: solve this more efficiently on the lower Boost::Histogram level
     template <class N>
@@ -48,11 +48,11 @@ struct [[gnu::visibility("hidden")]] fill_helper {
         // N is a compile-time number with N == arrs.size()
         // Type: tuple<double, ..., double> (N times)
         mp_repeat<std::tuple<double>, N> tp;
-        
+
         // Note that splitting and filling from multiple threads is only supported with atomics
         py::gil_scoped_release gil;
-        
-        for (std::size_t i = 0; i < (std::size_t) size; ++i) {
+
+        for(std::size_t i = 0; i < (std::size_t)size; ++i) {
             mp_for_each<mp_iota<N>>([&](auto I) {
                 // I is mp_size_t<0>, mp_size_t<1>, ..., mp_size_t<N-1>
                 std::get<I>(tp) = arrs[I].second[i];
@@ -60,31 +60,28 @@ struct [[gnu::visibility("hidden")]] fill_helper {
             hist(tp); // throws invalid_argument if tup has wrong size
         }
     }
-    
+
     // specialization for N=0 to prevent compile-time error in histogram
-    void operator()(boost::mp11::mp_size_t<0>) {
-        throw std::invalid_argument("at least one argument required");
-    }
-    
+    void operator()(boost::mp11::mp_size_t<0>) { throw std::invalid_argument("at least one argument required"); }
+
     // specialization for N=1, implement potential optimizations here
     void operator()(boost::mp11::mp_size_t<1>) {
         // compilers often emit faster code for range-based for loops
         struct span {
-            const double* begin() const { return ptr; }
-            const double* end() const { return ptr + size; }
-            const double* ptr;
+            const double *begin() const { return ptr; }
+            const double *end() const { return ptr + size; }
+            const double *ptr;
             std::size_t size;
         };
-        
+
         // Note that splitting and filling from multiple threads is only supported with atomics
         py::gil_scoped_release gil;
-        
-        for (double xi : span{arrs.front().second, (std::size_t) size})
+
+        for(double xi : span{arrs.front().second, (std::size_t)size})
             hist(xi); // throws invalid_argument if hist.rank() != 1
     }
-    
-    Histogram& hist;
-    std::vector<std::pair<py::array_t<double>, const double*>> arrs;
+
+    Histogram &hist;
+    std::vector<std::pair<py::array_t<double>, const double *>> arrs;
     ssize_t size;
 };
-

--- a/include/boost/histogram/python/histogram_threaded.hpp
+++ b/include/boost/histogram/python/histogram_threaded.hpp
@@ -12,64 +12,65 @@
 #include <boost/mp11.hpp>
 
 #include <cassert>
-#include <vector>
-#include <tuple>
 #include <cmath>
+#include <tuple>
+#include <vector>
 
-#include <thread>
 #include <future>
+#include <thread>
 
 template <class Histogram>
 struct [[gnu::visibility("hidden")]] fill_helper_threaded {
-    fill_helper_threaded(Histogram& h, py::args args, size_t threads) : hist(h) , threads_(threads){
+    fill_helper_threaded(Histogram & h, py::args args, size_t threads)
+        : hist(h)
+        , threads_(threads) {
         size_t dim = args.size();
-        if (dim == 0)
+        if(dim == 0)
             throw std::invalid_argument("at least one argument required");
-        
+
         arrs.reserve(dim);
-        for (size_t i = 0; i < dim; ++i) {
+        for(size_t i = 0; i < dim; ++i) {
             auto a = py::cast<py::array_t<double>>(args[i]);
-            if (a.ndim() > 1)
+            if(a.ndim() > 1)
                 throw std::invalid_argument("array dim must be 0 or 1");
             arrs.emplace_back(a, a.data());
         }
-        
-        
+
         ssize_t ssize = arrs[0].first.size();
-        for (size_t i = 1; i < dim; ++i)
-            if (arrs[i].first.size() != ssize)
+        for(size_t i = 1; i < dim; ++i)
+            if(arrs[i].first.size() != ssize)
                 throw std::invalid_argument("arrays must have same length");
-        if (ssize == 0) // handle scalars by setting size to 1
+        if(ssize == 0) // handle scalars by setting size to 1
             ++ssize;
-        
-        size = (size_t) ssize;
+
+        size = (size_t)ssize;
     }
-    
+
     // keep function small to minimize code bloat, it is instantiated 32 times :(
     // TODO: solve this more efficiently on the lower Boost::Histogram level
     template <class N>
     void operator()(N) {
         using namespace boost::mp11;
         // N is a compile-time number with N == arrs.size()
-        
+
         py::gil_scoped_release gil;
-        
+
         size_t threads = threads_ == 0 ? std::thread::hardware_concurrency() : threads_;
-        
+
         std::vector<std::thread> threadpool;
         std::vector<std::future<Histogram>> histpool;
 
-        for(size_t i=0; i<threads; i++) {
-            size_t start = i * size/threads;
-            size_t stop = (i+1==threads) ? size : (i+1)*size/threads;
-            std::packaged_task<Histogram()> task([start, stop, this](){
+        for(size_t i = 0; i < threads; i++) {
+            size_t start = i * size / threads;
+            size_t stop  = (i + 1 == threads) ? size : (i + 1) * size / threads;
+            std::packaged_task<Histogram()> task([start, stop, this]() {
                 Histogram local_hist(hist);
                 local_hist.reset();
-                
+
                 // Type: tuple<double, ..., double> (N times)
                 mp_repeat<std::tuple<double>, N> tp;
-                
-                for (std::size_t i = start; i < stop; ++i) {
+
+                for(std::size_t i = start; i < stop; ++i) {
                     mp_for_each<mp_iota<N>>([&](auto I) {
                         // I is mp_size_t<0>, mp_size_t<1>, ..., mp_size_t<N-1>
                         std::get<I>(tp) = arrs[I].second[i];
@@ -78,68 +79,65 @@ struct [[gnu::visibility("hidden")]] fill_helper_threaded {
                 }
                 return local_hist;
             });
-            
+
             histpool.push_back(task.get_future());
             threadpool.emplace_back(std::move(task));
         }
-        
-        for(auto& hp : histpool)
+
+        for(auto &hp : histpool)
             hist += hp.get();
-        
-        for(auto& t : threadpool)
+
+        for(auto &t : threadpool)
             t.join();
     }
-    
+
     // specialization for N=0 to prevent compile-time error in histogram
-    void operator()(boost::mp11::mp_size_t<0>) {
-        throw std::invalid_argument("at least one argument required");
-    }
-    
+    void operator()(boost::mp11::mp_size_t<0>) { throw std::invalid_argument("at least one argument required"); }
+
     // specialization for N=1, implement potential optimizations here
     void operator()(boost::mp11::mp_size_t<1>) {
         // compilers often emit faster code for range-based for loops
         struct span {
-            const double* begin() const { return start; }
-            const double* end() const { return stop; }
-            const double* start;
-            const double* stop;
+            const double *begin() const { return start; }
+            const double *end() const { return stop; }
+            const double *start;
+            const double *stop;
         };
-        
+
         // Note that splitting and filling from multiple threads is only supported with atomics
         py::gil_scoped_release gil;
-        
+
         size_t threads = threads_ == 0 ? std::thread::hardware_concurrency() : threads_;
-        
+
         std::vector<std::thread> threadpool;
         std::vector<std::future<Histogram>> histpool;
-        
-        for(size_t i=0; i<threads; i++) {
-            size_t start = i * size/threads;
-            size_t stop = (i+1==threads) ? size : (i+1)*size/threads;
-            std::packaged_task<Histogram()> task([start, stop, this](){
+
+        for(size_t i = 0; i < threads; i++) {
+            size_t start = i * size / threads;
+            size_t stop  = (i + 1 == threads) ? size : (i + 1) * size / threads;
+            std::packaged_task<Histogram()> task([start, stop, this]() {
                 Histogram local_hist(hist);
                 local_hist.reset();
-                
-                for (double xi : span{arrs.front().second + start, arrs.front().second + stop})
+
+                for(double xi : span{arrs.front().second + start, arrs.front().second + stop})
                     local_hist(xi); // throws invalid_argument if tup has wrong size
-                
+
                 return local_hist;
             });
-            
+
             histpool.push_back(task.get_future());
             threadpool.emplace_back(std::move(task));
         }
-        
-        for(auto& hp : histpool)
+
+        for(auto &hp : histpool)
             hist += hp.get();
-        
-        for(auto& t : threadpool)
+
+        for(auto &t : threadpool)
             t.join();
-        
     }
-    
-    Histogram& hist;
-    std::vector<std::pair<py::array_t<double>, const double*>> arrs;
+
+    Histogram &hist;
+    std::vector<std::pair<py::array_t<double>, const double *>> arrs;
     size_t size;
     size_t threads_;
 };

--- a/include/boost/histogram/python/kwargs.hpp
+++ b/include/boost/histogram/python/kwargs.hpp
@@ -7,10 +7,9 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
-
 /// Get and remove a value from a keyword argument dict
-template<typename T>
-T required_arg(py::kwargs& kwargs, const char* name) {
+template <typename T>
+T required_arg(py::kwargs &kwargs, const char *name) {
     if(kwargs.contains(name)) {
         return py::cast<T>(kwargs.attr("pop")(name));
     } else {
@@ -19,8 +18,8 @@ T required_arg(py::kwargs& kwargs, const char* name) {
 }
 
 /// Get and remove a value from a keyword argument dict, or return a empty pointer
-template<typename T>
-std::unique_ptr<T> optional_arg(py::kwargs& kwargs, const char* name) {
+template <typename T>
+std::unique_ptr<T> optional_arg(py::kwargs &kwargs, const char *name) {
     if(kwargs.contains(name)) {
         return std::make_unique<T>(py::cast<T>(kwargs.attr("pop")(name)));
     } else {
@@ -29,8 +28,8 @@ std::unique_ptr<T> optional_arg(py::kwargs& kwargs, const char* name) {
 }
 
 /// Get and remove a value from a keyword argument dict with default
-template<typename T>
-T optional_arg(py::kwargs& kwargs, const char* name, T original_value) {
+template <typename T>
+T optional_arg(py::kwargs &kwargs, const char *name, T original_value) {
     if(kwargs.contains(name)) {
         return py::cast<T>(kwargs[name]);
     } else {
@@ -39,11 +38,10 @@ T optional_arg(py::kwargs& kwargs, const char* name, T original_value) {
 }
 
 /// Run this last; it will provide an error if other keyword are still present
-inline
-void finalize_args(const py::kwargs& kwargs) {
+inline void finalize_args(const py::kwargs &kwargs) {
     if(kwargs.size() > 0) {
         std::stringstream out;
-        for(const auto& item : kwargs) {
+        for(const auto &item : kwargs) {
             out << " " << item.first;
         }
         throw py::key_error("Unidentfied keywords found:" + out.str());

--- a/include/boost/histogram/python/pybind11.hpp
+++ b/include/boost/histogram/python/pybind11.hpp
@@ -7,13 +7,13 @@
 
 #pragma once
 
-#include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <functional>
-#include <type_traits>
 #include <sstream>
+#include <type_traits>
 
 // Allow command line overide
 #ifndef BOOST_HISTOGRAM_DETAIL_AXES_LIMIT
@@ -23,23 +23,25 @@
 namespace py = pybind11;
 using namespace pybind11::literals; // For ""_a syntax
 
-namespace boost { namespace histogram {}}
+namespace boost {
+namespace histogram {}
+} // namespace boost
 namespace bh = boost::histogram;
 
 /// Static if standin: define a method if expression is true
-template<typename T, typename... Args>
-void def_optionally(T&& module, std::true_type, Args&&... expression) {
+template <typename T, typename... Args>
+void def_optionally(T &&module, std::true_type, Args &&... expression) {
     module.def(std::forward<Args...>(expression...));
 }
 
 /// Static if standin: Do nothing if compile time expression is false
-template<typename T, typename... Args>
-void def_optionally(T&&, std::false_type, Args&&...) {}
+template <typename T, typename... Args>
+void def_optionally(T &&, std::false_type, Args &&...) {}
 
 /// Shift to string
-template<typename T>
+template <typename T>
 auto shift_to_string() {
-    return [](const T& self){
+    return [](const T &self) {
         std::ostringstream out;
         out << self;
         return out.str();

--- a/include/boost/histogram/python/storage.hpp
+++ b/include/boost/histogram/python/storage.hpp
@@ -13,16 +13,15 @@
 
 #include <cstdint>
 
-
 namespace storage {
 
 // Names match Python names
-using int_ = bh::dense_storage<uint64_t>;
-using atomic_int = bh::dense_storage<copyable_atomic<uint64_t>>;
-using double_ = bh::dense_storage<double>;
-using unlimited = bh::unlimited_storage<>;
-using weight = bh::weight_storage;
-using profile = bh::profile_storage;
+using int_             = bh::dense_storage<uint64_t>;
+using atomic_int       = bh::dense_storage<copyable_atomic<uint64_t>>;
+using double_          = bh::dense_storage<double>;
+using unlimited        = bh::unlimited_storage<>;
+using weight           = bh::weight_storage;
+using profile          = bh::profile_storage;
 using weighted_profile = bh::weighted_profile_storage;
 
-}  // namespace storage
+} // namespace storage

--- a/include/boost/histogram/python/try_cast.hpp
+++ b/include/boost/histogram/python/try_cast.hpp
@@ -7,40 +7,40 @@
 
 #include <pybind11/pybind11.h>
 
-#include <boost/mp11/list.hpp>
 #include <boost/mp11/algorithm.hpp>
+#include <boost/mp11/list.hpp>
 
 // end of recursion
 template <class R, class Unary>
-R try_cast_impl(boost::mp11::mp_list<>, py::object, Unary&&) {
-  throw py::cast_error("try_cast failed to find a match for object argument");
+R try_cast_impl(boost::mp11::mp_list<>, py::object, Unary &&) {
+    throw py::cast_error("try_cast failed to find a match for object argument");
 }
 
 // recursion
 template <class R, class T, class... Ts, class Unary>
-R try_cast_impl(boost::mp11::mp_list<T, Ts...>, py::object obj, Unary&& unary) {
-  if (py::isinstance<T>(obj))
-    return unary(py::cast<T>(obj));
-  return try_cast_impl<R>(boost::mp11::mp_list<Ts...>{}, obj, std::forward<Unary>(unary));
+R try_cast_impl(boost::mp11::mp_list<T, Ts...>, py::object obj, Unary &&unary) {
+    if(py::isinstance<T>(obj))
+        return unary(py::cast<T>(obj));
+    return try_cast_impl<R>(boost::mp11::mp_list<Ts...>{}, obj, std::forward<Unary>(unary));
 }
 
 /**
   Cast python object to first match in type list and run functor with that type.
 
-  Returns whatever the functor returns. The functor return type must not depend on 
+  Returns whatever the functor returns. The functor return type must not depend on
   the argument type. In other words, all functor overloads must return the same type.
 
   Throws pybind11::cast_error if no match is found.
 */
 template <class TypeList, class Unary>
-decltype(auto) try_cast_over(py::object obj, Unary&& unary) {
-  using R = decltype(unary(std::declval<boost::mp11::mp_first<TypeList>>()));
-  using L = boost::mp11::mp_rename<TypeList, boost::mp11::mp_list>;
-  return try_cast_impl<R>(L{}, obj, std::forward<Unary>(unary));
+decltype(auto) try_cast_over(py::object obj, Unary &&unary) {
+    using R = decltype(unary(std::declval<boost::mp11::mp_first<TypeList>>()));
+    using L = boost::mp11::mp_rename<TypeList, boost::mp11::mp_list>;
+    return try_cast_impl<R>(L{}, obj, std::forward<Unary>(unary));
 }
 
 /// Like try_cast_over, but passing the types explicitly.
 template <class T, class... Ts, class Unary>
-decltype(auto) try_cast(py::object obj, Unary&& unary) {
-  return try_cast_over<boost::mp11::mp_list<T, Ts...>>(obj, std::forward<Unary>(unary));
+decltype(auto) try_cast(py::object obj, Unary &&unary) {
+    return try_cast_over<boost::mp11::mp_list<T, Ts...>>(obj, std::forward<Unary>(unary));
 }

--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+set -evx
+
+# Also good but untagged: CLANG_FORMAT=unibeautify/clang-format
+CLANG_FORMAT=saschpe/clang-format:5.0.1
+
+
+if [ -x "$(command -v clang-format)" ] ; then
+
+    clang-format --version
+    git ls-files -- '*.cpp' '*.hpp' '*.cu' '*.h' | xargs clang-format -style=file -sort-includes -i
+
+elif [ -x "$(command -v docker)" ] ; then
+
+    docker run -it --rm ${CLANG_FORMAT} --version
+    docker run -it --rm -v "$(pwd)":/workdir -w /workdir  ${CLANG_FORMAT} -style=file -sort-includes -i $(git ls-files -- '*.cpp' '*.hpp' '*.cu' '*.h')
+
+fi
+
+git diff --exit-code --color
+
+set +evx
+

--- a/scripts/check_style_docker.sh
+++ b/scripts/check_style_docker.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# Also good but untagged: CLANG_FORMAT=unibeautify/clang-format
+CLANG_FORMAT=saschpe/clang-format:5.0.1
+
+set -evx
+
+docker run -it --rm ${CLANG_FORMAT} --version
+docker run -it --rm -v "$(pwd)":/workdir -w /workdir ${CLANG_FORMAT} -style=file -sort-includes -i $(git ls-files -- '*.cpp' '*.hpp' '*.cu' '*.h')
+
+git diff --exit-code --color
+
+set +evx

--- a/scripts/check_style_docker.sh
+++ b/scripts/check_style_docker.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env sh
 
-# Also good but untagged: CLANG_FORMAT=unibeautify/clang-format
-CLANG_FORMAT=saschpe/clang-format:5.0.1
+# Good and locked to a version: origin/develop
+CLANG_FORMAT=unibeautify/clang-format
 
 set -evx
 
-docker run -it --rm ${CLANG_FORMAT} --version
-docker run -it --rm -v "$(pwd)":/workdir -w /workdir ${CLANG_FORMAT} -style=file -sort-includes -i $(git ls-files -- '*.cpp' '*.hpp' '*.cu' '*.h')
+docker run --rm ${CLANG_FORMAT} --version
+docker run --rm -v "$(pwd)":/workdir -w /workdir ${CLANG_FORMAT} -style=file -sort-includes -i $(git ls-files -- '*.cpp' '*.hpp' '*.cu' '*.h')
 
 git diff --exit-code --color
 

--- a/src/histogram/accumulators.cpp
+++ b/src/histogram/accumulators.cpp
@@ -9,122 +9,131 @@
 #include <boost/histogram/python/pickle.hpp>
 
 #include <boost/histogram.hpp>
-#include <boost/histogram/accumulators/weighted_sum.hpp>
-#include <boost/histogram/accumulators/weighted_mean.hpp>
 #include <boost/histogram/accumulators/mean.hpp>
-#include <boost/histogram/accumulators/sum.hpp>
 #include <boost/histogram/accumulators/ostream.hpp>
+#include <boost/histogram/accumulators/sum.hpp>
+#include <boost/histogram/accumulators/weighted_mean.hpp>
+#include <boost/histogram/accumulators/weighted_sum.hpp>
 
-
-template<typename A, typename... Args>
-py::class_<A> add_accumulator(py::module acc, Args&&... args) {
-    
+template <typename A, typename... Args>
+py::class_<A> add_accumulator(py::module acc, Args &&... args) {
     return py::class_<A>(acc, std::forward<Args>(args)...)
         .def(py::init<>())
-    
+
         .def(py::self += py::self)
         .def(py::self == py::self)
         .def(py::self != py::self)
-    
+
         .def("__repr__", shift_to_string<A>())
-    
-        .def("__copy__", [](const A& self){return A(self);})
-        .def("__deepcopy__", [](const A& self, py::object){return A(self);})
-    
-        .def(make_pickle<A>())
-    ;
+
+        .def("__copy__", [](const A &self) { return A(self); })
+        .def("__deepcopy__", [](const A &self, py::object) { return A(self); })
+
+        .def(make_pickle<A>());
 }
 
 py::module register_accumulators(py::module &m) {
-    
     py::module accumulators = m.def_submodule("accumulators");
 
     using weighted_sum = bh::accumulators::weighted_sum<double>;
-    
+
     add_accumulator<weighted_sum>(accumulators, "weighted_sum")
-        .def(py::init<const double&>(), "value"_a)
-        .def(py::init<const double&, const double&>(), "value"_a, "variance"_a)
-    
+        .def(py::init<const double &>(), "value"_a)
+        .def(py::init<const double &, const double &>(), "value"_a, "variance"_a)
+
         .def_property_readonly("variance", &weighted_sum::variance)
         .def_property_readonly("value", &weighted_sum::value)
-    
+
         .def(py::self += double())
         .def(py::self += py::self)
         .def(py::self *= double())
-    
-        .def("__call__", py::vectorize([](weighted_sum& self, double value){
-            self += value;
-            return self.value();
-        }), "values"_a)
-    
-        .def("__call__", py::vectorize([](weighted_sum& self, double value, double variance){
-            self += weighted_sum(value, variance);
-            return self.value(); 
-        }), "values"_a, "variances"_a)
-    ;
+
+        .def("__call__",
+             py::vectorize([](weighted_sum &self, double value) {
+                 self += value;
+                 return self.value();
+             }),
+             "values"_a)
+
+        .def("__call__",
+             py::vectorize([](weighted_sum &self, double value, double variance) {
+                 self += weighted_sum(value, variance);
+                 return self.value();
+             }),
+             "values"_a,
+             "variances"_a);
 
     using weighted_mean = bh::accumulators::weighted_mean<double>;
 
     add_accumulator<weighted_mean>(accumulators, "weighted_mean")
-        .def(py::init<const double&, const double&, const double&, const double&>(),
-             "wsum"_a, "wsum2"_a, "mean"_a, "variance"_a)
-
+        .def(py::init<const double &, const double &, const double &, const double &>(),
+             "wsum"_a,
+             "wsum2"_a,
+             "mean"_a,
+             "variance"_a)
 
         .def_property_readonly("sum_of_weights", &weighted_mean::sum_of_weights)
         .def_property_readonly("variance", &weighted_mean::variance)
         .def_property_readonly("value", &weighted_mean::value)
 
         .def(py::self *= double())
-    
-        .def("__call__", py::vectorize([](weighted_mean& self, double value){
-            self(value);
-            return self.value();
-        }), "value"_a)
-       .def("__call__", py::vectorize([](weighted_mean& self, double weight, double value){
-           self(weight, value);
-           return self.value();
-       }), "weight"_a, "value"_a)
-    
-      ;
 
-    
+        .def("__call__",
+             py::vectorize([](weighted_mean &self, double value) {
+                 self(value);
+                 return self.value();
+             }),
+             "value"_a)
+        .def("__call__",
+             py::vectorize([](weighted_mean &self, double weight, double value) {
+                 self(weight, value);
+                 return self.value();
+             }),
+             "weight"_a,
+             "value"_a)
+
+        ;
+
     using mean = bh::accumulators::mean<double>;
-    
+
     add_accumulator<mean>(accumulators, "mean")
-        .def(py::init<std::size_t, const double&, const double&>(),
-             "value"_a, "mean"_a, "variance"_a)
-    
+        .def(py::init<std::size_t, const double &, const double &>(), "value"_a, "mean"_a, "variance"_a)
+
         .def_property_readonly("count", &mean::count)
         .def_property_readonly("variance", &mean::variance)
         .def_property_readonly("value", &mean::value)
-    
+
         .def(py::self *= double())
-    
-        .def("__call__", py::vectorize([](mean& self, double value){
-            self(value);
-            return self.value();
-        }), "value"_a)
-    ;
-    
+
+        .def("__call__",
+             py::vectorize([](mean &self, double value) {
+                 self(value);
+                 return self.value();
+             }),
+             "value"_a);
+
     using sum = bh::accumulators::sum<double>;
-    
+
     add_accumulator<sum>(accumulators, "sum")
-        .def(py::init<const double&>(), "value"_a)
-    
-        .def_property("value", &sum::operator double, [](sum& s, double v){s = v;})
-    
+        .def(py::init<const double &>(), "value"_a)
+
+        .def_property(
+            "value", &sum::operator double, [](sum &s, double v) { s = v; })
+
         .def(py::self += double())
         .def(py::self *= double())
-    
-        .def("__call__", py::vectorize([](sum& self, double value){
-            self += value;
-            return (double) self;
-        }), "value"_a)
-    
+
+        .def("__call__",
+             py::vectorize([](sum &self, double value) {
+                 self += value;
+                 return (double)self;
+             }),
+             "value"_a)
+
         .def_property_readonly("small", &sum::small)
         .def_property_readonly("large", &sum::large)
-    
-    ;
+
+        ;
 
     return accumulators;
 }

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -5,15 +5,15 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
+#include <pybind11/eval.h>
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
-#include <pybind11/eval.h>
 
 #include <boost/histogram/python/axis.hpp>
 #include <boost/histogram/python/pickle.hpp>
 
-#include <boost/histogram/axis/ostream.hpp>
 #include <boost/histogram.hpp>
+#include <boost/histogram/axis/ostream.hpp>
 
 #include <boost/histogram/axis/traits.hpp>
 
@@ -30,80 +30,89 @@ using namespace std::literals;
 struct regular_base {};
 
 /// Add items to an axis where the axis values are continious
-template<typename A, typename B>
-void add_to_axis(B&& axis, std::false_type) {
+template <typename A, typename B>
+void add_to_axis(B &&axis, std::false_type) {
     axis.def("bin", &A::bin, "The bin details (center, lower, upper)", "idx"_a, py::keep_alive<0, 1>());
-    axis.def("bins", [](const A& self, bool flow){
-        return axis_to_bins(self, flow);
-    }, "flow"_a=false);
+    axis.def(
+        "bins", [](const A &self, bool flow) { return axis_to_bins(self, flow); }, "flow"_a = false);
     axis.def("index", py::vectorize(&A::index), "The index at a point(s) on the axis", "x"_a);
     axis.def("value", py::vectorize(&A::value), "The value(s) for a fractional bin(s) in the axis", "i"_a);
 
-    axis.def("edges", [](const A& ax, bool flow){
-        return axis_to_edges(ax, flow);
-    }, "flow"_a = false, "The bin edges (length: bins + 1) (include over/underflow if flow=True)");
+    axis.def(
+        "edges",
+        [](const A &ax, bool flow) { return axis_to_edges(ax, flow); },
+        "flow"_a = false,
+        "The bin edges (length: bins + 1) (include over/underflow if flow=True)");
 
-    axis.def("centers", [](const A& ax){
-        py::array_t<double> centers((unsigned) ax.size());
-        std::transform(ax.begin(), ax.end(), centers.mutable_data(), [](const auto& bin){return bin.center();});
-        return centers;
-    }, "Return the bin centers");
+    axis.def(
+        "centers",
+        [](const A &ax) {
+            py::array_t<double> centers((unsigned)ax.size());
+            std::transform(ax.begin(), ax.end(), centers.mutable_data(), [](const auto &bin) { return bin.center(); });
+            return centers;
+        },
+        "Return the bin centers");
 }
 
 /// Add items to an axis where the axis values are not continious (categories of strings, for example)
-template<typename A, typename B>
-void add_to_axis(B&& axis, std::true_type) {
+template <typename A, typename B>
+void add_to_axis(B &&axis, std::true_type) {
     axis.def("bin", &A::bin, "The bin name", "idx"_a);
-    axis.def("bins", [](const A& self, bool flow){
-        return axis_to_bins(self, flow);
-    }, "flow"_a=false);
+    axis.def(
+        "bins", [](const A &self, bool flow) { return axis_to_bins(self, flow); }, "flow"_a = false);
     // Not that these really just don't work with string labels; they would work for numerical labels.
     axis.def("index", &A::index, "The index at a point on the axis", "x"_a);
     axis.def("value", &A::value, "The value for a fractional bin in the axis", "i"_a);
 }
 
 /// Add helpers common to all axis types
-template<typename A, typename... Args>
-py::class_<A> register_axis_by_type(py::module& m, Args&&... args) {
+template <typename A, typename... Args>
+py::class_<A> register_axis_by_type(py::module &m, Args &&... args) {
     py::class_<A> axis(m, std::forward<Args>(args)...);
 
     // using value_type = decltype(A::value(1.0));
 
-    axis
-    .def("__repr__", shift_to_string<A>())
+    axis.def("__repr__", shift_to_string<A>())
 
-    .def(py::self == py::self)
-    .def(py::self != py::self)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
 
-    .def("size", [](const A& self, bool flow){
-        if(flow)
-            return bh::axis::traits::extent(self);
-        else
-            return self.size();
-    } , "flow"_a=false, "Returns the number of bins, without over- or underflow unless flow=True")
+        .def(
+            "size",
+            [](const A &self, bool flow) {
+                if(flow)
+                    return bh::axis::traits::extent(self);
+                else
+                    return self.size();
+            },
+            "flow"_a = false,
+            "Returns the number of bins, without over- or underflow unless flow=True")
 
-    .def("update", &A::update, "Bin and add a value if allowed", "i"_a)
-    .def_static("options", &A::options, "Return the options associated to the axis")
-    .def_property("metadata",
-                  [](const A& self){return self.metadata();},
-                  [](A& self, const metadata_t& label){self.metadata() = label;},
-                  "Set the axis label")
-    
-    .def("__copy__", [](const A& self){return A(self);})
-    .def("__deepcopy__", [](const A& self, py::object memo){
-        A* a = new A(self);
-        py::module copy = py::module::import("copy");
-        a->metadata() = copy.attr("deepcopy")(a->metadata(), memo);
-        return a;
-    })
+        .def("update", &A::update, "Bin and add a value if allowed", "i"_a)
+        .def_static("options", &A::options, "Return the options associated to the axis")
+        .def_property(
+            "metadata",
+            [](const A &self) { return self.metadata(); },
+            [](A &self, const metadata_t &label) { self.metadata() = label; },
+            "Set the axis label")
 
-    ;
+        .def("__copy__", [](const A &self) { return A(self); })
+        .def("__deepcopy__",
+             [](const A &self, py::object memo) {
+                 A *a            = new A(self);
+                 py::module copy = py::module::import("copy");
+                 a->metadata()   = copy.attr("deepcopy")(a->metadata(), memo);
+                 return a;
+             })
+
+        ;
 
     // We only need keepalive if this is a reference.
     using Result = decltype(std::declval<A>().bin(std::declval<int>()));
 
     // This is a replacement for constexpr if
-    add_to_axis<A>(axis, std::integral_constant<bool, std::is_reference<Result>::value || std::is_integral<Result>::value>{});
+    add_to_axis<A>(
+        axis, std::integral_constant < bool, std::is_reference<Result>::value || std::is_integral<Result>::value > {});
 
     axis.def(make_pickle<A>());
 
@@ -111,150 +120,135 @@ py::class_<A> register_axis_by_type(py::module& m, Args&&... args) {
 }
 
 /// Add helpers common to all types with a range of values
-template<typename A>
-py::class_<bh::axis::interval_view<A>> register_axis_iv_by_type(py::module& m, const char* name) {
-    using A_iv = bh::axis::interval_view<A>;
+template <typename A>
+py::class_<bh::axis::interval_view<A>> register_axis_iv_by_type(py::module &m, const char *name) {
+    using A_iv               = bh::axis::interval_view<A>;
     py::class_<A_iv> axis_iv = py::class_<A_iv>(m, name, "Lightweight bin view");
 
-    axis_iv
-    .def("upper", &A_iv::upper)
-    .def("lower", &A_iv::lower)
-    .def("center", &A_iv::center)
-    .def("width", &A_iv::width)
-    .def(py::self == py::self)
-    .def(py::self != py::self)
-    .def("__repr__", [](const A_iv& self){
-        return "<bin ["s + std::to_string(self.lower()) + ", "s + std::to_string(self.upper()) + "]>"s;
-    })
-    ;
+    axis_iv.def("upper", &A_iv::upper)
+        .def("lower", &A_iv::lower)
+        .def("center", &A_iv::center)
+        .def("width", &A_iv::width)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def("__repr__", [](const A_iv &self) {
+            return "<bin ["s + std::to_string(self.lower()) + ", "s + std::to_string(self.upper()) + "]>"s;
+        });
 
     return axis_iv;
 }
 
 struct regular_type {};
 
-
 py::module register_axis(py::module &m) {
-
     py::module ax = m.def_submodule("axis");
 
     py::module opt = ax.def_submodule("options");
 
-    opt.attr("none") =      (unsigned) bh::axis::option::none;
-    opt.attr("underflow") = (unsigned) bh::axis::option::underflow;
-    opt.attr("overflow") =  (unsigned) bh::axis::option::overflow;
-    opt.attr("circular") =  (unsigned) bh::axis::option::circular;
-    opt.attr("growth") =    (unsigned) bh::axis::option::growth;
-    
+    opt.attr("none")      = (unsigned)bh::axis::option::none;
+    opt.attr("underflow") = (unsigned)bh::axis::option::underflow;
+    opt.attr("overflow")  = (unsigned)bh::axis::option::overflow;
+    opt.attr("circular")  = (unsigned)bh::axis::option::circular;
+    opt.attr("growth")    = (unsigned)bh::axis::option::growth;
+
     // This factory makes a class that can be used to create axes and also be used in is_instance
     py::object factory_meta_py = py::module::import("boost.histogram_utils").attr("FactoryMeta");
-    
+
     register_axis_by_type<axis::regular_uoflow>(ax, "regular_uoflow", "Evenly spaced bins")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
-    ;
+        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
 
     register_axis_iv_by_type<axis::regular_uoflow>(ax, "_regular_internal_view");
 
-
     register_axis_by_type<axis::regular_noflow>(ax, "regular_noflow", "Evenly spaced bins without over/under flow")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
-    ;
+        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::regular_noflow>(ax, "_regular_noflow_internal_view");
 
-
     register_axis_by_type<axis::regular_growth>(ax, "regular_growth", "Evenly spaced bins that grow as needed")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
-    ;
+        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::regular_growth>(ax, "_regular_growth_internal_view");
 
-    ax.def("make_regular",
-           [](unsigned n, double start, double stop, metadata_t metadata, bool flow, bool growth) -> py::object {
-               if(growth) {
-                   return py::cast(axis::regular_growth(n, start, stop, metadata), py::return_value_policy::move);
-               } else if(flow) {
-                   return py::cast(axis::regular_uoflow(n, start, stop, metadata), py::return_value_policy::move);
-               } else  {
-                   return py::cast(axis::regular_noflow(n, start, stop, metadata), py::return_value_policy::move);
-               }
-           },
-           "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str(), "flow"_a = true, "growth"_a = false,
-           "Make a regular axis with nice keyword arguments for flow and growth");
-    
-    ax.attr("regular") = factory_meta_py(ax.attr("make_regular"), py::make_tuple(ax.attr("regular_uoflow"),
-                                                                                 ax.attr("regular_noflow"),
-                                                                                 ax.attr("regular_growth")));
+    ax.def(
+        "make_regular",
+        [](unsigned n, double start, double stop, metadata_t metadata, bool flow, bool growth) -> py::object {
+            if(growth) {
+                return py::cast(axis::regular_growth(n, start, stop, metadata), py::return_value_policy::move);
+            } else if(flow) {
+                return py::cast(axis::regular_uoflow(n, start, stop, metadata), py::return_value_policy::move);
+            } else {
+                return py::cast(axis::regular_noflow(n, start, stop, metadata), py::return_value_policy::move);
+            }
+        },
+        "n"_a,
+        "start"_a,
+        "stop"_a,
+        "metadata"_a = py::str(),
+        "flow"_a     = true,
+        "growth"_a   = false,
+        "Make a regular axis with nice keyword arguments for flow and growth");
+
+    ax.attr("regular") = factory_meta_py(
+        ax.attr("make_regular"),
+        py::make_tuple(ax.attr("regular_uoflow"), ax.attr("regular_noflow"), ax.attr("regular_growth")));
 
     register_axis_by_type<axis::circular>(ax, "circular", "Evenly spaced bins with wraparound")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
-    .def(py::init([](unsigned n, double stop, metadata_t metadata){
-        return new axis::circular{n, 0.0, stop, metadata};
-    }), "n"_a, "stop"_a, "metadata"_a = py::str())
-    ;
+        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
+        .def(py::init([](unsigned n, double stop, metadata_t metadata) {
+                 return new axis::circular{n, 0.0, stop, metadata};
+             }),
+             "n"_a,
+             "stop"_a,
+             "metadata"_a = py::str());
     register_axis_iv_by_type<axis::circular>(ax, "_circular_internal_view");
 
-
     register_axis_by_type<axis::regular_log>(ax, "regular_log", "Evenly spaced bins in log10")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
-    ;
+        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::regular_log>(ax, "_regular_log_internal_view");
 
-
     register_axis_by_type<axis::regular_sqrt>(ax, "regular_sqrt", "Evenly spaced bins in sqrt")
-    .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
-    ;
+        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::regular_sqrt>(ax, "_regular_sqrt_internal_view");
 
-
     register_axis_by_type<axis::regular_pow>(ax, "regular_pow", "Evenly spaced bins in a power")
-    .def(py::init([](unsigned n, double start, double stop, double pow, metadata_t metadata){
-        return new axis::regular_pow(bh::axis::transform::pow{pow}, n, start, stop, metadata);} ),
-         "n"_a, "start"_a, "stop"_a, "power"_a, "metadata"_a = py::str())
-    ;
+        .def(py::init([](unsigned n, double start, double stop, double pow, metadata_t metadata) {
+                 return new axis::regular_pow(bh::axis::transform::pow{pow}, n, start, stop, metadata);
+             }),
+             "n"_a,
+             "start"_a,
+             "stop"_a,
+             "power"_a,
+             "metadata"_a = py::str());
     register_axis_iv_by_type<axis::regular_pow>(ax, "_regular_pow_internal_view");
 
-
     register_axis_by_type<axis::variable>(ax, "variable", "Unevenly spaced bins")
-    .def(py::init<std::vector<double>, metadata_t>(), "edges"_a, "metadata"_a = py::str())
-    ;
+        .def(py::init<std::vector<double>, metadata_t>(), "edges"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::variable>(ax, "_variable_internal_view");
 
-
     register_axis_by_type<axis::integer_uoflow>(ax, "integer_uoflow", "Contigious integers")
-    .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str())
-    ;
+        .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::integer_uoflow>(ax, "_integer_internal_view");
 
     register_axis_by_type<axis::integer_noflow>(ax, "integer_noflow", "Contigious integers with no under/overflow")
-    .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str())
-    ;
+        .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::integer_noflow>(ax, "_integer_noflow_internal_view");
 
     register_axis_by_type<axis::integer_growth>(ax, "integer_growth", "Contigious integers with growth")
-    .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str())
-    ;
+        .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::integer_growth>(ax, "_integer_integer_growth_internal_view");
 
     register_axis_by_type<axis::category_int>(ax, "category_int", "Text label bins")
-    .def(py::init<std::vector<int>, metadata_t>(), "labels"_a, "metadata"_a = py::str())
-    ;
-
+        .def(py::init<std::vector<int>, metadata_t>(), "labels"_a, "metadata"_a = py::str());
 
     register_axis_by_type<axis::category_int_growth>(ax, "category_int_growth", "Text label bins")
-    .def(py::init<std::vector<int>, metadata_t>(), "labels"_a, "metadata"_a = py::str())
-    .def(py::init<>())
-    ;
-
+        .def(py::init<std::vector<int>, metadata_t>(), "labels"_a, "metadata"_a = py::str())
+        .def(py::init<>());
 
     register_axis_by_type<axis::category_str>(ax, "category_str", "Text label bins")
-    .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "metadata"_a = py::str())
-    ;
-
+        .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "metadata"_a = py::str());
 
     register_axis_by_type<axis::category_str_growth>(ax, "category_str_growth", "Text label bins")
-    .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "metadata"_a = py::str())
-    // Add way to allow empty list of strings
-    .def(py::init<>())
-    ;
+        .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "metadata"_a = py::str())
+        // Add way to allow empty list of strings
+        .def(py::init<>());
 
     return ax;
 }

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -3,65 +3,58 @@
 // Distributed under the 3-Clause BSD License.  See accompanying
 // file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
 
-#include <boost/histogram/python/pybind11.hpp>
 #include <boost/histogram/python/kwargs.hpp>
+#include <boost/histogram/python/pybind11.hpp>
 #include <pybind11/operators.h>
 
 #include <boost/histogram/python/axis.hpp>
-#include <boost/histogram/python/storage.hpp>
 #include <boost/histogram/python/histogram.hpp>
-#include <boost/histogram/python/histogram_fill.hpp>
 #include <boost/histogram/python/histogram_atomic.hpp>
+#include <boost/histogram/python/histogram_fill.hpp>
 #include <boost/histogram/python/histogram_threaded.hpp>
 #include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/storage.hpp>
 
 #include <boost/histogram.hpp>
-#include <boost/histogram/axis/ostream.hpp>
-#include <boost/histogram/algorithm/sum.hpp>
-#include <boost/histogram/ostream.hpp>
 #include <boost/histogram/algorithm/project.hpp>
+#include <boost/histogram/algorithm/sum.hpp>
+#include <boost/histogram/axis/ostream.hpp>
+#include <boost/histogram/ostream.hpp>
 
 #include <boost/mp11.hpp>
 
-#include <vector>
 #include <sstream>
 #include <tuple>
+#include <vector>
 
-
-template<typename A, typename S>
-py::class_<bh::histogram<A, S>> register_histogram_by_type(py::module& m, const char* name, const char* desc) {
-
+template <typename A, typename S>
+py::class_<bh::histogram<A, S>> register_histogram_by_type(py::module &m, const char *name, const char *desc) {
     using histogram_t = bh::histogram<A, S>;
 
     py::class_<histogram_t> hist(m, name, desc, py::buffer_protocol());
 
-    hist
-    .def(py::init<const A&, S>(), "axes"_a, "storage"_a=S())
+    hist.def(py::init<const A &, S>(), "axes"_a, "storage"_a = S())
 
-    .def_buffer([](bh::histogram<A, S>& h) -> py::buffer_info
-        {return make_buffer(h, false);})
+        .def_buffer([](bh::histogram<A, S> &h) -> py::buffer_info { return make_buffer(h, false); })
 
-    .def("rank", &histogram_t::rank,
-         "Number of axes (dimensions) of histogram" )
-    .def("size", &histogram_t::size,
-         "Total number of bins in the histogram (including underflow/overflow)" )
-    .def("reset", &histogram_t::reset,
-         "Reset bin counters to zero")
-    
-    .def("__copy__", [](const histogram_t& self){return histogram_t(self);})
-    .def("__deepcopy__", [](const histogram_t& self, py::object memo){
-        histogram_t* a = new histogram_t(self);
-        py::module copy = py::module::import("copy");
-        for(unsigned i=0; i<a->rank(); i++) {
-            bh::unsafe_access::axis(*a, i).metadata() = copy.attr("deepcopy")(a->axis(i).metadata(), memo);
-        }
-        return a;
-    })
+        .def("rank", &histogram_t::rank, "Number of axes (dimensions) of histogram")
+        .def("size", &histogram_t::size, "Total number of bins in the histogram (including underflow/overflow)")
+        .def("reset", &histogram_t::reset, "Reset bin counters to zero")
 
-    .def(py::self + py::self)
-    .def(py::self == py::self)
-    .def(py::self != py::self)
-    ;
+        .def("__copy__", [](const histogram_t &self) { return histogram_t(self); })
+        .def("__deepcopy__",
+             [](const histogram_t &self, py::object memo) {
+                 histogram_t *a  = new histogram_t(self);
+                 py::module copy = py::module::import("copy");
+                 for(unsigned i = 0; i < a->rank(); i++) {
+                     bh::unsafe_access::axis(*a, i).metadata() = copy.attr("deepcopy")(a->axis(i).metadata(), memo);
+                 }
+                 return a;
+             })
+
+        .def(py::self + py::self)
+        .def(py::self == py::self)
+        .def(py::self != py::self);
 
     // Atomics for example do not support these operations
     def_optionally(hist, bh::detail::has_operator_rmul<histogram_t, double>{}, py::self *= double());
@@ -70,181 +63,191 @@ py::class_<bh::histogram<A, S>> register_histogram_by_type(py::module& m, const 
     def_optionally(hist, bh::detail::has_operator_rdiv<histogram_t, double>{}, py::self /= double());
     def_optionally(hist, bh::detail::has_operator_rdiv<histogram_t, double>{}, py::self / double());
 
-    hist.def("to_numpy", [](histogram_t& h, bool flow){
-        py::list listing;
+    hist.def(
+            "to_numpy",
+            [](histogram_t &h, bool flow) {
+                py::list listing;
 
-        // Add the histogram as the first argument
-        py::array arr(make_buffer(h, flow));
-        listing.append(arr);
+                // Add the histogram as the first argument
+                py::array arr(make_buffer(h, flow));
+                listing.append(arr);
 
-        // Add the axis edges
-        for(unsigned i=0; i<h.rank(); i++) {
-            const auto& ax = h.axis(i);
-            listing.append(axis_to_edges(ax, flow));
-        }
+                // Add the axis edges
+                for(unsigned i = 0; i < h.rank(); i++) {
+                    const auto &ax = h.axis(i);
+                    listing.append(axis_to_edges(ax, flow));
+                }
 
-        return py::cast<py::tuple>(listing);
-    },
-         "flow"_a = false, "convert to a numpy style tuple of returns")
+                return py::cast<py::tuple>(listing);
+            },
+            "flow"_a = false,
+            "convert to a numpy style tuple of returns")
 
-    .def("view", [](histogram_t& h, bool flow){
-        return py::array(make_buffer(h, flow));
-    }, "flow"_a = false,
-         "Return a view into the data, optionally with overflow turned on")
-    
-    .def("axis",
-        [](histogram_t &self, int i){
-            unsigned ii = i < 0 ? self.rank() - (unsigned) std::abs(i) : (unsigned) i;
-            if(ii < self.rank())
-                return self.axis(ii);
-            else
-                throw std::out_of_range("The axis value must be less than the rank");
-        },
-     "Get N-th axis with runtime index", "i"_a,
-         py::return_value_policy::move)
+        .def(
+            "view",
+            [](histogram_t &h, bool flow) { return py::array(make_buffer(h, flow)); },
+            "flow"_a = false,
+            "Return a view into the data, optionally with overflow turned on")
 
-    .def("at", [](histogram_t &self, py::args &args) {
-        // Optimize for no dynamic?
-        auto int_args = py::cast<std::vector<int>>(args);
-        return self.at(int_args);
-        },
-         "Access bin counter at indices")
+        .def(
+            "axis",
+            [](histogram_t &self, int i) {
+                unsigned ii = i < 0 ? self.rank() - (unsigned)std::abs(i) : (unsigned)i;
+                if(ii < self.rank())
+                    return self.axis(ii);
+                else
+                    throw std::out_of_range("The axis value must be less than the rank");
+            },
+            "Get N-th axis with runtime index",
+            "i"_a,
+            py::return_value_policy::move)
 
-    .def("__repr__", shift_to_string<histogram_t>())
-    
-    .def("sum", [](const histogram_t &self, bool flow) {
-        if(flow) {
-            return bh::algorithm::sum(self);
-        } else {
-            using T = typename bh::histogram<A, S>::value_type;
-            using AddType = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
-            using Sum = boost::mp11::mp_if<std::is_arithmetic<T>, bh::accumulators::sum<double>, T>;
-            Sum sum;
-            for (auto x : bh::indexed(self)) sum += (AddType) *x;
-            using R = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
-            return static_cast<R>(sum);
-        }
-    }, "flow"_a = false)
-    
-    /* Broken: Does not work if any string axes present (even just in variant)
-    .def("rebin", [](const histogram_t &self, unsigned axis, unsigned merge){
-        return bh::algorithm::reduce(self, bh::algorithm::rebin(axis, merge));
-    }, "axis"_a, "merge"_a, "Rebin by merging bins. You must select an axis.")
-    
-    .def("shrink", [](const histogram_t &self, unsigned axis, double lower, double upper){
-        return bh::algorithm::reduce(self, bh::algorithm::shrink(axis, lower, upper));
-    }, "axis"_a, "lower"_a, "upper"_a, "Shrink an axis. You must select an axis.")
-    
-    .def("shrink_and_rebin", [](const histogram_t &self, unsigned axis, double lower, double upper, unsigned merge){
-        return bh::algorithm::reduce(self, bh::algorithm::shrink_and_rebin(axis, lower, upper, merge));
-    }, "axis"_a, "lower"_a, "upper"_a, "merge"_a, "Shrink an axis and rebin. You must select an axis.")
-    */
-    
-    .def("project", [](const histogram_t &self, py::args values){
-        // If static
-        // histogram<any_axis> any = self;
-        return bh::algorithm::project(self, py::cast<std::vector<unsigned>>(values));
-    }, "Project to a single axis or several axes on a multidiminsional histogram")
-    
-    .def(make_pickle<histogram_t>())
-    
-    ;
-    
+        .def(
+            "at",
+            [](histogram_t &self, py::args &args) {
+                // Optimize for no dynamic?
+                auto int_args = py::cast<std::vector<int>>(args);
+                return self.at(int_args);
+            },
+            "Access bin counter at indices")
+
+        .def("__repr__", shift_to_string<histogram_t>())
+
+        .def(
+            "sum",
+            [](const histogram_t &self, bool flow) {
+                if(flow) {
+                    return bh::algorithm::sum(self);
+                } else {
+                    using T       = typename bh::histogram<A, S>::value_type;
+                    using AddType = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
+                    using Sum     = boost::mp11::mp_if<std::is_arithmetic<T>, bh::accumulators::sum<double>, T>;
+                    Sum sum;
+                    for(auto x : bh::indexed(self))
+                        sum += (AddType)*x;
+                    using R = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
+                    return static_cast<R>(sum);
+                }
+            },
+            "flow"_a = false)
+
+        /* Broken: Does not work if any string axes present (even just in variant)
+        .def("rebin", [](const histogram_t &self, unsigned axis, unsigned merge){
+            return bh::algorithm::reduce(self, bh::algorithm::rebin(axis, merge));
+        }, "axis"_a, "merge"_a, "Rebin by merging bins. You must select an axis.")
+
+        .def("shrink", [](const histogram_t &self, unsigned axis, double lower, double upper){
+            return bh::algorithm::reduce(self, bh::algorithm::shrink(axis, lower, upper));
+        }, "axis"_a, "lower"_a, "upper"_a, "Shrink an axis. You must select an axis.")
+
+        .def("shrink_and_rebin", [](const histogram_t &self, unsigned axis, double lower, double upper, unsigned merge){
+            return bh::algorithm::reduce(self, bh::algorithm::shrink_and_rebin(axis, lower, upper, merge));
+        }, "axis"_a, "lower"_a, "upper"_a, "merge"_a, "Shrink an axis and rebin. You must select an axis.")
+        */
+
+        .def(
+            "project",
+            [](const histogram_t &self, py::args values) {
+                // If static
+                // histogram<any_axis> any = self;
+                return bh::algorithm::project(self, py::cast<std::vector<unsigned>>(values));
+            },
+            "Project to a single axis or several axes on a multidiminsional histogram")
+
+        .def(make_pickle<histogram_t>())
+
+        ;
+
     add_fill(std::is_same<S, storage::atomic_int>{}, hist);
 
     return hist;
 }
 
 // Atomic fill supported?
-template<typename A, typename S >
-void add_fill(std::true_type, py::class_<bh::histogram<A, S>>& hist) {
+template <typename A, typename S>
+void add_fill(std::true_type, py::class_<bh::histogram<A, S>> &hist) {
     using histogram_t = bh::histogram<A, S>;
-    
+
     // generic threaded and atomic fill for 1 to N args
-    hist.def("fill",
-             [](histogram_t &self, py::args args, py::kwargs kwargs) {
-                 std::unique_ptr<size_t> threads = optional_arg<size_t>(kwargs, "threads");
-                 std::unique_ptr<size_t> atomic = optional_arg<size_t>(kwargs, "atomic");
-                 finalize_args(kwargs);
-                 
-                 if(threads && atomic)
-                     throw py::key_error("Cannot have both atomic and threads in one fill call!");
-                 else if(threads)
-                     boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(), fill_helper_threaded<histogram_t>(self, args, *threads));
-                 else if(atomic)
-                     boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(), fill_helper_atomic<histogram_t>(self, args, *atomic));
-                 else
-                     boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(), fill_helper<histogram_t>(self, args));
-                 
-             }, "Insert data into histogram in threads (0 for machine cores). Keyword arguments: threads=N, atomic=N (exclusive)");
+    hist.def(
+        "fill",
+        [](histogram_t &self, py::args args, py::kwargs kwargs) {
+            std::unique_ptr<size_t> threads = optional_arg<size_t>(kwargs, "threads");
+            std::unique_ptr<size_t> atomic  = optional_arg<size_t>(kwargs, "atomic");
+            finalize_args(kwargs);
+
+            if(threads && atomic)
+                throw py::key_error("Cannot have both atomic and threads in one fill call!");
+            else if(threads)
+                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(
+                    args.size(), fill_helper_threaded<histogram_t>(self, args, *threads));
+            else if(atomic)
+                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(
+                    args.size(), fill_helper_atomic<histogram_t>(self, args, *atomic));
+            else
+                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(),
+                                                                              fill_helper<histogram_t>(self, args));
+        },
+        "Insert data into histogram in threads (0 for machine cores). Keyword arguments: threads=N, atomic=N "
+        "(exclusive)");
 }
 
-template<typename A, typename S>
-void add_fill(std::false_type, py::class_<bh::histogram<A, S>>& hist) {
+template <typename A, typename S>
+void add_fill(std::false_type, py::class_<bh::histogram<A, S>> &hist) {
     using histogram_t = bh::histogram<A, S>;
-    
-    // generic threaded fill for 1 to N args
-    hist.def("fill",
-         [](histogram_t &self, py::args args, py::kwargs kwargs) {
-             std::unique_ptr<size_t> threads = optional_arg<size_t>(kwargs, "threads");
-             finalize_args(kwargs);
-             
-             if(threads)
-                 boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(), fill_helper_threaded<histogram_t>(self, args, *threads));
-             else
-                 boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(), fill_helper<histogram_t>(self, args));
-             
-         }, "Insert data into histogram in threads (0 for machine cores). Keyword argument: threads=N");
 
+    // generic threaded fill for 1 to N args
+    hist.def(
+        "fill",
+        [](histogram_t &self, py::args args, py::kwargs kwargs) {
+            std::unique_ptr<size_t> threads = optional_arg<size_t>(kwargs, "threads");
+            finalize_args(kwargs);
+
+            if(threads)
+                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(
+                    args.size(), fill_helper_threaded<histogram_t>(self, args, *threads));
+            else
+                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(),
+                                                                              fill_helper<histogram_t>(self, args));
+        },
+        "Insert data into histogram in threads (0 for machine cores). Keyword argument: threads=N");
 }
 
-
-py::module register_histogram(py::module& m) {
-    
+py::module register_histogram(py::module &m) {
     m.attr("BOOST_HISTOGRAM_DETAIL_AXES_LIMIT") = BOOST_HISTOGRAM_DETAIL_AXES_LIMIT;
-    
-    py::module hist = m.def_submodule("hist");
 
+    py::module hist = m.def_submodule("hist");
 
     // Fast specializations - uniform types
 
-    register_histogram_by_type<axes::regular, storage::unlimited>(hist,
-        "regular_unlimited",
-        "N-dimensional histogram for real-valued data.");
+    register_histogram_by_type<axes::regular, storage::unlimited>(
+        hist, "regular_unlimited", "N-dimensional histogram for real-valued data.");
 
-    register_histogram_by_type<axes::regular, storage::int_>(hist,
-        "regular_int",
-        "N-dimensional histogram for int-valued data.");
-    
-    auto regular_atomic_int = register_histogram_by_type<axes::regular, storage::atomic_int>(hist,
-        "regular_atomic_int",
-        "N-dimensional histogram for atomic int-valued data.");
+    register_histogram_by_type<axes::regular, storage::int_>(
+        hist, "regular_int", "N-dimensional histogram for int-valued data.");
 
-    register_histogram_by_type<axes::regular_noflow, storage::int_>(hist,
-        "regular_noflow_int",
-        "N-dimensional histogram for int-valued data.");
+    auto regular_atomic_int = register_histogram_by_type<axes::regular, storage::atomic_int>(
+        hist, "regular_atomic_int", "N-dimensional histogram for atomic int-valued data.");
+
+    register_histogram_by_type<axes::regular_noflow, storage::int_>(
+        hist, "regular_noflow_int", "N-dimensional histogram for int-valued data.");
 
     // Completely general histograms
 
-    register_histogram_by_type<axes::any, storage::int_>(hist,
-        "any_int",
-        "N-dimensional histogram for int-valued data with any axis types.");
-    
-    auto any_atomic_int = register_histogram_by_type<axes::any, storage::atomic_int>(hist,
-        "any_atomic_int",
-        "N-dimensional histogram for int-valued data with any axis types (threadsafe).");
+    register_histogram_by_type<axes::any, storage::int_>(
+        hist, "any_int", "N-dimensional histogram for int-valued data with any axis types.");
 
-    register_histogram_by_type<axes::any, storage::double_>(hist,
-        "any_double",
-        "N-dimensional histogram for real-valued data with weights with any axis types.");
+    auto any_atomic_int = register_histogram_by_type<axes::any, storage::atomic_int>(
+        hist, "any_atomic_int", "N-dimensional histogram for int-valued data with any axis types (threadsafe).");
 
-    register_histogram_by_type<axes::any, storage::unlimited>(hist,
-        "any_unlimited",
-        "N-dimensional histogram for unlimited size data with any axis types.");
+    register_histogram_by_type<axes::any, storage::double_>(
+        hist, "any_double", "N-dimensional histogram for real-valued data with weights with any axis types.");
 
-    register_histogram_by_type<axes::any, storage::weight>(hist,
-        "any_weight",
-        "N-dimensional histogram for weighted data with any axis types.");
+    register_histogram_by_type<axes::any, storage::unlimited>(
+        hist, "any_unlimited", "N-dimensional histogram for unlimited size data with any axis types.");
+
+    register_histogram_by_type<axes::any, storage::weight>(
+        hist, "any_weight", "N-dimensional histogram for weighted data with any axis types.");
 
     // Requieres sampled fills
     // register_histogram_by_type<axes::any, bh::profile_storage>(hist,
@@ -254,8 +257,6 @@ py::module register_histogram(py::module& m) {
     // register_histogram_by_type<axes::any, bh::weighted_profile_storage>(hist,
     //    "any_weighted_profile",
     //    "N-dimensional histogram for weighted and sampled data with any axis types.");
-    
+
     return hist;
-
 }
-

--- a/src/histogram/make_histogram.cpp
+++ b/src/histogram/make_histogram.cpp
@@ -6,10 +6,10 @@
 #include <boost/histogram/python/pybind11.hpp>
 #include <pybind11/operators.h>
 
+#include <boost/histogram/python/axis.hpp>
 #include <boost/histogram/python/histogram.hpp>
 #include <boost/histogram/python/storage.hpp>
 #include <boost/histogram/python/try_cast.hpp>
-#include <boost/histogram/python/axis.hpp>
 
 #include <boost/histogram.hpp>
 
@@ -17,56 +17,44 @@
 
 #include <vector>
 
-void register_make_histogram(py::module& m, py::module& hist) {
-    
-    
-    m.def("make_histogram", [](py::args args, py::kwargs kwargs) -> py::object {
-        
-        py::object storage = kwargs.contains("storage") ? kwargs["storage"] : py::cast(storage::int_());
-        
-        // We try each possible axes type that has high-performance single-type overloads.
-        
-        try {
-            return try_cast<
-            storage::int_,
-            storage::atomic_int,
-            storage::unlimited
-            >(storage, [&args](auto&& storage) {
-                auto reg = py::cast<axes::regular>(args);
-                return py::cast(bh::make_histogram_with(storage, reg),
-                                py::return_value_policy::move);
-            });
-        } catch(const py::cast_error&) {}
-        
-        try {
-            return try_cast<
-            storage::int_
-            >(storage, [&args](auto&& storage) {
-                auto reg = py::cast<axes::regular_noflow>(args);
-                return py::cast(bh::make_histogram_with(storage, reg),
-                                py::return_value_policy::move);
-            });
-        } catch(const py::cast_error&) {}
-        
-        // fallback to slower generic implementation
-        auto axes = py::cast<axes::any>(args);
-        
-        return try_cast<
-        storage::int_,
-        storage::double_,
-        storage::unlimited,
-        storage::weight,
-        storage::atomic_int
-        >(storage, [&axes](auto&& storage) {
-            return py::cast(bh::make_histogram_with(storage, axes),
-                            py::return_value_policy::move);
-        });
-        
-    }, "Make any histogram");
-    
+void register_make_histogram(py::module &m, py::module &hist) {
+    m.def(
+        "make_histogram",
+        [](py::args args, py::kwargs kwargs) -> py::object {
+            py::object storage = kwargs.contains("storage") ? kwargs["storage"] : py::cast(storage::int_());
+
+            // We try each possible axes type that has high-performance single-type overloads.
+
+            try {
+                return try_cast<storage::int_, storage::atomic_int, storage::unlimited>(
+                    storage, [&args](auto &&storage) {
+                        auto reg = py::cast<axes::regular>(args);
+                        return py::cast(bh::make_histogram_with(storage, reg), py::return_value_policy::move);
+                    });
+            } catch(const py::cast_error &) {
+            }
+
+            try {
+                return try_cast<storage::int_>(storage, [&args](auto &&storage) {
+                    auto reg = py::cast<axes::regular_noflow>(args);
+                    return py::cast(bh::make_histogram_with(storage, reg), py::return_value_policy::move);
+                });
+            } catch(const py::cast_error &) {
+            }
+
+            // fallback to slower generic implementation
+            auto axes = py::cast<axes::any>(args);
+
+            return try_cast<storage::int_, storage::double_, storage::unlimited, storage::weight, storage::atomic_int>(
+                storage, [&axes](auto &&storage) {
+                    return py::cast(bh::make_histogram_with(storage, axes), py::return_value_policy::move);
+                });
+        },
+        "Make any histogram");
+
     // This factory makes a class that can be used to create histograms and also be used in is_instance
     py::object factory_meta_py = py::module::import("boost.histogram_utils").attr("FactoryMeta");
-    
+
     m.attr("histogram") = factory_meta_py(m.attr("make_histogram"),
                                           py::make_tuple(hist.attr("regular_unlimited"),
                                                          hist.attr("regular_int"),
@@ -76,7 +64,5 @@ void register_make_histogram(py::module& m, py::module& hist) {
                                                          hist.attr("any_atomic_int"),
                                                          hist.attr("any_double"),
                                                          hist.attr("any_unlimited"),
-                                                         hist.attr("any_weight")
-                                                         ));
+                                                         hist.attr("any_weight")));
 }
-

--- a/src/histogram/storage.cpp
+++ b/src/histogram/storage.cpp
@@ -5,8 +5,8 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
-#include <boost/histogram/python/storage.hpp>
 #include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/storage.hpp>
 #include <pybind11/operators.h>
 
 #include <boost/histogram.hpp>
@@ -20,28 +20,24 @@
 #include <vector>
 
 /// Add helpers common to all storage types
-template<typename A, typename T>
-py::class_<A> register_storage_by_type(py::module& m, const char* name, const char* desc) {
+template <typename A, typename T>
+py::class_<A> register_storage_by_type(py::module &m, const char *name, const char *desc) {
     py::class_<A> storage(m, name, desc);
-    
-    storage
-    .def(py::init<>())
-    .def("__getitem__", [](A& self, size_t ind){return self.at(ind);})
-    .def("__setitem__", [](A& self, size_t ind, T val){self.at(ind) = val;})
-    .def("push_back", [](A& self, T val){self.push_back(val);})
-    .def(py::self == py::self)
-    .def(py::self != py::self)
-    .def(make_pickle<A>())
-    .def("__copy__", [](const A& self){return A(self);})
-    .def("__deepcopy__", [](const A& self, py::object){return A(self);})
-    ;
-    
+
+    storage.def(py::init<>())
+        .def("__getitem__", [](A &self, size_t ind) { return self.at(ind); })
+        .def("__setitem__", [](A &self, size_t ind, T val) { self.at(ind) = val; })
+        .def("push_back", [](A &self, T val) { self.push_back(val); })
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def(make_pickle<A>())
+        .def("__copy__", [](const A &self) { return A(self); })
+        .def("__deepcopy__", [](const A &self, py::object) { return A(self); });
+
     return storage;
 }
 
-
 py::module register_storage(py::module &m) {
-
     py::module storage = m.def_submodule("storage");
 
     // Fast storages
@@ -49,30 +45,25 @@ py::module register_storage(py::module &m) {
     register_storage_by_type<storage::int_, unsigned>(storage, "int", "Integers in vectors storage type");
 
     py::class_<storage::double_>(storage, "double", "Weighted storage without variance type (fast but simple)")
-    .def(py::init<>())
-    ;
+        .def(py::init<>());
 
     py::class_<storage::atomic_int>(storage, "atomic_int", "Threadsafe (not growing axis) integer storage")
-    .def(py::init<>())
-    ;
+        .def(py::init<>());
 
     // Default storages
 
     py::class_<storage::unlimited>(storage, "unlimited", "Optimized for unweighted histograms, adaptive")
-    .def(py::init<>())
-    ;
+        .def(py::init<>());
 
     py::class_<storage::weight>(storage, "weight", "Dense storage which tracks sums of weights and a variance estimate")
-    .def(py::init<>())
-    ;
+        .def(py::init<>());
 
     py::class_<storage::profile>(storage, "profile", "Dense storage which tracks means of samples in each cell")
-    .def(py::init<>())
-    ;
+        .def(py::init<>());
 
-    py::class_<storage::weighted_profile>(storage, "weighted_profile", "Dense storage which tracks means of weighted samples in each cell")
-    .def(py::init<>())
-    ;
+    py::class_<storage::weighted_profile>(
+        storage, "weighted_profile", "Dense storage which tracks means of weighted samples in each cell")
+        .def(py::init<>());
 
     return storage;
 }

--- a/src/histogram/version.cpp
+++ b/src/histogram/version.cpp
@@ -6,9 +6,7 @@
 #include <boost/histogram/python/pybind11.hpp>
 
 void register_version(py::module &m) {
-    
     py::module ver = py::module::import("boost.histogram_version");
-    
+
     m.attr("__version__") = ver.attr("__version__");
-    
 }


### PR DESCRIPTION
Add clang-format, and apply formatting. ~~This is not being checked yet by CI to keep PRs fast and simple.~~ Okay, yes, they are checked.

On a system with docker, run `scripts/check_style_docker.sh`, or run `scripts/check_style.sh` if you have a recent Clang-Format (5.0 is too old).