### PR TITLE
Axes types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,10 +119,26 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/boost/histogram_version.py"
     COPYONLY)
 
+
 # Tests (Requires pytest to be available to run)
 include(CTest)
 
 if(BUILD_TESTING)
+
+    # Support for running from build directory
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/pytest.ini"
+        "[pytest]\n"
+        "addopts = --benchmark-disable\n"
+        "testpaths = . ../tests\n"
+        )
+
+    # Support plain "pytest" in addition to "python -m pytest"
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/conftest.py"
+        "import os, sys\n"
+        "sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))\n"
+        )
+
+
     # Look for all the tests
     file(GLOB
         BOOST_HIST_PY_TESTS

--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -95,19 +95,32 @@ bool compare_axes_ne(const T &self, const T &other) {
 namespace axis {
 
 // These match the Python names
-using regular_uoflow      = bh::axis::regular<double, bh::use_default, metadata_t>;
-using regular_noflow      = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::none_t>;
-using regular_growth      = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::growth_t>;
-using circular            = bh::axis::circular<double, metadata_t>;
-using regular_log         = bh::axis::regular<double, bh::axis::transform::log, metadata_t>;
-using regular_sqrt        = bh::axis::regular<double, bh::axis::transform::sqrt, metadata_t>;
-using regular_pow         = bh::axis::regular<double, bh::axis::transform::pow, metadata_t>;
-using variable            = bh::axis::variable<double, metadata_t>;
-using integer_uoflow      = bh::axis::integer<int, metadata_t>;
-using integer_noflow      = bh::axis::integer<int, metadata_t, bh::axis::option::none_t>;
-using integer_growth      = bh::axis::integer<int, metadata_t, bh::axis::option::growth_t>;
+
+using regular_uoflow = bh::axis::regular<double, bh::use_default, metadata_t>;
+using regular_uflow  = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::underflow_t>;
+using regular_oflow  = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::overflow_t>;
+using regular_noflow = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::none_t>;
+using regular_growth = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::growth_t>;
+
+using circular     = bh::axis::circular<double, metadata_t>;
+using regular_log  = bh::axis::regular<double, bh::axis::transform::log, metadata_t>;
+using regular_sqrt = bh::axis::regular<double, bh::axis::transform::sqrt, metadata_t>;
+using regular_pow  = bh::axis::regular<double, bh::axis::transform::pow, metadata_t>;
+
+using variable_uoflow = bh::axis::variable<double, metadata_t>;
+using variable_uflow  = bh::axis::variable<double, metadata_t, bh::axis::option::underflow_t>;
+using variable_oflow  = bh::axis::variable<double, metadata_t, bh::axis::option::overflow_t>;
+using variable_noflow = bh::axis::variable<double, metadata_t, bh::axis::option::none_t>;
+
+using integer_uoflow = bh::axis::integer<int, metadata_t>;
+using integer_uflow  = bh::axis::integer<int, metadata_t, bh::axis::option::underflow_t>;
+using integer_oflow  = bh::axis::integer<int, metadata_t, bh::axis::option::overflow_t>;
+using integer_noflow = bh::axis::integer<int, metadata_t, bh::axis::option::none_t>;
+using integer_growth = bh::axis::integer<int, metadata_t, bh::axis::option::growth_t>;
+
 using category_int        = bh::axis::category<int, metadata_t>;
 using category_int_growth = bh::axis::category<int, metadata_t, bh::axis::option::growth_t>;
+
 using category_str        = bh::axis::category<std::string, metadata_t>;
 using category_str_growth = bh::axis::category<std::string, metadata_t, bh::axis::option::growth_t>;
 
@@ -117,14 +130,21 @@ namespace axes {
 
 // The following list is all types supported
 using any = std::vector<bh::axis::variant<axis::regular_uoflow,
+                                          axis::regular_uflow,
+                                          axis::regular_oflow,
                                           axis::regular_noflow,
                                           axis::regular_growth,
                                           axis::circular,
                                           axis::regular_log,
                                           axis::regular_pow,
                                           axis::regular_sqrt,
-                                          axis::variable,
+                                          axis::variable_uoflow,
+                                          axis::variable_oflow,
+                                          axis::variable_uflow,
+                                          axis::variable_noflow,
                                           axis::integer_uoflow,
+                                          axis::integer_oflow,
+                                          axis::integer_uflow,
                                           axis::integer_noflow,
                                           axis::integer_growth,
                                           axis::category_int,
@@ -133,9 +153,7 @@ using any = std::vector<bh::axis::variant<axis::regular_uoflow,
                                           axis::category_str_growth>>;
 
 // Specialization for some speed improvement
-using regular = std::vector<axis::regular_uoflow>;
-
-// Specialization for some speed improvement
+using regular_uoflow = std::vector<axis::regular_uoflow>;
 using regular_noflow = std::vector<axis::regular_noflow>;
 
 } // namespace axes

--- a/include/boost/histogram/python/pybind11.hpp
+++ b/include/boost/histogram/python/pybind11.hpp
@@ -3,9 +3,13 @@
 // Distributed under the 3-Clause BSD License.  See accompanying
 // file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
 
-// This file must be the first include
+// This file must be the first include (that is, it must be before stdlib or boost headers)
+// This reduces the warning output from Python.h and also lets us define s afew things
 
 #pragma once
+
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
+#define BOOST_MPL_LIMIT_LIST_SIZE 30
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>

--- a/include/boost/histogram/python/register_accumulator.hpp
+++ b/include/boost/histogram/python/register_accumulator.hpp
@@ -1,0 +1,30 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/python/pybind11.hpp>
+#include <pybind11/operators.h>
+
+#include <boost/histogram/python/pickle.hpp>
+
+#include <utility>
+
+template <typename A, typename... Args>
+py::class_<A> register_accumulator(py::module acc, Args &&... args) {
+    return py::class_<A>(acc, std::forward<Args>(args)...)
+        .def(py::init<>())
+
+        .def(py::self += py::self)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+
+        .def("__repr__", shift_to_string<A>())
+
+        .def("__copy__", [](const A &self) { return A(self); })
+        .def("__deepcopy__", [](const A &self, py::object) { return A(self); })
+
+        .def(make_pickle<A>());
+}

--- a/include/boost/histogram/python/register_axis.hpp
+++ b/include/boost/histogram/python/register_axis.hpp
@@ -27,29 +27,48 @@
 
 using namespace std::literals;
 
+/// Ensure metadata is valid.
+inline void validate_metadata(metadata_t v) {
+    try {
+        py::cast<double>(v);
+        throw py::type_error("Numeric types not allowed for metatdata in the the constructor. Use .metadata after "
+                             "constructing instead if you *really* need numeric metadata.");
+    } catch(const py::cast_error &) {
+    }
+}
+
+/// Add a constructor for an axes, with smart handling for the metadata (will not allow numeric types)"
+template <typename T, typename... Args>
+decltype(auto) construct_axes() {
+    return py::init([](Args... args, metadata_t v) {
+        // Check for numeric v here
+        validate_metadata(v);
+        return new T{std::forward<Args>(args)..., v};
+    });
+}
 
 /// Add helpers common to all types with a range of values
 template <typename A>
 py::class_<bh::axis::interval_view<A>> register_axis_iv(py::module &m, const char *name) {
     using A_iv               = bh::axis::interval_view<A>;
     py::class_<A_iv> axis_iv = py::class_<A_iv>(m, name, "Lightweight bin view");
-    
+
     axis_iv.def("upper", &A_iv::upper)
-    .def("lower", &A_iv::lower)
-    .def("center", &A_iv::center)
-    .def("width", &A_iv::width)
-    .def(py::self == py::self)
-    .def(py::self != py::self)
-    .def("__repr__", [](const A_iv &self) {
-        return "<bin ["s + std::to_string(self.lower()) + ", "s + std::to_string(self.upper()) + "]>"s;
-    });
-    
+        .def("lower", &A_iv::lower)
+        .def("center", &A_iv::center)
+        .def("width", &A_iv::width)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def("__repr__", [](const A_iv &self) {
+            return "<bin ["s + std::to_string(self.lower()) + ", "s + std::to_string(self.upper()) + "]>"s;
+        });
+
     return axis_iv;
 }
 
 /// Add items to an axis where the axis values are continious
 template <typename A, typename B>
-void add_to_axis(py::module m, const char* name, B &&axis, std::false_type) {
+void add_to_axis(py::module m, const char *name, B &&axis, std::false_type) {
     axis.def("bin", &A::bin, "The bin details (center, lower, upper)", "idx"_a, py::keep_alive<0, 1>());
     axis.def(
         "bins", [](const A &self, bool flow) { return axis_to_bins(self, flow); }, "flow"_a = false);
@@ -70,15 +89,15 @@ void add_to_axis(py::module m, const char* name, B &&axis, std::false_type) {
             return centers;
         },
         "Return the bin centers");
-    
+
     std::string name_iv = "_"s + name + "_iv"s;
-    
+
     register_axis_iv<A>(m, name_iv.c_str());
 }
 
 /// Add items to an axis where the axis values are not continious (categories of strings, for example)
 template <typename A, typename B>
-void add_to_axis(py::module, const char*, B &&axis, std::true_type) {
+void add_to_axis(py::module, const char *, B &&axis, std::true_type) {
     axis.def("bin", &A::bin, "The bin name", "idx"_a);
     axis.def(
         "bins", [](const A &self, bool flow) { return axis_to_bins(self, flow); }, "flow"_a = false);
@@ -89,7 +108,7 @@ void add_to_axis(py::module, const char*, B &&axis, std::true_type) {
 
 /// Add helpers common to all axis types
 template <typename A, typename... Args>
-py::class_<A> register_axis(py::module &m, const char* name, Args &&... args) {
+py::class_<A> register_axis(py::module &m, const char *name, Args &&... args) {
     py::class_<A> axis(m, name, std::forward<Args>(args)...);
 
     // using value_type = decltype(A::value(1.0));
@@ -137,11 +156,13 @@ py::class_<A> register_axis(py::module &m, const char* name, Args &&... args) {
     using Result = decltype(std::declval<A>().bin(std::declval<int>()));
 
     // This is a replacement for constexpr if
-    add_to_axis<A>(m, name,
-        axis, std::integral_constant < bool, std::is_reference<Result>::value || std::is_integral<Result>::value > {});
+    add_to_axis<A>(m,
+                   name,
+                   axis,
+                   std::integral_constant < bool,
+                   std::is_reference<Result>::value || std::is_integral<Result>::value > {});
 
     axis.def(make_pickle<A>());
 
     return axis;
 }
-

--- a/include/boost/histogram/python/register_axis.hpp
+++ b/include/boost/histogram/python/register_axis.hpp
@@ -27,9 +27,29 @@
 
 using namespace std::literals;
 
+
+/// Add helpers common to all types with a range of values
+template <typename A>
+py::class_<bh::axis::interval_view<A>> register_axis_iv(py::module &m, const char *name) {
+    using A_iv               = bh::axis::interval_view<A>;
+    py::class_<A_iv> axis_iv = py::class_<A_iv>(m, name, "Lightweight bin view");
+    
+    axis_iv.def("upper", &A_iv::upper)
+    .def("lower", &A_iv::lower)
+    .def("center", &A_iv::center)
+    .def("width", &A_iv::width)
+    .def(py::self == py::self)
+    .def(py::self != py::self)
+    .def("__repr__", [](const A_iv &self) {
+        return "<bin ["s + std::to_string(self.lower()) + ", "s + std::to_string(self.upper()) + "]>"s;
+    });
+    
+    return axis_iv;
+}
+
 /// Add items to an axis where the axis values are continious
 template <typename A, typename B>
-void add_to_axis(B &&axis, std::false_type) {
+void add_to_axis(py::module m, const char* name, B &&axis, std::false_type) {
     axis.def("bin", &A::bin, "The bin details (center, lower, upper)", "idx"_a, py::keep_alive<0, 1>());
     axis.def(
         "bins", [](const A &self, bool flow) { return axis_to_bins(self, flow); }, "flow"_a = false);
@@ -50,11 +70,15 @@ void add_to_axis(B &&axis, std::false_type) {
             return centers;
         },
         "Return the bin centers");
+    
+    std::string name_iv = "_"s + name + "_iv"s;
+    
+    register_axis_iv<A>(m, name_iv.c_str());
 }
 
 /// Add items to an axis where the axis values are not continious (categories of strings, for example)
 template <typename A, typename B>
-void add_to_axis(B &&axis, std::true_type) {
+void add_to_axis(py::module, const char*, B &&axis, std::true_type) {
     axis.def("bin", &A::bin, "The bin name", "idx"_a);
     axis.def(
         "bins", [](const A &self, bool flow) { return axis_to_bins(self, flow); }, "flow"_a = false);
@@ -65,8 +89,8 @@ void add_to_axis(B &&axis, std::true_type) {
 
 /// Add helpers common to all axis types
 template <typename A, typename... Args>
-py::class_<A> register_axis(py::module &m, Args &&... args) {
-    py::class_<A> axis(m, std::forward<Args>(args)...);
+py::class_<A> register_axis(py::module &m, const char* name, Args &&... args) {
+    py::class_<A> axis(m, name, std::forward<Args>(args)...);
 
     // using value_type = decltype(A::value(1.0));
 
@@ -113,7 +137,7 @@ py::class_<A> register_axis(py::module &m, Args &&... args) {
     using Result = decltype(std::declval<A>().bin(std::declval<int>()));
 
     // This is a replacement for constexpr if
-    add_to_axis<A>(
+    add_to_axis<A>(m, name,
         axis, std::integral_constant < bool, std::is_reference<Result>::value || std::is_integral<Result>::value > {});
 
     axis.def(make_pickle<A>());
@@ -121,21 +145,3 @@ py::class_<A> register_axis(py::module &m, Args &&... args) {
     return axis;
 }
 
-/// Add helpers common to all types with a range of values
-template <typename A>
-py::class_<bh::axis::interval_view<A>> register_axis_iv_by_type(py::module &m, const char *name) {
-    using A_iv               = bh::axis::interval_view<A>;
-    py::class_<A_iv> axis_iv = py::class_<A_iv>(m, name, "Lightweight bin view");
-
-    axis_iv.def("upper", &A_iv::upper)
-        .def("lower", &A_iv::lower)
-        .def("center", &A_iv::center)
-        .def("width", &A_iv::width)
-        .def(py::self == py::self)
-        .def(py::self != py::self)
-        .def("__repr__", [](const A_iv &self) {
-            return "<bin ["s + std::to_string(self.lower()) + ", "s + std::to_string(self.upper()) + "]>"s;
-        });
-
-    return axis_iv;
-}

--- a/include/boost/histogram/python/register_axis.hpp
+++ b/include/boost/histogram/python/register_axis.hpp
@@ -1,0 +1,141 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/python/pybind11.hpp>
+
+#include <pybind11/eval.h>
+#include <pybind11/numpy.h>
+#include <pybind11/operators.h>
+
+#include <boost/histogram/python/axis.hpp>
+#include <boost/histogram/python/pickle.hpp>
+
+#include <boost/histogram.hpp>
+#include <boost/histogram/axis/ostream.hpp>
+#include <boost/histogram/axis/traits.hpp>
+
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+using namespace std::literals;
+
+/// Add items to an axis where the axis values are continious
+template <typename A, typename B>
+void add_to_axis(B &&axis, std::false_type) {
+    axis.def("bin", &A::bin, "The bin details (center, lower, upper)", "idx"_a, py::keep_alive<0, 1>());
+    axis.def(
+        "bins", [](const A &self, bool flow) { return axis_to_bins(self, flow); }, "flow"_a = false);
+    axis.def("index", py::vectorize(&A::index), "The index at a point(s) on the axis", "x"_a);
+    axis.def("value", py::vectorize(&A::value), "The value(s) for a fractional bin(s) in the axis", "i"_a);
+
+    axis.def(
+        "edges",
+        [](const A &ax, bool flow) { return axis_to_edges(ax, flow); },
+        "flow"_a = false,
+        "The bin edges (length: bins + 1) (include over/underflow if flow=True)");
+
+    axis.def(
+        "centers",
+        [](const A &ax) {
+            py::array_t<double> centers((unsigned)ax.size());
+            std::transform(ax.begin(), ax.end(), centers.mutable_data(), [](const auto &bin) { return bin.center(); });
+            return centers;
+        },
+        "Return the bin centers");
+}
+
+/// Add items to an axis where the axis values are not continious (categories of strings, for example)
+template <typename A, typename B>
+void add_to_axis(B &&axis, std::true_type) {
+    axis.def("bin", &A::bin, "The bin name", "idx"_a);
+    axis.def(
+        "bins", [](const A &self, bool flow) { return axis_to_bins(self, flow); }, "flow"_a = false);
+    // Not that these really just don't work with string labels; they would work for numerical labels.
+    axis.def("index", &A::index, "The index at a point on the axis", "x"_a);
+    axis.def("value", &A::value, "The value for a fractional bin in the axis", "i"_a);
+}
+
+/// Add helpers common to all axis types
+template <typename A, typename... Args>
+py::class_<A> register_axis(py::module &m, Args &&... args) {
+    py::class_<A> axis(m, std::forward<Args>(args)...);
+
+    // using value_type = decltype(A::value(1.0));
+
+    axis.def("__repr__", shift_to_string<A>())
+
+        .def("__eq__", [](const A &self, const A &other) { return compare_axes_eq(self, other); })
+        .def("__ne__", [](const A &self, const A &other) { return compare_axes_ne(self, other); })
+
+        // Fall through for non-matching types
+        .def("__eq__", [](const A &, const py::object &) { return false; })
+        .def("__ne__", [](const A &, const py::object &) { return true; })
+
+        .def(
+            "size",
+            [](const A &self, bool flow) {
+                if(flow)
+                    return bh::axis::traits::extent(self);
+                else
+                    return self.size();
+            },
+            "flow"_a = false,
+            "Returns the number of bins, without over- or underflow unless flow=True")
+
+        .def("update", &A::update, "Bin and add a value if allowed", "i"_a)
+        .def_static("options", &A::options, "Return the options associated to the axis")
+        .def_property(
+            "metadata",
+            [](const A &self) { return self.metadata(); },
+            [](A &self, const metadata_t &label) { self.metadata() = label; },
+            "Set the axis label")
+
+        .def("__copy__", [](const A &self) { return A(self); })
+        .def("__deepcopy__",
+             [](const A &self, py::object memo) {
+                 A *a            = new A(self);
+                 py::module copy = py::module::import("copy");
+                 a->metadata()   = copy.attr("deepcopy")(a->metadata(), memo);
+                 return a;
+             })
+
+        ;
+
+    // We only need keepalive if this is a reference.
+    using Result = decltype(std::declval<A>().bin(std::declval<int>()));
+
+    // This is a replacement for constexpr if
+    add_to_axis<A>(
+        axis, std::integral_constant < bool, std::is_reference<Result>::value || std::is_integral<Result>::value > {});
+
+    axis.def(make_pickle<A>());
+
+    return axis;
+}
+
+/// Add helpers common to all types with a range of values
+template <typename A>
+py::class_<bh::axis::interval_view<A>> register_axis_iv_by_type(py::module &m, const char *name) {
+    using A_iv               = bh::axis::interval_view<A>;
+    py::class_<A_iv> axis_iv = py::class_<A_iv>(m, name, "Lightweight bin view");
+
+    axis_iv.def("upper", &A_iv::upper)
+        .def("lower", &A_iv::lower)
+        .def("center", &A_iv::center)
+        .def("width", &A_iv::width)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def("__repr__", [](const A_iv &self) {
+            return "<bin ["s + std::to_string(self.lower()) + ", "s + std::to_string(self.upper()) + "]>"s;
+        });
+
+    return axis_iv;
+}

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -1,0 +1,244 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/python/kwargs.hpp>
+#include <boost/histogram/python/pybind11.hpp>
+#include <pybind11/operators.h>
+
+#include <boost/histogram/python/axis.hpp>
+#include <boost/histogram/python/histogram.hpp>
+#include <boost/histogram/python/histogram_atomic.hpp>
+#include <boost/histogram/python/histogram_fill.hpp>
+#include <boost/histogram/python/histogram_threaded.hpp>
+#include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/storage.hpp>
+
+#include <boost/histogram.hpp>
+#include <boost/histogram/algorithm/project.hpp>
+#include <boost/histogram/algorithm/sum.hpp>
+#include <boost/histogram/axis/ostream.hpp>
+#include <boost/histogram/ostream.hpp>
+#include <boost/histogram/unsafe_access.hpp>
+
+#include <boost/mp11.hpp>
+
+#include <sstream>
+#include <tuple>
+#include <vector>
+
+template <typename A, typename S>
+py::class_<bh::histogram<A, S>> register_histogram(py::module &m, const char *name, const char *desc) {
+    using histogram_t = bh::histogram<A, S>;
+
+    py::class_<histogram_t> hist(m, name, desc, py::buffer_protocol());
+
+    hist.def(py::init<const A &, S>(), "axes"_a, "storage"_a = S())
+
+        .def_buffer([](bh::histogram<A, S> &h) -> py::buffer_info { return make_buffer(h, false); })
+
+        .def("rank", &histogram_t::rank, "Number of axes (dimensions) of histogram")
+        .def("size", &histogram_t::size, "Total number of bins in the histogram (including underflow/overflow)")
+        .def("reset", &histogram_t::reset, "Reset bin counters to zero")
+
+        .def("__copy__", [](const histogram_t &self) { return histogram_t(self); })
+        .def("__deepcopy__",
+             [](const histogram_t &self, py::object memo) {
+                 histogram_t *a  = new histogram_t(self);
+                 py::module copy = py::module::import("copy");
+                 for(unsigned i = 0; i < a->rank(); i++) {
+                     bh::unsafe_access::axis(*a, i).metadata() = copy.attr("deepcopy")(a->axis(i).metadata(), memo);
+                 }
+                 return a;
+             })
+
+        .def(py::self + py::self)
+
+        .def("__eq__",
+             [](const histogram_t &self, const histogram_t &other) {
+                 if(self.rank() != other.rank())
+                     return false;
+
+                 for(unsigned i = 0; i < self.rank(); i++)
+                     if(!compare_axes_eq(self.axis(i), other.axis(i)))
+                         return false;
+
+                 return bh::unsafe_access::storage(self) == bh::unsafe_access::storage(other);
+             })
+        .def("__ne__",
+             [](const histogram_t &self, const histogram_t &other) {
+                 if(self.rank() != other.rank())
+                     return true;
+
+                 for(unsigned i = 0; i < self.rank(); i++)
+                     if(compare_axes_ne(self.axis(i), other.axis(i)))
+                         return true;
+
+                 return !(bh::unsafe_access::storage(self) == bh::unsafe_access::storage(other));
+             })
+
+        // Fall through for non-matching types
+        .def("__eq__", [](const histogram_t &, const py::object &) { return false; })
+        .def("__ne__", [](const histogram_t &, const py::object &) { return true; })
+
+        ;
+
+    // Atomics for example do not support these operations
+    def_optionally(hist, bh::detail::has_operator_rmul<histogram_t, double>{}, py::self *= double());
+    def_optionally(hist, bh::detail::has_operator_rmul<histogram_t, double>{}, py::self * double());
+    def_optionally(hist, bh::detail::has_operator_rmul<histogram_t, double>{}, double() * py::self);
+    def_optionally(hist, bh::detail::has_operator_rdiv<histogram_t, double>{}, py::self /= double());
+    def_optionally(hist, bh::detail::has_operator_rdiv<histogram_t, double>{}, py::self / double());
+
+    hist.def(
+            "to_numpy",
+            [](histogram_t &h, bool flow) {
+                py::list listing;
+
+                // Add the histogram as the first argument
+                py::array arr(make_buffer(h, flow));
+                listing.append(arr);
+
+                // Add the axis edges
+                for(unsigned i = 0; i < h.rank(); i++) {
+                    const auto &ax = h.axis(i);
+                    listing.append(axis_to_edges(ax, flow));
+                }
+
+                return py::cast<py::tuple>(listing);
+            },
+            "flow"_a = false,
+            "convert to a numpy style tuple of returns")
+
+        .def(
+            "view",
+            [](histogram_t &h, bool flow) { return py::array(make_buffer(h, flow)); },
+            "flow"_a = false,
+            "Return a view into the data, optionally with overflow turned on")
+
+        .def(
+            "axis",
+            [](histogram_t &self, int i) {
+                unsigned ii = i < 0 ? self.rank() - (unsigned)std::abs(i) : (unsigned)i;
+                if(ii < self.rank())
+                    return self.axis(ii);
+                else
+                    throw std::out_of_range("The axis value must be less than the rank");
+            },
+            "Get N-th axis with runtime index",
+            "i"_a,
+            py::return_value_policy::move)
+
+        .def(
+            "at",
+            [](histogram_t &self, py::args &args) {
+                // Optimize for no dynamic?
+                auto int_args = py::cast<std::vector<int>>(args);
+                return self.at(int_args);
+            },
+            "Access bin counter at indices")
+
+        .def("__repr__", shift_to_string<histogram_t>())
+
+        .def(
+            "sum",
+            [](const histogram_t &self, bool flow) {
+                if(flow) {
+                    return bh::algorithm::sum(self);
+                } else {
+                    using T       = typename bh::histogram<A, S>::value_type;
+                    using AddType = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
+                    using Sum     = boost::mp11::mp_if<std::is_arithmetic<T>, bh::accumulators::sum<double>, T>;
+                    Sum sum;
+                    for(auto x : bh::indexed(self))
+                        sum += (AddType)*x;
+                    using R = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
+                    return static_cast<R>(sum);
+                }
+            },
+            "flow"_a = false)
+
+        /* Broken: Does not work if any string axes present (even just in variant)
+         .def("rebin", [](const histogram_t &self, unsigned axis, unsigned merge){
+         return bh::algorithm::reduce(self, bh::algorithm::rebin(axis, merge));
+         }, "axis"_a, "merge"_a, "Rebin by merging bins. You must select an axis.")
+
+         .def("shrink", [](const histogram_t &self, unsigned axis, double lower, double upper){
+         return bh::algorithm::reduce(self, bh::algorithm::shrink(axis, lower, upper));
+         }, "axis"_a, "lower"_a, "upper"_a, "Shrink an axis. You must select an axis.")
+
+         .def("shrink_and_rebin", [](const histogram_t &self, unsigned axis, double lower, double upper, unsigned
+         merge){ return bh::algorithm::reduce(self, bh::algorithm::shrink_and_rebin(axis, lower, upper, merge));
+         }, "axis"_a, "lower"_a, "upper"_a, "merge"_a, "Shrink an axis and rebin. You must select an axis.")
+         */
+
+        .def(
+            "project",
+            [](const histogram_t &self, py::args values) {
+                // If static
+                // histogram<any_axis> any = self;
+                return bh::algorithm::project(self, py::cast<std::vector<unsigned>>(values));
+            },
+            "Project to a single axis or several axes on a multidiminsional histogram")
+
+        .def(make_pickle<histogram_t>())
+
+        ;
+
+    add_fill(std::is_same<S, storage::atomic_int>{}, hist);
+
+    return hist;
+}
+
+// Atomic fill supported?
+template <typename A, typename S>
+void add_fill(std::true_type, py::class_<bh::histogram<A, S>> &hist) {
+    using histogram_t = bh::histogram<A, S>;
+
+    // generic threaded and atomic fill for 1 to N args
+    hist.def(
+        "fill",
+        [](histogram_t &self, py::args args, py::kwargs kwargs) {
+            std::unique_ptr<size_t> threads = optional_arg<size_t>(kwargs, "threads");
+            std::unique_ptr<size_t> atomic  = optional_arg<size_t>(kwargs, "atomic");
+            finalize_args(kwargs);
+
+            if(threads && atomic)
+                throw py::key_error("Cannot have both atomic and threads in one fill call!");
+            else if(threads)
+                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(
+                    args.size(), fill_helper_threaded<histogram_t>(self, args, *threads));
+            else if(atomic)
+                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(
+                    args.size(), fill_helper_atomic<histogram_t>(self, args, *atomic));
+            else
+                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(),
+                                                                              fill_helper<histogram_t>(self, args));
+        },
+        "Insert data into histogram in threads (0 for machine cores). Keyword arguments: threads=N, atomic=N "
+        "(exclusive)");
+}
+
+template <typename A, typename S>
+void add_fill(std::false_type, py::class_<bh::histogram<A, S>> &hist) {
+    using histogram_t = bh::histogram<A, S>;
+
+    // generic threaded fill for 1 to N args
+    hist.def(
+        "fill",
+        [](histogram_t &self, py::args args, py::kwargs kwargs) {
+            std::unique_ptr<size_t> threads = optional_arg<size_t>(kwargs, "threads");
+            finalize_args(kwargs);
+
+            if(threads)
+                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(
+                    args.size(), fill_helper_threaded<histogram_t>(self, args, *threads));
+            else
+                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(),
+                                                                              fill_helper<histogram_t>(self, args));
+        },
+        "Insert data into histogram in threads (0 for machine cores). Keyword argument: threads=N");
+}

--- a/include/boost/histogram/python/register_storage.hpp
+++ b/include/boost/histogram/python/register_storage.hpp
@@ -11,17 +11,42 @@
 #include <boost/histogram/python/storage.hpp>
 #include <pybind11/operators.h>
 
+#include <type_traits>
+
 /// Add helpers common to all storage types
-template <typename A, typename T>
+template <typename A>
 py::class_<A> register_storage(py::module &m, const char *name, const char *desc) {
+    using value_type = typename A::value_type;
+
     py::class_<A> storage(m, name, desc);
 
     storage.def(py::init<>())
         .def("__getitem__", [](A &self, size_t ind) { return self.at(ind); })
-        .def("__setitem__", [](A &self, size_t ind, T val) { self.at(ind) = val; })
-        .def("push_back", [](A &self, T val) { self.push_back(val); })
+        .def("__setitem__", [](A &self, size_t ind, value_type val) { self.at(ind) = val; })
+        .def("push_back", [](A &self, value_type val) { self.push_back(val); })
         .def(py::self == py::self)
         .def(py::self != py::self)
+        .def(make_pickle<A>())
+        .def("__copy__", [](const A &self) { return A(self); })
+        .def("__deepcopy__", [](const A &self, py::object) { return A(self); });
+
+    return storage;
+}
+
+/// Add helpers to the unlimited storage type
+template <>
+py::class_<storage::unlimited> register_storage(py::module &m, const char *name, const char *desc) {
+    using A = storage::unlimited; // match code above
+
+    using value_type = A::value_type;
+
+    py::class_<A> storage(m, name, desc);
+
+    storage.def(py::init<>())
+        .def("__getitem__", [](A &self, size_t ind) { return self[ind]; })
+        .def("__setitem__", [](A &self, size_t ind, value_type val) { self[ind] = val; })
+        .def(py::self == py::self)
+        .def("__ne__", [](const A &a, const A &b) { return !(a == b); })
         .def(make_pickle<A>())
         .def("__copy__", [](const A &self) { return A(self); })
         .def("__deepcopy__", [](const A &self, py::object) { return A(self); });

--- a/include/boost/histogram/python/register_storage.hpp
+++ b/include/boost/histogram/python/register_storage.hpp
@@ -1,0 +1,30 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/python/pybind11.hpp>
+
+#include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/storage.hpp>
+#include <pybind11/operators.h>
+
+/// Add helpers common to all storage types
+template <typename A, typename T>
+py::class_<A> register_storage(py::module &m, const char *name, const char *desc) {
+    py::class_<A> storage(m, name, desc);
+
+    storage.def(py::init<>())
+        .def("__getitem__", [](A &self, size_t ind) { return self.at(ind); })
+        .def("__setitem__", [](A &self, size_t ind, T val) { self.at(ind) = val; })
+        .def("push_back", [](A &self, T val) { self.push_back(val); })
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def(make_pickle<A>())
+        .def("__copy__", [](const A &self) { return A(self); })
+        .def("__deepcopy__", [](const A &self, py::object) { return A(self); });
+
+    return storage;
+}

--- a/src/histogram/accumulators.cpp
+++ b/src/histogram/accumulators.cpp
@@ -6,7 +6,7 @@
 #include <boost/histogram/python/pybind11.hpp>
 #include <pybind11/operators.h>
 
-#include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/register_accumulator.hpp>
 
 #include <boost/histogram.hpp>
 #include <boost/histogram/accumulators/mean.hpp>
@@ -15,29 +15,12 @@
 #include <boost/histogram/accumulators/weighted_mean.hpp>
 #include <boost/histogram/accumulators/weighted_sum.hpp>
 
-template <typename A, typename... Args>
-py::class_<A> add_accumulator(py::module acc, Args &&... args) {
-    return py::class_<A>(acc, std::forward<Args>(args)...)
-        .def(py::init<>())
-
-        .def(py::self += py::self)
-        .def(py::self == py::self)
-        .def(py::self != py::self)
-
-        .def("__repr__", shift_to_string<A>())
-
-        .def("__copy__", [](const A &self) { return A(self); })
-        .def("__deepcopy__", [](const A &self, py::object) { return A(self); })
-
-        .def(make_pickle<A>());
-}
-
 py::module register_accumulators(py::module &m) {
     py::module accumulators = m.def_submodule("accumulators");
 
     using weighted_sum = bh::accumulators::weighted_sum<double>;
 
-    add_accumulator<weighted_sum>(accumulators, "weighted_sum")
+    register_accumulator<weighted_sum>(accumulators, "weighted_sum")
         .def(py::init<const double &>(), "value"_a)
         .def(py::init<const double &, const double &>(), "value"_a, "variance"_a)
 
@@ -65,7 +48,7 @@ py::module register_accumulators(py::module &m) {
 
     using weighted_mean = bh::accumulators::weighted_mean<double>;
 
-    add_accumulator<weighted_mean>(accumulators, "weighted_mean")
+    register_accumulator<weighted_mean>(accumulators, "weighted_mean")
         .def(py::init<const double &, const double &, const double &, const double &>(),
              "wsum"_a,
              "wsum2"_a,
@@ -96,7 +79,7 @@ py::module register_accumulators(py::module &m) {
 
     using mean = bh::accumulators::mean<double>;
 
-    add_accumulator<mean>(accumulators, "mean")
+    register_accumulator<mean>(accumulators, "mean")
         .def(py::init<std::size_t, const double &, const double &>(), "value"_a, "mean"_a, "variance"_a)
 
         .def_property_readonly("count", &mean::count)
@@ -114,7 +97,7 @@ py::module register_accumulators(py::module &m) {
 
     using sum = bh::accumulators::sum<double>;
 
-    add_accumulator<sum>(accumulators, "sum")
+    register_accumulator<sum>(accumulators, "sum")
         .def(py::init<const double &>(), "value"_a)
 
         .def_property(

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -6,6 +6,7 @@
 #include <boost/histogram/python/pybind11.hpp>
 
 #include <boost/histogram/python/axis.hpp>
+#include <boost/histogram/python/kwargs.hpp>
 #include <boost/histogram/python/register_axis.hpp>
 
 #include <vector>
@@ -31,6 +32,20 @@ py::module register_axes(py::module &m) {
              "stop"_a,
              "metadata"_a = py::str());
 
+    register_axis<axis::regular_uflow>(ax, "regular_uflow", "Evenly spaced bins with underflow")
+        .def(construct_axes<axis::regular_uflow, unsigned, double, double>(),
+             "n"_a,
+             "start"_a,
+             "stop"_a,
+             "metadata"_a = py::str());
+
+    register_axis<axis::regular_oflow>(ax, "regular_oflow", "Evenly spaced bins with overflow ")
+        .def(construct_axes<axis::regular_oflow, unsigned, double, double>(),
+             "n"_a,
+             "start"_a,
+             "stop"_a,
+             "metadata"_a = py::str());
+
     register_axis<axis::regular_noflow>(ax, "regular_noflow", "Evenly spaced bins without over/under flow")
         .def(construct_axes<axis::regular_noflow, unsigned, double, double>(),
              "n"_a,
@@ -47,13 +62,33 @@ py::module register_axes(py::module &m) {
 
     ax.def(
         "make_regular",
-        [](unsigned n, double start, double stop, metadata_t metadata, bool flow, bool growth) -> py::object {
+        [](unsigned n,
+           double start,
+           double stop,
+           metadata_t metadata,
+           bool underflow,
+           bool overflow,
+           bool growth,
+           py::kwargs kwargs) -> py::object {
             validate_metadata(metadata);
+
+            std::unique_ptr<bool> flow = optional_arg<bool>(kwargs, "flow");
+            finalize_args(kwargs);
+
+            // Allow "flow" to override
+            if(flow) {
+                underflow = *flow;
+                overflow  = *flow;
+            }
 
             if(growth) {
                 return py::cast(axis::regular_growth(n, start, stop, metadata), py::return_value_policy::move);
-            } else if(flow) {
+            } else if(underflow && overflow) {
                 return py::cast(axis::regular_uoflow(n, start, stop, metadata), py::return_value_policy::move);
+            } else if(underflow && !overflow) {
+                return py::cast(axis::regular_uflow(n, start, stop, metadata), py::return_value_policy::move);
+            } else if(!underflow && overflow) {
+                return py::cast(axis::regular_oflow(n, start, stop, metadata), py::return_value_policy::move);
             } else {
                 return py::cast(axis::regular_noflow(n, start, stop, metadata), py::return_value_policy::move);
             }
@@ -61,14 +96,19 @@ py::module register_axes(py::module &m) {
         "n"_a,
         "start"_a,
         "stop"_a,
-        "metadata"_a = py::str(),
-        "flow"_a     = true,
-        "growth"_a   = false,
-        "Make a regular axis with nice keyword arguments for flow and growth");
+        "metadata"_a  = py::str(),
+        "underflow"_a = true,
+        "overflow"_a  = true,
+        "growth"_a    = false,
+        "Make a regular axis with nice keyword arguments for underflow, overflow, and growth. "
+        "Passing 'flow' will override underflow and overflow at the same time.");
 
-    ax.attr("regular") = factory_meta_py(
-        ax.attr("make_regular"),
-        py::make_tuple(ax.attr("regular_uoflow"), ax.attr("regular_noflow"), ax.attr("regular_growth")));
+    ax.attr("regular") = factory_meta_py(ax.attr("make_regular"),
+                                         py::make_tuple(ax.attr("regular_uoflow"),
+                                                        ax.attr("regular_uflow"),
+                                                        ax.attr("regular_oflow"),
+                                                        ax.attr("regular_noflow"),
+                                                        ax.attr("regular_growth")));
 
     register_axis<axis::circular>(ax, "circular", "Evenly spaced bins with wraparound")
         .def(construct_axes<axis::circular, unsigned, double, double>(),
@@ -109,17 +149,113 @@ py::module register_axes(py::module &m) {
              "power"_a,
              "metadata"_a = py::str());
 
-    register_axis<axis::variable>(ax, "variable", "Unevenly spaced bins")
-        .def(construct_axes<axis::variable, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
+    register_axis<axis::variable_uoflow>(ax, "variable_uoflow", "Unevenly spaced bins")
+        .def(construct_axes<axis::variable_uoflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
+
+    register_axis<axis::variable_uflow>(ax, "variable_uflow", "Unevenly spaced bins with underflow")
+        .def(construct_axes<axis::variable_uflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
+
+    register_axis<axis::variable_oflow>(ax, "variable_oflow", "Unevenly spaced bins with overflow")
+        .def(construct_axes<axis::variable_oflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
+
+    register_axis<axis::variable_noflow>(ax, "variable_noflow", "Unevenly spaced bins without under/overflow")
+        .def(construct_axes<axis::variable_noflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
+
+    ax.def(
+        "make_variable",
+        [](std::vector<double> edges, metadata_t metadata, bool underflow, bool overflow, py::kwargs kwargs)
+            -> py::object {
+            validate_metadata(metadata);
+
+            std::unique_ptr<bool> flow = optional_arg<bool>(kwargs, "flow");
+            finalize_args(kwargs);
+
+            // Allow "flow" to override
+            if(flow) {
+                underflow = *flow;
+                overflow  = *flow;
+            }
+
+            if(underflow && overflow) {
+                return py::cast(axis::variable_uoflow(edges, metadata), py::return_value_policy::move);
+            } else if(underflow && !overflow) {
+                return py::cast(axis::variable_uflow(edges, metadata), py::return_value_policy::move);
+            } else if(!underflow && overflow) {
+                return py::cast(axis::variable_oflow(edges, metadata), py::return_value_policy::move);
+            } else {
+                return py::cast(axis::variable_noflow(edges, metadata), py::return_value_policy::move);
+            }
+        },
+        "edges"_a,
+        "metadata"_a  = py::str(),
+        "underflow"_a = true,
+        "overflow"_a  = true,
+        "Make a variable binned axis with nice keyword arguments for underflow, overflow. "
+        "Passing 'flow' will override underflow and overflow at the same time.");
+
+    ax.attr("variable") = factory_meta_py(ax.attr("make_variable"),
+                                          py::make_tuple(ax.attr("variable_uoflow"),
+                                                         ax.attr("variable_uflow"),
+                                                         ax.attr("variable_oflow"),
+                                                         ax.attr("variable_noflow")));
 
     register_axis<axis::integer_uoflow>(ax, "integer_uoflow", "Contigious integers")
         .def(construct_axes<axis::integer_uoflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
+
+    register_axis<axis::integer_uflow>(ax, "integer_uflow", "Contigious integers with underflow")
+        .def(construct_axes<axis::integer_uflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
+
+    register_axis<axis::integer_oflow>(ax, "integer_oflow", "Contigious integers with overflow")
+        .def(construct_axes<axis::integer_oflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
 
     register_axis<axis::integer_noflow>(ax, "integer_noflow", "Contigious integers with no under/overflow")
         .def(construct_axes<axis::integer_noflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
 
     register_axis<axis::integer_growth>(ax, "integer_growth", "Contigious integers with growth")
         .def(construct_axes<axis::integer_growth, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
+
+    ax.def(
+        "make_integer",
+        [](int start, int stop, metadata_t metadata, bool underflow, bool overflow, bool growth, py::kwargs kwargs)
+            -> py::object {
+            validate_metadata(metadata);
+
+            std::unique_ptr<bool> flow = optional_arg<bool>(kwargs, "flow");
+            finalize_args(kwargs);
+
+            // Allow "flow" to override
+            if(flow) {
+                underflow = *flow;
+                overflow  = *flow;
+            }
+
+            if(growth) {
+                return py::cast(axis::integer_growth(start, stop, metadata), py::return_value_policy::move);
+            } else if(underflow && overflow) {
+                return py::cast(axis::integer_uoflow(start, stop, metadata), py::return_value_policy::move);
+            } else if(underflow && !overflow) {
+                return py::cast(axis::integer_uflow(start, stop, metadata), py::return_value_policy::move);
+            } else if(!underflow && overflow) {
+                return py::cast(axis::integer_oflow(start, stop, metadata), py::return_value_policy::move);
+            } else {
+                return py::cast(axis::integer_noflow(start, stop, metadata), py::return_value_policy::move);
+            }
+        },
+        "start"_a,
+        "stop"_a,
+        "metadata"_a  = py::str(),
+        "underflow"_a = true,
+        "overflow"_a  = true,
+        "growth"_a    = false,
+        "Make an integer axis with nice keyword arguments for underflow, overflow, and growth. "
+        "Passing 'flow' will override underflow and overflow at the same time.");
+
+    ax.attr("integer") = factory_meta_py(ax.attr("make_integer"),
+                                         py::make_tuple(ax.attr("integer_uoflow"),
+                                                        ax.attr("integer_uflow"),
+                                                        ax.attr("integer_oflow"),
+                                                        ax.attr("integer_noflow"),
+                                                        ax.attr("integer_growth")));
 
     register_axis<axis::category_int>(ax, "category_int", "Text label bins")
         .def(construct_axes<axis::category_int, std::vector<int>>(), "labels"_a, "metadata"_a = py::str());

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -26,17 +26,13 @@ py::module register_axes(py::module &m) {
 
     register_axis<axis::regular_uoflow>(ax, "regular_uoflow", "Evenly spaced bins")
         .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
-
-    register_axis_iv_by_type<axis::regular_uoflow>(ax, "_regular_internal_view");
-
+    
     register_axis<axis::regular_noflow>(ax, "regular_noflow", "Evenly spaced bins without over/under flow")
         .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
-    register_axis_iv_by_type<axis::regular_noflow>(ax, "_regular_noflow_internal_view");
-
+    
     register_axis<axis::regular_growth>(ax, "regular_growth", "Evenly spaced bins that grow as needed")
         .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
-    register_axis_iv_by_type<axis::regular_growth>(ax, "_regular_growth_internal_view");
-
+    
     ax.def(
         "make_regular",
         [](unsigned n, double start, double stop, metadata_t metadata, bool flow, bool growth) -> py::object {
@@ -68,16 +64,13 @@ py::module register_axes(py::module &m) {
              "n"_a,
              "stop"_a,
              "metadata"_a = py::str());
-    register_axis_iv_by_type<axis::circular>(ax, "_circular_internal_view");
-
+    
     register_axis<axis::regular_log>(ax, "regular_log", "Evenly spaced bins in log10")
         .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
-    register_axis_iv_by_type<axis::regular_log>(ax, "_regular_log_internal_view");
-
+    
     register_axis<axis::regular_sqrt>(ax, "regular_sqrt", "Evenly spaced bins in sqrt")
         .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
-    register_axis_iv_by_type<axis::regular_sqrt>(ax, "_regular_sqrt_internal_view");
-
+    
     register_axis<axis::regular_pow>(ax, "regular_pow", "Evenly spaced bins in a power")
         .def(py::init([](unsigned n, double start, double stop, double pow, metadata_t metadata) {
                  return new axis::regular_pow(bh::axis::transform::pow{pow}, n, start, stop, metadata);
@@ -87,24 +80,19 @@ py::module register_axes(py::module &m) {
              "stop"_a,
              "power"_a,
              "metadata"_a = py::str());
-    register_axis_iv_by_type<axis::regular_pow>(ax, "_regular_pow_internal_view");
-
+    
     register_axis<axis::variable>(ax, "variable", "Unevenly spaced bins")
         .def(py::init<std::vector<double>, metadata_t>(), "edges"_a, "metadata"_a = py::str());
-    register_axis_iv_by_type<axis::variable>(ax, "_variable_internal_view");
-
+    
     register_axis<axis::integer_uoflow>(ax, "integer_uoflow", "Contigious integers")
         .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
-    register_axis_iv_by_type<axis::integer_uoflow>(ax, "_integer_internal_view");
-
+    
     register_axis<axis::integer_noflow>(ax, "integer_noflow", "Contigious integers with no under/overflow")
         .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
-    register_axis_iv_by_type<axis::integer_noflow>(ax, "_integer_noflow_internal_view");
-
+    
     register_axis<axis::integer_growth>(ax, "integer_growth", "Contigious integers with growth")
         .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
-    register_axis_iv_by_type<axis::integer_growth>(ax, "_integer_integer_growth_internal_view");
-
+    
     register_axis<axis::category_int>(ax, "category_int", "Text label bins")
         .def(py::init<std::vector<int>, metadata_t>(), "labels"_a, "metadata"_a = py::str());
 

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -25,17 +25,31 @@ py::module register_axes(py::module &m) {
     py::object factory_meta_py = py::module::import("boost.histogram_utils").attr("FactoryMeta");
 
     register_axis<axis::regular_uoflow>(ax, "regular_uoflow", "Evenly spaced bins")
-        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
-    
+        .def(construct_axes<axis::regular_uoflow, unsigned, double, double>(),
+             "n"_a,
+             "start"_a,
+             "stop"_a,
+             "metadata"_a = py::str());
+
     register_axis<axis::regular_noflow>(ax, "regular_noflow", "Evenly spaced bins without over/under flow")
-        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
-    
+        .def(construct_axes<axis::regular_noflow, unsigned, double, double>(),
+             "n"_a,
+             "start"_a,
+             "stop"_a,
+             "metadata"_a = py::str());
+
     register_axis<axis::regular_growth>(ax, "regular_growth", "Evenly spaced bins that grow as needed")
-        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
-    
+        .def(construct_axes<axis::regular_growth, unsigned, double, double>(),
+             "n"_a,
+             "start"_a,
+             "stop"_a,
+             "metadata"_a = py::str());
+
     ax.def(
         "make_regular",
         [](unsigned n, double start, double stop, metadata_t metadata, bool flow, bool growth) -> py::object {
+            validate_metadata(metadata);
+
             if(growth) {
                 return py::cast(axis::regular_growth(n, start, stop, metadata), py::return_value_policy::move);
             } else if(flow) {
@@ -57,22 +71,36 @@ py::module register_axes(py::module &m) {
         py::make_tuple(ax.attr("regular_uoflow"), ax.attr("regular_noflow"), ax.attr("regular_growth")));
 
     register_axis<axis::circular>(ax, "circular", "Evenly spaced bins with wraparound")
-        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
+        .def(construct_axes<axis::circular, unsigned, double, double>(),
+             "n"_a,
+             "start"_a,
+             "stop"_a,
+             "metadata"_a = py::str())
         .def(py::init([](unsigned n, double stop, metadata_t metadata) {
+                 validate_metadata(metadata);
                  return new axis::circular{n, 0.0, stop, metadata};
              }),
              "n"_a,
              "stop"_a,
              "metadata"_a = py::str());
-    
+
     register_axis<axis::regular_log>(ax, "regular_log", "Evenly spaced bins in log10")
-        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
-    
+        .def(construct_axes<axis::regular_log, unsigned, double, double>(),
+             "n"_a,
+             "start"_a,
+             "stop"_a,
+             "metadata"_a = py::str());
+
     register_axis<axis::regular_sqrt>(ax, "regular_sqrt", "Evenly spaced bins in sqrt")
-        .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
-    
+        .def(construct_axes<axis::regular_sqrt, unsigned, double, double>(),
+             "n"_a,
+             "start"_a,
+             "stop"_a,
+             "metadata"_a = py::str());
+
     register_axis<axis::regular_pow>(ax, "regular_pow", "Evenly spaced bins in a power")
         .def(py::init([](unsigned n, double start, double stop, double pow, metadata_t metadata) {
+                 validate_metadata(metadata);
                  return new axis::regular_pow(bh::axis::transform::pow{pow}, n, start, stop, metadata);
              }),
              "n"_a,
@@ -80,33 +108,35 @@ py::module register_axes(py::module &m) {
              "stop"_a,
              "power"_a,
              "metadata"_a = py::str());
-    
+
     register_axis<axis::variable>(ax, "variable", "Unevenly spaced bins")
-        .def(py::init<std::vector<double>, metadata_t>(), "edges"_a, "metadata"_a = py::str());
-    
+        .def(construct_axes<axis::variable, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
+
     register_axis<axis::integer_uoflow>(ax, "integer_uoflow", "Contigious integers")
-        .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
-    
+        .def(construct_axes<axis::integer_uoflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
+
     register_axis<axis::integer_noflow>(ax, "integer_noflow", "Contigious integers with no under/overflow")
-        .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
-    
+        .def(construct_axes<axis::integer_noflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
+
     register_axis<axis::integer_growth>(ax, "integer_growth", "Contigious integers with growth")
-        .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
-    
+        .def(construct_axes<axis::integer_growth, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
+
     register_axis<axis::category_int>(ax, "category_int", "Text label bins")
-        .def(py::init<std::vector<int>, metadata_t>(), "labels"_a, "metadata"_a = py::str());
+        .def(construct_axes<axis::category_int, std::vector<int>>(), "labels"_a, "metadata"_a = py::str());
 
     register_axis<axis::category_int_growth>(ax, "category_int_growth", "Text label bins")
-        .def(py::init<std::vector<int>, metadata_t>(), "labels"_a, "metadata"_a = py::str())
+        .def(construct_axes<axis::category_int_growth, std::vector<int>>(), "labels"_a, "metadata"_a = py::str())
         .def(py::init<>());
 
     register_axis<axis::category_str>(ax, "category_str", "Text label bins")
-        .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "metadata"_a = py::str());
+        .def(construct_axes<axis::category_str, std::vector<std::string>>(), "labels"_a, "metadata"_a = py::str());
 
     register_axis<axis::category_str_growth>(ax, "category_str_growth", "Text label bins")
-        .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "metadata"_a = py::str())
-        // Add way to allow empty list of strings
+        .def(
+            construct_axes<axis::category_str_growth, std::vector<std::string>>(), "labels"_a, "metadata"_a = py::str())
         .def(py::init<>());
+
+    // TODO: Add way to allow empty lists as well.
 
     return ax;
 }

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -5,146 +5,12 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
-#include <pybind11/eval.h>
-#include <pybind11/numpy.h>
-#include <pybind11/operators.h>
-
 #include <boost/histogram/python/axis.hpp>
-#include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/register_axis.hpp>
 
-#include <boost/histogram.hpp>
-#include <boost/histogram/axis/ostream.hpp>
-
-#include <boost/histogram/axis/traits.hpp>
-
-#include <iostream>
-#include <sstream>
-#include <stdexcept>
-#include <type_traits>
-#include <utility>
 #include <vector>
 
-using namespace std::literals;
-
-// Base classes to allow type checking in Python
-struct regular_base {};
-
-/// Add items to an axis where the axis values are continious
-template <typename A, typename B>
-void add_to_axis(B &&axis, std::false_type) {
-    axis.def("bin", &A::bin, "The bin details (center, lower, upper)", "idx"_a, py::keep_alive<0, 1>());
-    axis.def(
-        "bins", [](const A &self, bool flow) { return axis_to_bins(self, flow); }, "flow"_a = false);
-    axis.def("index", py::vectorize(&A::index), "The index at a point(s) on the axis", "x"_a);
-    axis.def("value", py::vectorize(&A::value), "The value(s) for a fractional bin(s) in the axis", "i"_a);
-
-    axis.def(
-        "edges",
-        [](const A &ax, bool flow) { return axis_to_edges(ax, flow); },
-        "flow"_a = false,
-        "The bin edges (length: bins + 1) (include over/underflow if flow=True)");
-
-    axis.def(
-        "centers",
-        [](const A &ax) {
-            py::array_t<double> centers((unsigned)ax.size());
-            std::transform(ax.begin(), ax.end(), centers.mutable_data(), [](const auto &bin) { return bin.center(); });
-            return centers;
-        },
-        "Return the bin centers");
-}
-
-/// Add items to an axis where the axis values are not continious (categories of strings, for example)
-template <typename A, typename B>
-void add_to_axis(B &&axis, std::true_type) {
-    axis.def("bin", &A::bin, "The bin name", "idx"_a);
-    axis.def(
-        "bins", [](const A &self, bool flow) { return axis_to_bins(self, flow); }, "flow"_a = false);
-    // Not that these really just don't work with string labels; they would work for numerical labels.
-    axis.def("index", &A::index, "The index at a point on the axis", "x"_a);
-    axis.def("value", &A::value, "The value for a fractional bin in the axis", "i"_a);
-}
-
-/// Add helpers common to all axis types
-template <typename A, typename... Args>
-py::class_<A> register_axis_by_type(py::module &m, Args &&... args) {
-    py::class_<A> axis(m, std::forward<Args>(args)...);
-
-    // using value_type = decltype(A::value(1.0));
-
-    axis.def("__repr__", shift_to_string<A>())
-
-        .def("__eq__", [](const A &self, const A &other) { return compare_axes_eq(self, other); })
-        .def("__ne__", [](const A &self, const A &other) { return compare_axes_ne(self, other); })
-
-        // Fall through for non-matching types
-        .def("__eq__", [](const A &, const py::object &) { return false; })
-        .def("__ne__", [](const A &, const py::object &) { return true; })
-
-        .def(
-            "size",
-            [](const A &self, bool flow) {
-                if(flow)
-                    return bh::axis::traits::extent(self);
-                else
-                    return self.size();
-            },
-            "flow"_a = false,
-            "Returns the number of bins, without over- or underflow unless flow=True")
-
-        .def("update", &A::update, "Bin and add a value if allowed", "i"_a)
-        .def_static("options", &A::options, "Return the options associated to the axis")
-        .def_property(
-            "metadata",
-            [](const A &self) { return self.metadata(); },
-            [](A &self, const metadata_t &label) { self.metadata() = label; },
-            "Set the axis label")
-
-        .def("__copy__", [](const A &self) { return A(self); })
-        .def("__deepcopy__",
-             [](const A &self, py::object memo) {
-                 A *a            = new A(self);
-                 py::module copy = py::module::import("copy");
-                 a->metadata()   = copy.attr("deepcopy")(a->metadata(), memo);
-                 return a;
-             })
-
-        ;
-
-    // We only need keepalive if this is a reference.
-    using Result = decltype(std::declval<A>().bin(std::declval<int>()));
-
-    // This is a replacement for constexpr if
-    add_to_axis<A>(
-        axis, std::integral_constant < bool, std::is_reference<Result>::value || std::is_integral<Result>::value > {});
-
-    axis.def(make_pickle<A>());
-
-    return axis;
-}
-
-/// Add helpers common to all types with a range of values
-template <typename A>
-py::class_<bh::axis::interval_view<A>> register_axis_iv_by_type(py::module &m, const char *name) {
-    using A_iv               = bh::axis::interval_view<A>;
-    py::class_<A_iv> axis_iv = py::class_<A_iv>(m, name, "Lightweight bin view");
-
-    axis_iv.def("upper", &A_iv::upper)
-        .def("lower", &A_iv::lower)
-        .def("center", &A_iv::center)
-        .def("width", &A_iv::width)
-        .def(py::self == py::self)
-        .def(py::self != py::self)
-        .def("__repr__", [](const A_iv &self) {
-            return "<bin ["s + std::to_string(self.lower()) + ", "s + std::to_string(self.upper()) + "]>"s;
-        });
-
-    return axis_iv;
-}
-
-struct regular_type {};
-
-py::module register_axis(py::module &m) {
+py::module register_axes(py::module &m) {
     py::module ax = m.def_submodule("axis");
 
     py::module opt = ax.def_submodule("options");
@@ -158,16 +24,16 @@ py::module register_axis(py::module &m) {
     // This factory makes a class that can be used to create axes and also be used in is_instance
     py::object factory_meta_py = py::module::import("boost.histogram_utils").attr("FactoryMeta");
 
-    register_axis_by_type<axis::regular_uoflow>(ax, "regular_uoflow", "Evenly spaced bins")
+    register_axis<axis::regular_uoflow>(ax, "regular_uoflow", "Evenly spaced bins")
         .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
 
     register_axis_iv_by_type<axis::regular_uoflow>(ax, "_regular_internal_view");
 
-    register_axis_by_type<axis::regular_noflow>(ax, "regular_noflow", "Evenly spaced bins without over/under flow")
+    register_axis<axis::regular_noflow>(ax, "regular_noflow", "Evenly spaced bins without over/under flow")
         .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::regular_noflow>(ax, "_regular_noflow_internal_view");
 
-    register_axis_by_type<axis::regular_growth>(ax, "regular_growth", "Evenly spaced bins that grow as needed")
+    register_axis<axis::regular_growth>(ax, "regular_growth", "Evenly spaced bins that grow as needed")
         .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::regular_growth>(ax, "_regular_growth_internal_view");
 
@@ -194,7 +60,7 @@ py::module register_axis(py::module &m) {
         ax.attr("make_regular"),
         py::make_tuple(ax.attr("regular_uoflow"), ax.attr("regular_noflow"), ax.attr("regular_growth")));
 
-    register_axis_by_type<axis::circular>(ax, "circular", "Evenly spaced bins with wraparound")
+    register_axis<axis::circular>(ax, "circular", "Evenly spaced bins with wraparound")
         .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str())
         .def(py::init([](unsigned n, double stop, metadata_t metadata) {
                  return new axis::circular{n, 0.0, stop, metadata};
@@ -204,15 +70,15 @@ py::module register_axis(py::module &m) {
              "metadata"_a = py::str());
     register_axis_iv_by_type<axis::circular>(ax, "_circular_internal_view");
 
-    register_axis_by_type<axis::regular_log>(ax, "regular_log", "Evenly spaced bins in log10")
+    register_axis<axis::regular_log>(ax, "regular_log", "Evenly spaced bins in log10")
         .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::regular_log>(ax, "_regular_log_internal_view");
 
-    register_axis_by_type<axis::regular_sqrt>(ax, "regular_sqrt", "Evenly spaced bins in sqrt")
+    register_axis<axis::regular_sqrt>(ax, "regular_sqrt", "Evenly spaced bins in sqrt")
         .def(py::init<unsigned, double, double, metadata_t>(), "n"_a, "start"_a, "stop"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::regular_sqrt>(ax, "_regular_sqrt_internal_view");
 
-    register_axis_by_type<axis::regular_pow>(ax, "regular_pow", "Evenly spaced bins in a power")
+    register_axis<axis::regular_pow>(ax, "regular_pow", "Evenly spaced bins in a power")
         .def(py::init([](unsigned n, double start, double stop, double pow, metadata_t metadata) {
                  return new axis::regular_pow(bh::axis::transform::pow{pow}, n, start, stop, metadata);
              }),
@@ -223,33 +89,33 @@ py::module register_axis(py::module &m) {
              "metadata"_a = py::str());
     register_axis_iv_by_type<axis::regular_pow>(ax, "_regular_pow_internal_view");
 
-    register_axis_by_type<axis::variable>(ax, "variable", "Unevenly spaced bins")
+    register_axis<axis::variable>(ax, "variable", "Unevenly spaced bins")
         .def(py::init<std::vector<double>, metadata_t>(), "edges"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::variable>(ax, "_variable_internal_view");
 
-    register_axis_by_type<axis::integer_uoflow>(ax, "integer_uoflow", "Contigious integers")
+    register_axis<axis::integer_uoflow>(ax, "integer_uoflow", "Contigious integers")
         .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::integer_uoflow>(ax, "_integer_internal_view");
 
-    register_axis_by_type<axis::integer_noflow>(ax, "integer_noflow", "Contigious integers with no under/overflow")
+    register_axis<axis::integer_noflow>(ax, "integer_noflow", "Contigious integers with no under/overflow")
         .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::integer_noflow>(ax, "_integer_noflow_internal_view");
 
-    register_axis_by_type<axis::integer_growth>(ax, "integer_growth", "Contigious integers with growth")
+    register_axis<axis::integer_growth>(ax, "integer_growth", "Contigious integers with growth")
         .def(py::init<int, int, metadata_t>(), "min"_a, "max"_a, "metadata"_a = py::str());
     register_axis_iv_by_type<axis::integer_growth>(ax, "_integer_integer_growth_internal_view");
 
-    register_axis_by_type<axis::category_int>(ax, "category_int", "Text label bins")
+    register_axis<axis::category_int>(ax, "category_int", "Text label bins")
         .def(py::init<std::vector<int>, metadata_t>(), "labels"_a, "metadata"_a = py::str());
 
-    register_axis_by_type<axis::category_int_growth>(ax, "category_int_growth", "Text label bins")
+    register_axis<axis::category_int_growth>(ax, "category_int_growth", "Text label bins")
         .def(py::init<std::vector<int>, metadata_t>(), "labels"_a, "metadata"_a = py::str())
         .def(py::init<>());
 
-    register_axis_by_type<axis::category_str>(ax, "category_str", "Text label bins")
+    register_axis<axis::category_str>(ax, "category_str", "Text label bins")
         .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "metadata"_a = py::str());
 
-    register_axis_by_type<axis::category_str_growth>(ax, "category_str_growth", "Text label bins")
+    register_axis<axis::category_str_growth>(ax, "category_str_growth", "Text label bins")
         .def(py::init<std::vector<std::string>, metadata_t>(), "labels"_a, "metadata"_a = py::str())
         // Add way to allow empty list of strings
         .def(py::init<>());

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -3,278 +3,49 @@
 // Distributed under the 3-Clause BSD License.  See accompanying
 // file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
 
-#include <boost/histogram/python/kwargs.hpp>
 #include <boost/histogram/python/pybind11.hpp>
-#include <pybind11/operators.h>
 
 #include <boost/histogram/python/axis.hpp>
 #include <boost/histogram/python/histogram.hpp>
-#include <boost/histogram/python/histogram_atomic.hpp>
-#include <boost/histogram/python/histogram_fill.hpp>
-#include <boost/histogram/python/histogram_threaded.hpp>
-#include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/register_histogram.hpp>
 #include <boost/histogram/python/storage.hpp>
 
 #include <boost/histogram.hpp>
-#include <boost/histogram/algorithm/project.hpp>
-#include <boost/histogram/algorithm/sum.hpp>
-#include <boost/histogram/axis/ostream.hpp>
-#include <boost/histogram/ostream.hpp>
-#include <boost/histogram/unsafe_access.hpp>
 
-#include <boost/mp11.hpp>
-
-#include <sstream>
-#include <tuple>
-#include <vector>
-
-template <typename A, typename S>
-py::class_<bh::histogram<A, S>> register_histogram_by_type(py::module &m, const char *name, const char *desc) {
-    using histogram_t = bh::histogram<A, S>;
-
-    py::class_<histogram_t> hist(m, name, desc, py::buffer_protocol());
-
-    hist.def(py::init<const A &, S>(), "axes"_a, "storage"_a = S())
-
-        .def_buffer([](bh::histogram<A, S> &h) -> py::buffer_info { return make_buffer(h, false); })
-
-        .def("rank", &histogram_t::rank, "Number of axes (dimensions) of histogram")
-        .def("size", &histogram_t::size, "Total number of bins in the histogram (including underflow/overflow)")
-        .def("reset", &histogram_t::reset, "Reset bin counters to zero")
-
-        .def("__copy__", [](const histogram_t &self) { return histogram_t(self); })
-        .def("__deepcopy__",
-             [](const histogram_t &self, py::object memo) {
-                 histogram_t *a  = new histogram_t(self);
-                 py::module copy = py::module::import("copy");
-                 for(unsigned i = 0; i < a->rank(); i++) {
-                     bh::unsafe_access::axis(*a, i).metadata() = copy.attr("deepcopy")(a->axis(i).metadata(), memo);
-                 }
-                 return a;
-             })
-
-        .def(py::self + py::self)
-
-        .def("__eq__",
-             [](const histogram_t &self, const histogram_t &other) {
-                 if(self.rank() != other.rank())
-                     return false;
-
-                 for(unsigned i = 0; i < self.rank(); i++)
-                     if(!compare_axes_eq(self.axis(i), other.axis(i)))
-                         return false;
-
-                 return bh::unsafe_access::storage(self) == bh::unsafe_access::storage(other);
-             })
-        .def("__ne__",
-             [](const histogram_t &self, const histogram_t &other) {
-                 if(self.rank() != other.rank())
-                     return true;
-
-                 for(unsigned i = 0; i < self.rank(); i++)
-                     if(compare_axes_ne(self.axis(i), other.axis(i)))
-                         return true;
-
-                 return !(bh::unsafe_access::storage(self) == bh::unsafe_access::storage(other));
-             })
-
-        // Fall through for non-matching types
-        .def("__eq__", [](const histogram_t &, const py::object &) { return false; })
-        .def("__ne__", [](const histogram_t &, const py::object &) { return true; })
-
-        ;
-
-    // Atomics for example do not support these operations
-    def_optionally(hist, bh::detail::has_operator_rmul<histogram_t, double>{}, py::self *= double());
-    def_optionally(hist, bh::detail::has_operator_rmul<histogram_t, double>{}, py::self * double());
-    def_optionally(hist, bh::detail::has_operator_rmul<histogram_t, double>{}, double() * py::self);
-    def_optionally(hist, bh::detail::has_operator_rdiv<histogram_t, double>{}, py::self /= double());
-    def_optionally(hist, bh::detail::has_operator_rdiv<histogram_t, double>{}, py::self / double());
-
-    hist.def(
-            "to_numpy",
-            [](histogram_t &h, bool flow) {
-                py::list listing;
-
-                // Add the histogram as the first argument
-                py::array arr(make_buffer(h, flow));
-                listing.append(arr);
-
-                // Add the axis edges
-                for(unsigned i = 0; i < h.rank(); i++) {
-                    const auto &ax = h.axis(i);
-                    listing.append(axis_to_edges(ax, flow));
-                }
-
-                return py::cast<py::tuple>(listing);
-            },
-            "flow"_a = false,
-            "convert to a numpy style tuple of returns")
-
-        .def(
-            "view",
-            [](histogram_t &h, bool flow) { return py::array(make_buffer(h, flow)); },
-            "flow"_a = false,
-            "Return a view into the data, optionally with overflow turned on")
-
-        .def(
-            "axis",
-            [](histogram_t &self, int i) {
-                unsigned ii = i < 0 ? self.rank() - (unsigned)std::abs(i) : (unsigned)i;
-                if(ii < self.rank())
-                    return self.axis(ii);
-                else
-                    throw std::out_of_range("The axis value must be less than the rank");
-            },
-            "Get N-th axis with runtime index",
-            "i"_a,
-            py::return_value_policy::move)
-
-        .def(
-            "at",
-            [](histogram_t &self, py::args &args) {
-                // Optimize for no dynamic?
-                auto int_args = py::cast<std::vector<int>>(args);
-                return self.at(int_args);
-            },
-            "Access bin counter at indices")
-
-        .def("__repr__", shift_to_string<histogram_t>())
-
-        .def(
-            "sum",
-            [](const histogram_t &self, bool flow) {
-                if(flow) {
-                    return bh::algorithm::sum(self);
-                } else {
-                    using T       = typename bh::histogram<A, S>::value_type;
-                    using AddType = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
-                    using Sum     = boost::mp11::mp_if<std::is_arithmetic<T>, bh::accumulators::sum<double>, T>;
-                    Sum sum;
-                    for(auto x : bh::indexed(self))
-                        sum += (AddType)*x;
-                    using R = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
-                    return static_cast<R>(sum);
-                }
-            },
-            "flow"_a = false)
-
-        /* Broken: Does not work if any string axes present (even just in variant)
-        .def("rebin", [](const histogram_t &self, unsigned axis, unsigned merge){
-            return bh::algorithm::reduce(self, bh::algorithm::rebin(axis, merge));
-        }, "axis"_a, "merge"_a, "Rebin by merging bins. You must select an axis.")
-
-        .def("shrink", [](const histogram_t &self, unsigned axis, double lower, double upper){
-            return bh::algorithm::reduce(self, bh::algorithm::shrink(axis, lower, upper));
-        }, "axis"_a, "lower"_a, "upper"_a, "Shrink an axis. You must select an axis.")
-
-        .def("shrink_and_rebin", [](const histogram_t &self, unsigned axis, double lower, double upper, unsigned merge){
-            return bh::algorithm::reduce(self, bh::algorithm::shrink_and_rebin(axis, lower, upper, merge));
-        }, "axis"_a, "lower"_a, "upper"_a, "merge"_a, "Shrink an axis and rebin. You must select an axis.")
-        */
-
-        .def(
-            "project",
-            [](const histogram_t &self, py::args values) {
-                // If static
-                // histogram<any_axis> any = self;
-                return bh::algorithm::project(self, py::cast<std::vector<unsigned>>(values));
-            },
-            "Project to a single axis or several axes on a multidiminsional histogram")
-
-        .def(make_pickle<histogram_t>())
-
-        ;
-
-    add_fill(std::is_same<S, storage::atomic_int>{}, hist);
-
-    return hist;
-}
-
-// Atomic fill supported?
-template <typename A, typename S>
-void add_fill(std::true_type, py::class_<bh::histogram<A, S>> &hist) {
-    using histogram_t = bh::histogram<A, S>;
-
-    // generic threaded and atomic fill for 1 to N args
-    hist.def(
-        "fill",
-        [](histogram_t &self, py::args args, py::kwargs kwargs) {
-            std::unique_ptr<size_t> threads = optional_arg<size_t>(kwargs, "threads");
-            std::unique_ptr<size_t> atomic  = optional_arg<size_t>(kwargs, "atomic");
-            finalize_args(kwargs);
-
-            if(threads && atomic)
-                throw py::key_error("Cannot have both atomic and threads in one fill call!");
-            else if(threads)
-                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(
-                    args.size(), fill_helper_threaded<histogram_t>(self, args, *threads));
-            else if(atomic)
-                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(
-                    args.size(), fill_helper_atomic<histogram_t>(self, args, *atomic));
-            else
-                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(),
-                                                                              fill_helper<histogram_t>(self, args));
-        },
-        "Insert data into histogram in threads (0 for machine cores). Keyword arguments: threads=N, atomic=N "
-        "(exclusive)");
-}
-
-template <typename A, typename S>
-void add_fill(std::false_type, py::class_<bh::histogram<A, S>> &hist) {
-    using histogram_t = bh::histogram<A, S>;
-
-    // generic threaded fill for 1 to N args
-    hist.def(
-        "fill",
-        [](histogram_t &self, py::args args, py::kwargs kwargs) {
-            std::unique_ptr<size_t> threads = optional_arg<size_t>(kwargs, "threads");
-            finalize_args(kwargs);
-
-            if(threads)
-                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(
-                    args.size(), fill_helper_threaded<histogram_t>(self, args, *threads));
-            else
-                boost::mp11::mp_with_index<BOOST_HISTOGRAM_DETAIL_AXES_LIMIT>(args.size(),
-                                                                              fill_helper<histogram_t>(self, args));
-        },
-        "Insert data into histogram in threads (0 for machine cores). Keyword argument: threads=N");
-}
-
-py::module register_histogram(py::module &m) {
+py::module register_histograms(py::module &m) {
     m.attr("BOOST_HISTOGRAM_DETAIL_AXES_LIMIT") = BOOST_HISTOGRAM_DETAIL_AXES_LIMIT;
 
     py::module hist = m.def_submodule("hist");
 
     // Fast specializations - uniform types
 
-    register_histogram_by_type<axes::regular, storage::unlimited>(
+    register_histogram<axes::regular, storage::unlimited>(
         hist, "regular_unlimited", "N-dimensional histogram for real-valued data.");
 
-    register_histogram_by_type<axes::regular, storage::int_>(
+    register_histogram<axes::regular, storage::int_>(
         hist, "regular_int", "N-dimensional histogram for int-valued data.");
 
-    auto regular_atomic_int = register_histogram_by_type<axes::regular, storage::atomic_int>(
+    auto regular_atomic_int = register_histogram<axes::regular, storage::atomic_int>(
         hist, "regular_atomic_int", "N-dimensional histogram for atomic int-valued data.");
 
-    register_histogram_by_type<axes::regular_noflow, storage::int_>(
+    register_histogram<axes::regular_noflow, storage::int_>(
         hist, "regular_noflow_int", "N-dimensional histogram for int-valued data.");
 
     // Completely general histograms
 
-    register_histogram_by_type<axes::any, storage::int_>(
+    register_histogram<axes::any, storage::int_>(
         hist, "any_int", "N-dimensional histogram for int-valued data with any axis types.");
 
-    auto any_atomic_int = register_histogram_by_type<axes::any, storage::atomic_int>(
+    auto any_atomic_int = register_histogram<axes::any, storage::atomic_int>(
         hist, "any_atomic_int", "N-dimensional histogram for int-valued data with any axis types (threadsafe).");
 
-    register_histogram_by_type<axes::any, storage::double_>(
+    register_histogram<axes::any, storage::double_>(
         hist, "any_double", "N-dimensional histogram for real-valued data with weights with any axis types.");
 
-    register_histogram_by_type<axes::any, storage::unlimited>(
+    register_histogram<axes::any, storage::unlimited>(
         hist, "any_unlimited", "N-dimensional histogram for unlimited size data with any axis types.");
 
-    register_histogram_by_type<axes::any, storage::weight>(
+    register_histogram<axes::any, storage::weight>(
         hist, "any_weight", "N-dimensional histogram for weighted data with any axis types.");
 
     // Requieres sampled fills

--- a/src/histogram/histogram.cpp
+++ b/src/histogram/histogram.cpp
@@ -19,13 +19,13 @@ py::module register_histograms(py::module &m) {
 
     // Fast specializations - uniform types
 
-    register_histogram<axes::regular, storage::unlimited>(
+    register_histogram<axes::regular_uoflow, storage::unlimited>(
         hist, "regular_unlimited", "N-dimensional histogram for real-valued data.");
 
-    register_histogram<axes::regular, storage::int_>(
+    register_histogram<axes::regular_uoflow, storage::int_>(
         hist, "regular_int", "N-dimensional histogram for int-valued data.");
 
-    auto regular_atomic_int = register_histogram<axes::regular, storage::atomic_int>(
+    auto regular_atomic_int = register_histogram<axes::regular_uoflow, storage::atomic_int>(
         hist, "regular_atomic_int", "N-dimensional histogram for atomic int-valued data.");
 
     register_histogram<axes::regular_noflow, storage::int_>(

--- a/src/histogram/make_histogram.cpp
+++ b/src/histogram/make_histogram.cpp
@@ -28,7 +28,7 @@ void register_make_histogram(py::module &m, py::module &hist) {
             try {
                 return try_cast<storage::int_, storage::atomic_int, storage::unlimited>(
                     storage, [&args](auto &&storage) {
-                        auto reg = py::cast<axes::regular>(args);
+                        auto reg = py::cast<axes::regular_uoflow>(args);
                         return py::cast(bh::make_histogram_with(storage, reg), py::return_value_policy::move);
                     });
             } catch(const py::cast_error &) {

--- a/src/histogram/storage.cpp
+++ b/src/histogram/storage.cpp
@@ -5,44 +5,18 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
-#include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/register_storage.hpp>
 #include <boost/histogram/python/storage.hpp>
-#include <pybind11/operators.h>
 
 #include <boost/histogram.hpp>
 #include <boost/histogram/storage_adaptor.hpp>
 
-#include <iostream>
-#include <sstream>
-#include <stdexcept>
-#include <type_traits>
-#include <utility>
-#include <vector>
-
-/// Add helpers common to all storage types
-template <typename A, typename T>
-py::class_<A> register_storage_by_type(py::module &m, const char *name, const char *desc) {
-    py::class_<A> storage(m, name, desc);
-
-    storage.def(py::init<>())
-        .def("__getitem__", [](A &self, size_t ind) { return self.at(ind); })
-        .def("__setitem__", [](A &self, size_t ind, T val) { self.at(ind) = val; })
-        .def("push_back", [](A &self, T val) { self.push_back(val); })
-        .def(py::self == py::self)
-        .def(py::self != py::self)
-        .def(make_pickle<A>())
-        .def("__copy__", [](const A &self) { return A(self); })
-        .def("__deepcopy__", [](const A &self, py::object) { return A(self); });
-
-    return storage;
-}
-
-py::module register_storage(py::module &m) {
+py::module register_storages(py::module &m) {
     py::module storage = m.def_submodule("storage");
 
     // Fast storages
 
-    register_storage_by_type<storage::int_, unsigned>(storage, "int", "Integers in vectors storage type");
+    register_storage<storage::int_, unsigned>(storage, "int", "Integers in vectors storage type");
 
     py::class_<storage::double_>(storage, "double", "Weighted storage without variance type (fast but simple)")
         .def(py::init<>());

--- a/src/histogram/storage.cpp
+++ b/src/histogram/storage.cpp
@@ -25,7 +25,6 @@ py::module register_storages(py::module &m) {
     // Default storages
 
     register_storage<storage::unlimited>(storage, "unlimited", "Optimized for unweighted histograms, adaptive");
-    //.def(py::init<>());
 
     register_storage<storage::weight>(
         storage, "weight", "Dense storage which tracks sums of weights and a variance estimate");

--- a/src/histogram/storage.cpp
+++ b/src/histogram/storage.cpp
@@ -16,28 +16,24 @@ py::module register_storages(py::module &m) {
 
     // Fast storages
 
-    register_storage<storage::int_, unsigned>(storage, "int", "Integers in vectors storage type");
+    register_storage<storage::int_>(storage, "int", "Integers in vectors storage type");
 
-    py::class_<storage::double_>(storage, "double", "Weighted storage without variance type (fast but simple)")
-        .def(py::init<>());
+    register_storage<storage::double_>(storage, "double", "Weighted storage without variance type (fast but simple)");
 
-    py::class_<storage::atomic_int>(storage, "atomic_int", "Threadsafe (not growing axis) integer storage")
-        .def(py::init<>());
+    register_storage<storage::atomic_int>(storage, "atomic_int", "Threadsafe (not growing axis) integer storage");
 
     // Default storages
 
-    py::class_<storage::unlimited>(storage, "unlimited", "Optimized for unweighted histograms, adaptive")
-        .def(py::init<>());
+    register_storage<storage::unlimited>(storage, "unlimited", "Optimized for unweighted histograms, adaptive");
+    //.def(py::init<>());
 
-    py::class_<storage::weight>(storage, "weight", "Dense storage which tracks sums of weights and a variance estimate")
-        .def(py::init<>());
+    register_storage<storage::weight>(
+        storage, "weight", "Dense storage which tracks sums of weights and a variance estimate");
 
-    py::class_<storage::profile>(storage, "profile", "Dense storage which tracks means of samples in each cell")
-        .def(py::init<>());
+    register_storage<storage::profile>(storage, "profile", "Dense storage which tracks means of samples in each cell");
 
-    py::class_<storage::weighted_profile>(
-        storage, "weighted_profile", "Dense storage which tracks means of weighted samples in each cell")
-        .def(py::init<>());
+    register_storage<storage::weighted_profile>(
+        storage, "weighted_profile", "Dense storage which tracks means of weighted samples in each cell");
 
     return storage;
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -6,17 +6,17 @@
 #include <boost/histogram/python/pybind11.hpp>
 
 void register_version(py::module &);
-py::module register_storage(py::module &);
-py::module register_axis(py::module &);
-py::module register_histogram(py::module &);
+py::module register_storages(py::module &);
+py::module register_axes(py::module &);
+py::module register_histograms(py::module &);
 void register_make_histogram(py::module &, py::module &);
 py::module register_accumulators(py::module &);
 
 PYBIND11_MODULE(histogram, m) {
     register_version(m);
-    register_storage(m);
-    register_axis(m);
-    py::module hist = register_histogram(m);
+    register_storages(m);
+    register_axes(m);
+    py::module hist = register_histograms(m);
     register_make_histogram(m, hist);
     register_accumulators(m);
 }

--- a/tests/test_axis_internal.py
+++ b/tests/test_axis_internal.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 
-@pytest.mark.parametrize("axtype", [bh.axis.regular_uoflow, bh.axis.regular_noflow])
+@pytest.mark.parametrize("axtype", [bh.axis.regular_uoflow, bh.axis.regular_uflow, bh.axis.regular_oflow, bh.axis.regular_noflow])
 @pytest.mark.parametrize("function", [lambda x: x,
                                        lambda x: bh.make_histogram(x).axis(0),
                                        ])
@@ -36,14 +36,29 @@ def test_axis_regular_extents():
     assert 12 == ax.size(flow=True)
     assert 11 == len(ax.edges())
     assert 13 == len(ax.edges(True))
+    assert 10 == len(ax.centers())
     assert ax.options() == bh.axis.options.underflow | bh.axis.options.overflow
+
+    ax = bh.axis.regular_uflow(10,0,1)
+    assert 11 == ax.size(flow=True)
+    assert 11 == len(ax.edges())
+    assert 12 == len(ax.edges(True))
+    assert 10 == len(ax.centers())
+    assert ax.options() == bh.axis.options.underflow
+
+    ax = bh.axis.regular_oflow(10,0,1)
+    assert 11 == ax.size(flow=True)
+    assert 11 == len(ax.edges())
+    assert 12 == len(ax.edges(True))
+    assert 10 == len(ax.centers())
+    assert ax.options() == bh.axis.options.overflow
 
     ax = bh.axis.regular_noflow(10,0,1)
     assert 10 == ax.size(flow=True)
-    assert ax.options() == bh.axis.options.none
     assert 11 == len(ax.edges())
     assert 11 == len(ax.edges(True))
     assert 10 == len(ax.centers())
+    assert ax.options() == bh.axis.options.none
 
 def test_axis_growth():
     ax = bh.axis.regular_growth(10,0,1)

--- a/tests/test_public_axis.py
+++ b/tests/test_public_axis.py
@@ -2,11 +2,16 @@ import pytest
 from pytest import approx
 
 from boost.histogram.axis import (regular, regular_growth,
-                                  regular_uoflow, regular_noflow,
+                                  regular_uoflow, regular_uflow,
+                                  regular_oflow, regular_noflow,
                                   regular_log, regular_sqrt,
                                   regular_pow, circular,
-                                  variable, integer_uoflow,
-                                  integer_noflow, integer_growth,
+                                  variable,
+                                  variable_uoflow, variable_uflow,
+                                  variable_oflow, variable_noflow,
+                                  integer, integer_growth,
+                                  integer_uoflow, integer_oflow,
+                                  integer_uflow, integer_noflow,
                                   category_int as category)
 
 import numpy as np
@@ -61,11 +66,21 @@ class TestRegular(Axis):
         assert isinstance(regular(1,2,3), regular_uoflow)
         assert isinstance(regular(1,2,3), regular)
 
+        assert isinstance(regular(1,2,3, overflow=False), regular_uflow)
+        assert isinstance(regular(1,2,3, overflow=False), regular)
+
+        assert isinstance(regular(1,2,3, underflow=False), regular_oflow)
+        assert isinstance(regular(1,2,3, underflow=False), regular)
+
         assert isinstance(regular(1,2,3, flow=False), regular_noflow)
         assert isinstance(regular(1,2,3, flow=False), regular)
 
+        assert isinstance(regular(1,2,3, underflow=False, overflow=False), regular_noflow)
+        assert isinstance(regular(1,2,3, underflow=False, overflow=False, flow=True), regular_uoflow)
+
         assert isinstance(regular(1,2,3, growth=True), regular_growth)
         assert isinstance(regular(1,2,3, growth=True), regular)
+
 
     def test_init(self):
         # Should not throw
@@ -345,6 +360,21 @@ class TestCircular(Axis):
 
 
 class TestVariable(Axis):
+    def test_shortcut(self):
+        assert isinstance(variable([1,2,3]), variable_uoflow)
+        assert isinstance(variable([1,2,3]), variable)
+
+        assert isinstance(variable([1,2,3], overflow=False), variable_uflow)
+        assert isinstance(variable([1,2,3], overflow=False), variable)
+
+        assert isinstance(variable([1,2,3], underflow=False), variable_oflow)
+        assert isinstance(variable([1,2,3], underflow=False), variable)
+
+        assert isinstance(variable([1,2,3], flow=False), variable_noflow)
+        assert isinstance(variable([1,2,3], flow=False), variable)
+
+        assert isinstance(variable([1,2,3], underflow=False, overflow=False), variable_noflow)
+        assert isinstance(variable([1,2,3], underflow=False, overflow=False, flow=True), variable_uoflow)
 
     def test_init(self):
         variable([0, 1])
@@ -362,7 +392,7 @@ class TestVariable(Axis):
             variable([1, 1])
         with pytest.raises(TypeError):
             variable(["1", 2])
-        with pytest.raises(TypeError):
+        with pytest.raises(KeyError):
             variable([0.0, 1.0, 2.0], bad_keyword="ra")
 
         a = variable([-0.1, 0.2, 0.3])
@@ -426,6 +456,24 @@ class TestVariable(Axis):
         assert a.index(10) == 2
 
 class TestInteger:
+    def test_shortcut(self):
+        assert isinstance(integer(1, 3), integer_uoflow)
+        assert isinstance(integer(1, 3), integer)
+
+        assert isinstance(integer(1, 3, overflow=False), integer_uflow)
+        assert isinstance(integer(1, 3, overflow=False), integer)
+
+        assert isinstance(integer(1, 3, underflow=False), integer_oflow)
+        assert isinstance(integer(1, 3, underflow=False), integer)
+
+        assert isinstance(integer(1, 3, flow=False), integer_noflow)
+        assert isinstance(integer(1, 3, flow=False), integer)
+
+        assert isinstance(integer(1, 3, underflow=False, overflow=False), integer_noflow)
+        assert isinstance(integer(1, 3, underflow=False, overflow=False, flow=True), integer_uoflow)
+
+        assert isinstance(integer(1, 3, growth=True), integer_growth)
+        assert isinstance(integer(1, 3, growth=True), integer)
 
     def test_init(self):
         integer_uoflow(-1, 2)

--- a/tests/test_public_axis.py
+++ b/tests/test_public_axis.py
@@ -98,9 +98,8 @@ class TestRegular(Axis):
         with pytest.raises(ValueError):
             regular_uoflow(1, 1.0, 1.0)
 
-        # CLASSIC: this was not allowed. Now it is.
-        # with pytest.raises(TypeError):
-        regular_uoflow(1, 1.0, 2.0, metadata=0)
+        with pytest.raises(TypeError):
+            regular_uoflow(1, 1.0, 2.0, metadata=0)
 
 
 
@@ -261,10 +260,10 @@ class TestCircular(Axis):
             circular()
         with pytest.raises(Exception):
             circular(-1)
-        # CLASSIC: Used to be disallowed, now matches as metadata.
-        circular(1, 1.0, 2.0, 3.0)
-        # CLASSIC: Used to be disallowed.
-        circular(1, 1.0, metadata=1)
+        with pytest.raises(TypeError):
+            circular(1, 1.0, 2.0, 3.0)
+        with pytest.raises(TypeError):
+            circular(1, 1.0, metadata=1)
         with pytest.raises(TypeError):
             circular("1")
 
@@ -441,8 +440,8 @@ class TestInteger:
         with pytest.raises(ValueError):
             integer_uoflow(2, -1)
 
-        # CLASSIC: Used to fail
-        integer_uoflow(1, 2, 3)
+        with pytest.raises(TypeError):
+            integer_uoflow(1, 2, 3)
 
         assert integer_uoflow(-1, 2) == integer_uoflow(-1, 2)
         assert integer_uoflow(-1, 2) != integer_uoflow(-1, 2, metadata="Other")
@@ -511,8 +510,8 @@ class TestCategory(Axis):
             category(["1"])
         with pytest.raises(TypeError):
             category([1, "2"])
-        # CLASSIC: Used to raise TypeError
-        category([1, 2], metadata=1)
+        with pytest.raises(TypeError):
+            category([1, 2], metadata=1)
         with pytest.raises(TypeError):
             category([1, 2, 3], uoflow=True)
 


### PR DESCRIPTION
* Moving code to headers, so this can be extended more easily by users
* Cleanup for names and registration functions to make them nicer to use
* Automatically add IV to axis if they support it
* PyTest now works a bit better with the CMake build
* `metadata_t` cannot be numeric if in the constructor of an axis. (Common mistake)
* overflow and underflow separate, and supported for integer and variable axes (increased variant size)
    * Shortcut `flow=` still works and overrides other selections.