### PR TITLE
Adding shortcut for regular and variable axes

### DIFF
--- a/include/boost/histogram/python/kwargs.hpp
+++ b/include/boost/histogram/python/kwargs.hpp
@@ -31,7 +31,7 @@ std::unique_ptr<T> optional_arg(py::kwargs &kwargs, const char *name) {
 template <typename T>
 T optional_arg(py::kwargs &kwargs, const char *name, T original_value) {
     if(kwargs.contains(name)) {
-        return py::cast<T>(kwargs[name]);
+        return py::cast<T>(kwargs.attr("pop")(name));
     } else {
         return original_value;
     }

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -5,6 +5,7 @@ import math
 import boost.histogram as bh
 
 @pytest.mark.parametrize("axis,extent", ((bh.axis.regular_uoflow, 2),
+                                         (lambda *x: x, 2),
                                          (bh.axis.regular_noflow, 0)))
 def test_make_regular_1D(axis, extent):
     hist = bh.make_histogram(axis(3,2,5))
@@ -13,6 +14,16 @@ def test_make_regular_1D(axis, extent):
     assert hist.axis(0).size() == 3
     assert hist.axis(0).size(flow=True) == 3 + extent
     assert hist.axis(0).bin(1).center() == approx(3.5)
+
+def test_shortcuts():
+    hist = bh.histogram([1,2,3,4,5], (10,0,1))
+    assert hist.rank() == 2
+    assert isinstance(hist.axis(0), bh.axis.variable)
+    assert isinstance(hist.axis(0), bh.axis.variable_uoflow)
+    assert not isinstance(hist.axis(0), bh.axis.regular)
+    assert isinstance(hist.axis(1), bh.axis.regular)
+    assert isinstance(hist.axis(1), bh.axis.regular_uoflow)
+    assert not isinstance(hist.axis(1), bh.axis.variable)
 
 @pytest.mark.parametrize("axis,extent", ((bh.axis.regular_uoflow, 2),
                                          (bh.axis.regular_noflow, 0)))

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -25,6 +25,23 @@ def test_shortcuts():
     assert isinstance(hist.axis(1), bh.axis.regular_uoflow)
     assert not isinstance(hist.axis(1), bh.axis.variable)
 
+
+def test_shortcuts_with_metadata():
+    bh.histogram((1,2,3, "this"))
+    with pytest.raises(TypeError):
+        bh.histogram((1,2,3,4))
+    with pytest.raises(TypeError):
+        bh.histogram((1,2))
+    with pytest.raises(TypeError):
+        bh.histogram((1,2,3,4,5))
+
+    bh.histogram([1,2,3,4,5,6])
+    bh.histogram([1,2,3,4,5,6, "that"])
+
+    with pytest.raises(RuntimeError):
+        bh.histogram([1,2,"this",3])
+
+
 @pytest.mark.parametrize("axis,extent", ((bh.axis.regular_uoflow, 2),
                                          (bh.axis.regular_noflow, 0)))
 def test_make_regular_2D(axis, extent):

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -30,7 +30,7 @@ def test_init():
         histogram(1)
     with pytest.raises(RuntimeError):
         histogram("bla")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         histogram([])
     with pytest.raises(RuntimeError):
         histogram(regular_uoflow)
@@ -38,9 +38,8 @@ def test_init():
         histogram(regular_uoflow())
     with pytest.raises(RuntimeError):
         histogram([integer_uoflow(-1, 1)])
-     # TODO: Should fail
-     # CLASSIC: with pytest.raises(ValueError):
-    histogram(integer_uoflow(-1, 1), unknown_keyword="nh")
+    with pytest.raises(KeyError):
+        histogram(integer_uoflow(-1, 1), unknown_keyword="nh")
 
     h = histogram(integer_uoflow(-1, 2))
     assert h.rank() == 1

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -30,14 +30,16 @@ def test_init():
         histogram(1)
     with pytest.raises(RuntimeError):
         histogram("bla")
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         histogram([])
     with pytest.raises(RuntimeError):
         histogram(regular_uoflow)
     with pytest.raises(TypeError):
         histogram(regular_uoflow())
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         histogram([integer_uoflow(-1, 1)])
+    with pytest.raises(RuntimeError):
+        histogram([integer_uoflow(-1, 1), integer_uoflow(-1, 1)])
     with pytest.raises(KeyError):
         histogram(integer_uoflow(-1, 1), unknown_keyword="nh")
 


### PR DESCRIPTION
This makes the following equivalent:

```python
bh.histogram((10, 0, 1, "x"), [0, .5, .6, .9, 1.2])
```

```python
bh.histogram(bh.axis.regular(10, 0, 1, "x"), bh.axis.variable([0, .5, .6, .9, 1.2]))
```

A final string can be detected and used as metadata.