### PR TITLE
Dropping list shortcut for variable axes

### DIFF
--- a/src/histogram/make_histogram.cpp
+++ b/src/histogram/make_histogram.cpp
@@ -52,22 +52,6 @@ void register_make_histogram(py::module &m, py::module &hist) {
                         throw py::type_error(
                             "Only (bins, start, stop) and (bins, start, stop, metadata) tuples accepted");
                     }
-
-                    // A list converts to a variable length array.
-                } else if(py::isinstance<py::list>(args[i])) {
-                    py::list arg = py::cast<py::list>(args[i]);
-                    if(arg.size() < 2) {
-                        throw py::type_error("Variable axes require at least two edges (probably more)");
-                    }
-                    try {
-                        py::cast<double>(arg[arg.size() - 1]);
-                        args[i] = py::cast(new axis::variable_uoflow(py::cast<std::vector<double>>(arg), py::str()),
-                                           py::return_value_policy::take_ownership);
-                    } catch(const py::cast_error &) {
-                        py::object metadata = arg.attr("pop")();
-                        args[i] = py::cast(new axis::variable_uoflow(py::cast<std::vector<double>>(arg), metadata),
-                                           py::return_value_policy::take_ownership);
-                    }
                 }
             }
 

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -16,14 +16,12 @@ def test_make_regular_1D(axis, extent):
     assert hist.axis(0).bin(1).center() == approx(3.5)
 
 def test_shortcuts():
-    hist = bh.histogram([1,2,3,4,5], (10,0,1))
+    hist = bh.histogram((1,2,3), (10,0,1))
     assert hist.rank() == 2
-    assert isinstance(hist.axis(0), bh.axis.variable)
-    assert isinstance(hist.axis(0), bh.axis.variable_uoflow)
-    assert not isinstance(hist.axis(0), bh.axis.regular)
-    assert isinstance(hist.axis(1), bh.axis.regular)
-    assert isinstance(hist.axis(1), bh.axis.regular_uoflow)
-    assert not isinstance(hist.axis(1), bh.axis.variable)
+    for i in range(2):
+        assert isinstance(hist.axis(i), bh.axis.regular)
+        assert isinstance(hist.axis(i), bh.axis.regular_uoflow)
+        assert not isinstance(hist.axis(i), bh.axis.variable)
 
 
 def test_shortcuts_with_metadata():
@@ -35,11 +33,6 @@ def test_shortcuts_with_metadata():
     with pytest.raises(TypeError):
         bh.histogram((1,2,3,4,5))
 
-    bh.histogram([1,2,3,4,5,6])
-    bh.histogram([1,2,3,4,5,6, "that"])
-
-    with pytest.raises(RuntimeError):
-        bh.histogram([1,2,"this",3])
 
 
 @pytest.mark.parametrize("axis,extent", ((bh.axis.regular_uoflow, 2),

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -30,13 +30,13 @@ def test_init():
         histogram(1)
     with pytest.raises(RuntimeError):
         histogram("bla")
-    with pytest.raises(TypeError):
+    with pytest.raises(RuntimeError):
         histogram([])
     with pytest.raises(RuntimeError):
         histogram(regular_uoflow)
     with pytest.raises(TypeError):
         histogram(regular_uoflow())
-    with pytest.raises(TypeError):
+    with pytest.raises(RuntimeError):
         histogram([integer_uoflow(-1, 1)])
     with pytest.raises(RuntimeError):
         histogram([integer_uoflow(-1, 1), integer_uoflow(-1, 1)])


### PR DESCRIPTION
This removes the potentially controversial change from #47. This can be discussed later in a proper PR or issue.