### PR TITLE
Moving to latest Boost::Histogram develop, adding shrink and rebin

### DIFF
--- a/include/boost/histogram/python/pickle.hpp
+++ b/include/boost/histogram/python/pickle.hpp
@@ -4,26 +4,13 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef BOOST_HISTOGRAM_PICKLE_HPP
-#define BOOST_HISTOGRAM_PICKLE_HPP
+#pragma once
+
+#include <boost/histogram/detail/meta.hpp>
+#include <boost/histogram/python/pybind11.hpp>
 
 #include <boost/assert.hpp>
-#include <boost/histogram/accumulators/mean.hpp>
-#include <boost/histogram/accumulators/sum.hpp>
-#include <boost/histogram/accumulators/weighted_mean.hpp>
-#include <boost/histogram/accumulators/weighted_sum.hpp>
-#include <boost/histogram/axis/category.hpp>
-#include <boost/histogram/axis/integer.hpp>
-#include <boost/histogram/axis/regular.hpp>
-#include <boost/histogram/axis/variable.hpp>
-#include <boost/histogram/axis/variant.hpp>
-#include <boost/histogram/histogram.hpp>
-#include <boost/histogram/storage_adaptor.hpp>
-#include <boost/histogram/unlimited_storage.hpp>
-#include <boost/histogram/unsafe_access.hpp>
 #include <boost/mp11/tuple.hpp>
-
-#include <boost/histogram/python/pybind11.hpp>
 
 #include <type_traits>
 
@@ -113,146 +100,12 @@ decltype(auto) make_pickle() {
         });
 }
 
-// Note that this is just designed this way to make accessing private members easy.
-// Python does all the serialization.
+// This allows the serialization header to be as close as possible to the official one
+namespace serialization {
 
-namespace boost {
-namespace histogram {
-
-namespace accumulators {
-
-template <class RealType>
-template <class Archive>
-void sum<RealType>::serialize(Archive &ar, unsigned /* version */) {
-    ar &large_ &small_;
+template <typename T>
+decltype(auto) make_nvp(const char *, T &&item) {
+    return item;
 }
 
-template <class RealType>
-template <class Archive>
-void weighted_sum<RealType>::serialize(Archive &ar, unsigned /* version */) {
-    ar &sum_of_weights_ &sum_of_weights_squared_;
-}
-
-template <class RealType>
-template <class Archive>
-void mean<RealType>::serialize(Archive &ar, unsigned /* version */) {
-    ar &sum_ &mean_ &sum_of_deltas_squared_;
-}
-
-template <class RealType>
-template <class Archive>
-void weighted_mean<RealType>::serialize(Archive &ar, unsigned /* version */) {
-    ar &sum_of_weights_ &sum_of_weights_squared_ &weighted_mean_ &sum_of_weighted_deltas_squared_;
-}
-} // namespace accumulators
-
-namespace axis {
-
-namespace transform {
-template <class Archive>
-void serialize(Archive &, id &, unsigned /* version */) {}
-
-template <class Archive>
-void serialize(Archive &, log &, unsigned /* version */) {}
-
-template <class Archive>
-void serialize(Archive &, sqrt &, unsigned /* version */) {}
-
-template <class Archive>
-void serialize(Archive &ar, pow &t, unsigned /* version */) {
-    ar &t.power;
-}
-} // namespace transform
-
-template <class Archive>
-void serialize(Archive &, null_type &, unsigned /* version */) {}
-
-template <class T, class Tr, class M, class O>
-template <class Archive>
-void regular<T, Tr, M, O>::serialize(Archive &ar, unsigned /* version */) {
-    ar &static_cast<transform_type &>(*this);
-    ar &size_meta_.first() & size_meta_.second() & min_ &delta_;
-}
-
-template <class T, class M, class O>
-template <class Archive>
-void integer<T, M, O>::serialize(Archive &ar, unsigned /* version */) {
-    ar &size_meta_.first() & size_meta_.second() & min_;
-}
-
-template <class T, class M, class O, class A>
-template <class Archive>
-void variable<T, M, O, A>::serialize(Archive &ar, unsigned /* version */) {
-    ar &vec_meta_.first() & vec_meta_.second();
-}
-
-template <class T, class M, class O, class A>
-template <class Archive>
-void category<T, M, O, A>::serialize(Archive &ar, unsigned /* version */) {
-    ar &vec_meta_.first() & vec_meta_.second();
-}
-
-template <class... Ts>
-template <class Archive>
-void variant<Ts...>::serialize(Archive &ar, unsigned /* version */) {
-    ar &impl;
-}
-} // namespace axis
-
-namespace detail {
-template <class Archive, class T>
-void serialize(Archive &ar, vector_impl<T> &impl, unsigned /* version */) {
-    ar &static_cast<T &>(impl);
-}
-
-template <class Archive, class T>
-void serialize(Archive &ar, array_impl<T> &impl, unsigned /* version */) {
-    ar &impl.size_ &impl;
-}
-
-template <class Archive, class T>
-void serialize(Archive &ar, map_impl<T> &impl, unsigned /* version */) {
-    ar &impl.size_ &static_cast<T &>(impl);
-}
-
-template <class Archive, class Allocator>
-void serialize(Archive &ar, mp_int<Allocator> &x, unsigned /* version */) {
-    ar &x.data;
-}
-} // namespace detail
-
-template <class Archive, class T>
-void serialize(Archive &ar, storage_adaptor<T> &s, unsigned /* version */) {
-    ar &static_cast<detail::storage_adaptor_impl<T> &>(s);
-}
-
-template <class A>
-template <class Archive>
-void unlimited_storage<A>::serialize(Archive &ar, unsigned /* version */) {
-    if(Archive::is_loading::value) {
-        buffer_type dummy(buffer.alloc);
-        std::size_t size;
-
-        ar &dummy.type &size;
-
-        dummy.apply([this, size](auto *tp) {
-            BOOST_ASSERT(tp == nullptr);
-            using T = detail::remove_cvref_t<decltype(*tp)>;
-            buffer.template make<T>(size);
-        });
-    } else {
-        ar &buffer.type &buffer.size;
-    }
-
-    buffer.apply([&ar](auto *tp) { ar &*tp; });
-}
-
-template <class Archive, class A, class S>
-void serialize(Archive &ar, histogram<A, S> &h, unsigned /* version */) {
-    ar &unsafe_access::axes(h) & unsafe_access::storage(h);
-}
-
-} // namespace histogram
-} // namespace boost
-
-#endif
+} // namespace serialization

--- a/include/boost/histogram/python/register_accumulator.hpp
+++ b/include/boost/histogram/python/register_accumulator.hpp
@@ -8,7 +8,7 @@
 #include <boost/histogram/python/pybind11.hpp>
 #include <pybind11/operators.h>
 
-#include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/serializion.hpp>
 
 #include <utility>
 

--- a/include/boost/histogram/python/register_axis.hpp
+++ b/include/boost/histogram/python/register_axis.hpp
@@ -12,7 +12,7 @@
 #include <pybind11/operators.h>
 
 #include <boost/histogram/python/axis.hpp>
-#include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/serializion.hpp>
 
 #include <boost/histogram.hpp>
 #include <boost/histogram/axis/ostream.hpp>

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -12,7 +12,7 @@
 #include <boost/histogram/python/axis.hpp>
 #include <boost/histogram/python/histogram.hpp>
 #include <boost/histogram/python/histogram_fill.hpp>
-#include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/serializion.hpp>
 #include <boost/histogram/python/storage.hpp>
 
 #include <boost/histogram.hpp>
@@ -137,19 +137,36 @@ py::class_<bh::histogram<A, S>> register_histogram(py::module &m, const char *na
             },
             "flow"_a = false)
 
-        /* Broken: Does not work if any string axes present (even just in variant)
-         .def("rebin", [](const histogram_t &self, unsigned axis, unsigned merge){
-         return bh::algorithm::reduce(self, bh::algorithm::rebin(axis, merge));
-         }, "axis"_a, "merge"_a, "Rebin by merging bins. You must select an axis.")
+        /* Broken: Does not work if any string axes present (even just in variant) */
+        .def(
+            "rebin",
+            [](const histogram_t &self, unsigned axis, unsigned merge) {
+                return bh::algorithm::reduce(self, bh::algorithm::rebin(axis, merge));
+            },
+            "axis"_a,
+            "merge"_a,
+            "Rebin by merging bins. You must select an axis.")
 
-         .def("shrink", [](const histogram_t &self, unsigned axis, double lower, double upper){
-         return bh::algorithm::reduce(self, bh::algorithm::shrink(axis, lower, upper));
-         }, "axis"_a, "lower"_a, "upper"_a, "Shrink an axis. You must select an axis.")
+        .def(
+            "shrink",
+            [](const histogram_t &self, unsigned axis, double lower, double upper) {
+                return bh::algorithm::reduce(self, bh::algorithm::shrink(axis, lower, upper));
+            },
+            "axis"_a,
+            "lower"_a,
+            "upper"_a,
+            "Shrink an axis. You must select an axis.")
 
-         .def("shrink_and_rebin", [](const histogram_t &self, unsigned axis, double lower, double upper, unsigned
-         merge){ return bh::algorithm::reduce(self, bh::algorithm::shrink_and_rebin(axis, lower, upper, merge));
-         }, "axis"_a, "lower"_a, "upper"_a, "merge"_a, "Shrink an axis and rebin. You must select an axis.")
-         */
+        .def(
+            "shrink_and_rebin",
+            [](const histogram_t &self, unsigned axis, double lower, double upper, unsigned merge) {
+                return bh::algorithm::reduce(self, bh::algorithm::shrink_and_rebin(axis, lower, upper, merge));
+            },
+            "axis"_a,
+            "lower"_a,
+            "upper"_a,
+            "merge"_a,
+            "Shrink an axis and rebin. You must select an axis.")
 
         .def(
             "project",
@@ -166,7 +183,7 @@ py::class_<bh::histogram<A, S>> register_histogram(py::module &m, const char *na
 
     using S_value = typename bh::detail::remove_cvref_t<S>::value_type;
 
-    add_fill(bh::detail::is_incrementable<S_value>{}, std::is_same<S, storage::atomic_int>{}, hist);
+    add_fill(bh::detail::has_operator_preincrement<S_value>{}, std::is_same<S, storage::atomic_int>{}, hist);
 
     return hist;
 }

--- a/include/boost/histogram/python/register_storage.hpp
+++ b/include/boost/histogram/python/register_storage.hpp
@@ -7,7 +7,7 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
-#include <boost/histogram/python/pickle.hpp>
+#include <boost/histogram/python/serializion.hpp>
 #include <boost/histogram/python/storage.hpp>
 #include <pybind11/operators.h>
 

--- a/include/boost/histogram/python/serializion.hpp
+++ b/include/boost/histogram/python/serializion.hpp
@@ -1,0 +1,193 @@
+
+// Copyright 2015-2019 Hans Dembinski and Henry Schreiner
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_HISTOGRAM_PICKLE_HPP
+#define BOOST_HISTOGRAM_PICKLE_HPP
+
+#include <boost/histogram/python/pybind11.hpp>
+
+#include <boost/histogram/python/pickle.hpp>
+
+#include <boost/assert.hpp>
+#include <boost/histogram/accumulators/mean.hpp>
+#include <boost/histogram/accumulators/sum.hpp>
+#include <boost/histogram/accumulators/weighted_mean.hpp>
+#include <boost/histogram/accumulators/weighted_sum.hpp>
+#include <boost/histogram/axis/category.hpp>
+#include <boost/histogram/axis/integer.hpp>
+#include <boost/histogram/axis/regular.hpp>
+#include <boost/histogram/axis/variable.hpp>
+#include <boost/histogram/axis/variant.hpp>
+#include <boost/histogram/histogram.hpp>
+#include <boost/histogram/storage_adaptor.hpp>
+#include <boost/histogram/unlimited_storage.hpp>
+#include <boost/histogram/unsafe_access.hpp>
+#include <boost/mp11/tuple.hpp>
+
+#include <type_traits>
+
+// Note that this is just designed this way to make accessing private members easy.
+// Python does all the serialization.
+
+namespace boost {
+namespace histogram {
+
+namespace accumulators {
+
+template <class RealType>
+template <class Archive>
+void sum<RealType>::serialize(Archive &ar, unsigned /* version */) {
+    ar &serialization::make_nvp("large", large_);
+    ar &serialization::make_nvp("small", small_);
+}
+
+template <class RealType>
+template <class Archive>
+void weighted_sum<RealType>::serialize(Archive &ar, unsigned /* version */) {
+    ar &serialization::make_nvp("sum_of_weights", sum_of_weights_);
+    ar &serialization::make_nvp("sum_of_weights_squared", sum_of_weights_squared_);
+}
+
+template <class RealType>
+template <class Archive>
+void mean<RealType>::serialize(Archive &ar, unsigned /* version */) {
+    ar &serialization::make_nvp("sum", sum_);
+    ar &serialization::make_nvp("mean", mean_);
+    ar &serialization::make_nvp("sum_of_deltas_squared", sum_of_deltas_squared_);
+}
+
+template <class RealType>
+template <class Archive>
+void weighted_mean<RealType>::serialize(Archive &ar, unsigned /* version */) {
+    ar &serialization::make_nvp("sum_of_weights", sum_of_weights_);
+    ar &serialization::make_nvp("sum_of_weights_squared", sum_of_weights_squared_);
+    ar &serialization::make_nvp("weighted_mean", weighted_mean_);
+    ar &serialization::make_nvp("sum_of_weighted_deltas_squared", sum_of_weighted_deltas_squared_);
+}
+} // namespace accumulators
+
+namespace axis {
+
+namespace transform {
+template <class Archive>
+void serialize(Archive &, id &, unsigned /* version */) {}
+
+template <class Archive>
+void serialize(Archive &, log &, unsigned /* version */) {}
+
+template <class Archive>
+void serialize(Archive &, sqrt &, unsigned /* version */) {}
+
+template <class Archive>
+void serialize(Archive &ar, pow &t, unsigned /* version */) {
+    ar &serialization::make_nvp("power", t.power);
+}
+} // namespace transform
+
+template <class Archive>
+void serialize(Archive &, null_type &, unsigned /* version */) {}
+
+template <class T, class Tr, class M, class O>
+template <class Archive>
+void regular<T, Tr, M, O>::serialize(Archive &ar, unsigned /* version */) {
+    ar &serialization::make_nvp("transform", static_cast<transform_type &>(*this));
+    ar &serialization::make_nvp("size", size_meta_.first());
+    ar &serialization::make_nvp("meta", size_meta_.second());
+    ar &serialization::make_nvp("min", min_);
+    ar &serialization::make_nvp("delta", delta_);
+}
+
+template <class T, class M, class O>
+template <class Archive>
+void integer<T, M, O>::serialize(Archive &ar, unsigned /* version */) {
+    ar &serialization::make_nvp("size", size_meta_.first());
+    ar &serialization::make_nvp("meta", size_meta_.second());
+    ar &serialization::make_nvp("min", min_);
+}
+
+template <class T, class M, class O, class A>
+template <class Archive>
+void variable<T, M, O, A>::serialize(Archive &ar, unsigned /* version */) {
+    ar &serialization::make_nvp("seq", vec_meta_.first());
+    ar &serialization::make_nvp("meta", vec_meta_.second());
+}
+
+template <class T, class M, class O, class A>
+template <class Archive>
+void category<T, M, O, A>::serialize(Archive &ar, unsigned /* version */) {
+    ar &serialization::make_nvp("seq", vec_meta_.first());
+    ar &serialization::make_nvp("meta", vec_meta_.second());
+}
+
+template <class... Ts>
+template <class Archive>
+void variant<Ts...>::serialize(Archive &ar, unsigned /* version */) {
+    ar &serialization::make_nvp("variant", impl);
+}
+} // namespace axis
+
+namespace detail {
+template <class Archive, class T>
+void serialize(Archive &ar, vector_impl<T> &impl, unsigned /* version */) {
+    ar &serialization::make_nvp("vector", static_cast<T &>(impl));
+}
+
+template <class Archive, class T>
+void serialize(Archive &ar, array_impl<T> &impl, unsigned /* version */) {
+    ar &serialization::make_nvp("size", impl.size_);
+    ar &serialization::make_nvp("array", impl);
+}
+
+template <class Archive, class T>
+void serialize(Archive &ar, map_impl<T> &impl, unsigned /* version */) {
+    // Difference from official: arrays are directly supported
+    ar &serialization::make_nvp("size", impl.size_);
+    ar &serialization::make_nvp("map", static_cast<T &>(impl));
+}
+
+template <class Archive, class Allocator>
+void serialize(Archive &ar, large_int<Allocator> &x, unsigned /* version */) {
+    ar &serialization::make_nvp("data", x.data);
+}
+} // namespace detail
+
+template <class Archive, class T>
+void serialize(Archive &ar, storage_adaptor<T> &s, unsigned /* version */) {
+    ar &serialization::make_nvp("impl", static_cast<detail::storage_adaptor_impl<T> &>(s));
+}
+
+template <class Allocator, class Archive>
+void serialize(Archive &ar, unlimited_storage<Allocator> &s, unsigned /* version */) {
+    auto &buffer   = unsafe_access::unlimited_storage_buffer(s);
+    using buffer_t = std::remove_reference_t<decltype(buffer)>;
+    if(Archive::is_loading::value) {
+        buffer_t helper(buffer.alloc);
+        std::size_t size;
+        ar &serialization::make_nvp("type", helper.type);
+        ar &serialization::make_nvp("size", size);
+        helper.visit([&buffer, size](auto *tp) {
+            BOOST_ASSERT(tp == nullptr);
+            using T = detail::remove_cvref_t<decltype(*tp)>;
+            buffer.template make<T>(size);
+        });
+    } else {
+        ar &serialization::make_nvp("type", buffer.type);
+        ar &serialization::make_nvp("size", buffer.size);
+    }
+    buffer.visit([&buffer, &ar](auto *) { ar &serialization::make_nvp("buffer", buffer); });
+}
+
+template <class Archive, class A, class S>
+void serialize(Archive &ar, histogram<A, S> &h, unsigned /* version */) {
+    ar &serialization::make_nvp("axes", unsafe_access::axes(h));
+    ar &serialization::make_nvp("storage", unsafe_access::storage(h));
+}
+
+} // namespace histogram
+} // namespace boost
+
+#endif

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -305,29 +305,47 @@ def test_operators():
     with pytest.raises(TypeError):
         h + h2
 
-# CLASSIC: reduce is not yet supported
-@pytest.mark.skip(message="Reductions not yet supported")
-def test_reduce_to(self):
+# CLASSIC: reduce_to -> project,
+def test_project():
     h = histogram(integer_uoflow(0, 2), integer_uoflow(1, 4))
     h.fill(0, 1)
     h.fill(0, 2)
     h.fill(1, 3)
 
-    h0 = h.reduce_to(0)
+    h0 = h.project(0)
     assert h0.rank() == 1
-    assert h0.axis() == integer_uoflow(0, 2)
+    assert h0.axis(0) == integer_uoflow(0, 2)
     assert [h0.at(i) for i in range(2)] == [2, 1]
 
-    h1 = h.reduce_to(1)
+    h1 = h.project(1)
     assert h1.rank() == 1
-    assert h1.axis() == integer_uoflow(1, 4)
+    assert h1.axis(0) == integer_uoflow(1, 4)
     assert [h1.at(i) for i in range(3)] == [1, 1, 1]
 
-    with pytest.raises(ValueError):
-        h.reduce_to(*range(100))
+    # CLASSIC: Was value error
+    with pytest.raises(IndexError):
+        h.project(*range(10))
 
-    with pytest.raises(ValueError):
-        h.reduce_to(2, 1)
+    with pytest.raises(IndexError):
+        h.project(2, 1)
+
+def test_shrink_1d():
+    h = histogram(regular_uoflow(20, 1, 5))
+    h.fill(1.1)
+    hs = h.shrink(0, 1, 2)
+    assert_array_equal(hs.view(), [1,0,0,0,0])
+
+def test_rebin_1d():
+    h = histogram(regular_uoflow(20, 1, 5))
+    h.fill(1.1)
+    hs = h.rebin(0, 4)
+    assert_array_equal(hs.view(), [1,0,0,0,0])
+
+def test_shrink_rebin_1d():
+    h = histogram(regular_uoflow(20, 0, 4))
+    h.fill(1.1)
+    hs = h.shrink_and_rebin(0, 1, 3, 2)
+    assert_array_equal(hs.view(), [1,0,0,0,0])
 
 
 # CLASSIC: This used to have metadata too, but that does not compare equal


### PR DESCRIPTION
Restructured serialization to more closely resemble official serialization headers. It would be nice if some of the code could be shared to reduce changes in the future.