### PR TITLE
CMake checks for dev packages when configuring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,8 @@ configure_file(
 include(CTest)
 
 function(python_import PACKAGE_NAME)
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import ${PACKAGE_NAME}" RESULT_VARIABLE RESULT_PRESENT)
+    string(REPLACE "-" "_" PYTHON_PACKAGE_NAME "${PACKAGE_NAME}")
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import ${PYTHON_PACKAGE_NAME}" RESULT_VARIABLE RESULT_PRESENT)
     if(RESULT_PRESENT)
         message(SEND_ERROR "You should pip install ${PACKAGE_NAME}")
     endif()
@@ -134,7 +135,7 @@ if(BUILD_TESTING)
 
     python_import(numpy)
     python_import(pytest)
-    python_import(pytest_benchmark)
+    python_import(pytest-benchmark)
 
     # Support for running from build directory
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/pytest.ini"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,18 @@ configure_file(
 # Tests (Requires pytest to be available to run)
 include(CTest)
 
+function(python_import PACKAGE_NAME)
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import ${PACKAGE_NAME}" RESULT_VARIABLE RESULT_PRESENT)
+    if(RESULT_PRESENT)
+        message(SEND_ERROR "You should pip install ${PACKAGE_NAME}")
+    endif()
+endfunction()
+
 if(BUILD_TESTING)
+
+    python_import(numpy)
+    python_import(pytest)
+    python_import(pytest_benchmark)
 
     # Support for running from build directory
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/pytest.ini"


### PR DESCRIPTION
As requested by @HDembinski, a CMake user will now get an error sooner if they don't have pytest-benchmark.

TODO: Fix the name so that it says `pip install pytest-benchmark` instead of `pip install pytest_benchmark`. Have I mentioned that dashes in package names are irritating? ✅ 

Closes #63.