### PR TITLE
Adding live at head check

### DIFF
--- a/.ci/azure-live-at-head-pipeline.yml
+++ b/.ci/azure-live-at-head-pipeline.yml
@@ -1,0 +1,32 @@
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 12 * * 0"
+  displayName: Weekly Sunday build
+  branches:
+    include:
+    - develop
+  always: true
+
+
+variables:
+  # This is the output name, - is replaced by _
+  package_name: boost_histogram
+
+jobs:
+
+
+- job: LinuxCMake
+  strategy:
+    matrix:
+      Python37:
+        python.version: '3.7'
+        python.architecture: 'x64'
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - template: azure-setup.yml
+    - template: azure-live-at-head.yml
+    - template: azure-cmake-steps.yml
+

--- a/.ci/azure-live-at-head.yml
+++ b/.ci/azure-live-at-head.yml
@@ -1,0 +1,6 @@
+steps:
+
+- script: |
+    git submodule foreach "git checkout develop || git checkout master"
+    # Note: you need to add a git pull here if you are not on a clean checkout, but Azure always is
+  displayName: 'Live at head'


### PR DESCRIPTION
Adding a weekly check for the most recent develop or master branches of all dependencies. Based on Google's live at head philosophy.