### PR TITLE
Private rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Python bindings for [Boost::Histogram][] ([source][Boost::Histogram source]), a 
 
 ## Installation
 
-This library is under development, but you can install directly from github if you would like. You need a C++14 compiler and Python 2.7--3.7. Boost 1.70 is not required or needed (this only depends on included header-only dependencies).
+This library is under development, but you can install directly from github if you would like. You need a C++14 compiler and Python 2.7--3.7. Boost 1.71 is not required or needed (this only depends on included header-only dependencies).
 All the normal best-practices for Python apply; you should be in a virtual environment, otherwise add `--user`, etc.
 
 ```bash
@@ -44,31 +44,13 @@ counts = hist.view()
 
 * Many axis types (all support `metadata=...`)
     * `bh.axis.regular(n, start, stop, underflow=True, overflow=True, growth=False)`: shortcut to make the types below. `flow=False` is also supported.
-        * `bh.axis._regular_uoflow(n, start, stop)`: `n` evenly spaced bins from `start` to `stop`
-        * `bh.axis._regular_uflow(n, start, stop)`: `n` evenly spaced bins from `start` to `stop` (no overflow)
-        * `bh.axis._regular_oflow(n, start, stop)`: `n` evenly spaced bins from `start` to `stop` (no underflow)
-        * `bh.axis._regular_noflow(n, start, stop)`: `regular` but with no underflow or overflow bins
-        * `bh.axis._regular_growth(n, start, stop)`: `regular` but grows if a value is added outside the range
     * `bh.axis.circular(n, start, stop)`: Value outside the range wrap into the range
     * `bh.axis.regular_log(n, start, stop)`: Regularly spaced values in log 10 scale
     * `bh.axis.regular_sqrt(n, start, stop)`: Regularly spaced value in sqrt scale
     * `bh.axis.regular_pow(n, start, stop, power)`: Regularly spaced value to some `power`
     * `bh.axis.integer(start, stop, underflow=True, overflow=True, growth=False)`: Special high-speed version of `regular` for evenly spaced bins of width 1
-        * `bh.axis._integer_uoflow(start, stop)`: `n` evenly spaced bins from `start` to `stop`
-        * `bh.axis._integer_uflow(start, stop)`: `n` evenly spaced bins from `start` to `stop` (no overflow)
-        * `bh.axis._integer_oflow(start, stop)`: `n` evenly spaced bins from `start` to `stop` (no underflow)
-        * `bh.axis._integer_noflow(start, stop)`: `integer` but with no underflow or overflow bins
-        * `bh.axis._integer_growth(start, stop)`: `integer` but grows if a value is added outside the range
     * `bh.axis.variable([start, edge1, edge2, ..., stop], underflow=True, overflow=True)`: Uneven bin spacing
-        * `bh.axis._variable_uoflow([start, edge1, edge2, ..., stop])`: `n` evenly spaced bins from `start` to `stop`
-        * `bh.axis._variable_uflow([start, edge1, edge2, ..., stop])`: `n` evenly spaced bins from `start` to `stop` (no overflow)
-        * `bh.axis._variable_oflow([start, edge1, edge2, ..., stop])`: `n` evenly spaced bins from `start` to `stop` (no underflow)
-        * `bh.axis._variable_noflow([start, edge1, edge2, ..., stop])`: `variable` but with no underflow or overflow bins
-    * `bh.axis.category([...], growth=False)`: Integer or string categories
-        * `bh.axis._category_int([1, 2, ...])`: Integer bins
-        * `bh.axis._category_int_growth([1, 2, ...])`: Integer bins where new items are added automatically
-        * `bh.axis._category_str(["item1", "item2", ...])`: WIP: String bins
-        * `bh.axis._category_str_growth(["item1", "item2", ...])`: WIP: String bins where new items are added automatically
+    * `bh.axis.category([...], growth=False)`: Integer or (WIP) string categories
 * Axis features:
     * `.bin(i)`: The bin or a bin view for continuous axis types
         * `.lower()`: The lower value
@@ -98,6 +80,7 @@ counts = hist.view()
     * `bh.accumulator.sum`: High accuracy sum (Neumaier)
     * `bh.accumulator.mean`: Running count, mean, and variance (Welfords's incremental algorithm)
 * Histogram operations
+    * `.fill(arr, ..., weight=...)` Fill with N arrays or single values
     * `(a, b, ...)`: Fill with arrays or single values
     * `+`: Add two histograms
     * `.rank()`: The number of dimensions
@@ -214,7 +197,7 @@ This will checkout new versions of the dependencies. Example given using the fis
 for f in *
     cd $f
     git fetch
-    git checkout boost-1.70.0 || echo "Not found"
+    git checkout boost-1.71.0 || echo "Not found"
     cd ..
 end
 ```
@@ -232,6 +215,6 @@ end
 [rtd-badge]:               https://readthedocs.org/projects/boost-histogram/badge/?version=latest
 [rtd-link]:                https://boost-histogram.readthedocs.io/en/latest/?badge=latest
 
-[Boost::Histogram]:        https://www.boost.org/doc/libs/1_70_0/libs/histogram/doc/html/index.html
+[Boost::Histogram]:        https://www.boost.org/doc/libs/1_71_0/libs/histogram/doc/html/index.html
 [Boost::Histogram source]: https://github.com/boostorg/histogram
 [fastest libraries]:       https://iscinumpy.gitlab.io/post/histogram-speeds-in-python/

--- a/README.md
+++ b/README.md
@@ -44,31 +44,31 @@ counts = hist.view()
 
 * Many axis types (all support `metadata=...`)
     * `bh.axis.regular(n, start, stop, underflow=True, overflow=True, growth=False)`: shortcut to make the types below. `flow=False` is also supported.
-        * `bh.axis.regular_uoflow(n, start, stop)`: `n` evenly spaced bins from `start` to `stop`
-        * `bh.axis.regular_uflow(n, start, stop)`: `n` evenly spaced bins from `start` to `stop` (no overflow)
-        * `bh.axis.regular_oflow(n, start, stop)`: `n` evenly spaced bins from `start` to `stop` (no underflow)
-        * `bh.axis.regular_noflow(n, start, stop)`: `regular` but with no underflow or overflow bins
-        * `bh.axis.regular_growth(n, start, stop)`: `regular` but grows if a value is added outside the range
+        * `bh.axis._regular_uoflow(n, start, stop)`: `n` evenly spaced bins from `start` to `stop`
+        * `bh.axis._regular_uflow(n, start, stop)`: `n` evenly spaced bins from `start` to `stop` (no overflow)
+        * `bh.axis._regular_oflow(n, start, stop)`: `n` evenly spaced bins from `start` to `stop` (no underflow)
+        * `bh.axis._regular_noflow(n, start, stop)`: `regular` but with no underflow or overflow bins
+        * `bh.axis._regular_growth(n, start, stop)`: `regular` but grows if a value is added outside the range
     * `bh.axis.circular(n, start, stop)`: Value outside the range wrap into the range
     * `bh.axis.regular_log(n, start, stop)`: Regularly spaced values in log 10 scale
     * `bh.axis.regular_sqrt(n, start, stop)`: Regularly spaced value in sqrt scale
     * `bh.axis.regular_pow(n, start, stop, power)`: Regularly spaced value to some `power`
     * `bh.axis.integer(start, stop, underflow=True, overflow=True, growth=False)`: Special high-speed version of `regular` for evenly spaced bins of width 1
-        * `bh.axis.integer_uoflow(start, stop)`: `n` evenly spaced bins from `start` to `stop`
-        * `bh.axis.integer_uflow(start, stop)`: `n` evenly spaced bins from `start` to `stop` (no overflow)
-        * `bh.axis.integer_oflow(start, stop)`: `n` evenly spaced bins from `start` to `stop` (no underflow)
-        * `bh.axis.integer_noflow(start, stop)`: `integer` but with no underflow or overflow bins
-        * `bh.axis.integer_growth(start, stop)`: `integer` but grows if a value is added outside the range
+        * `bh.axis._integer_uoflow(start, stop)`: `n` evenly spaced bins from `start` to `stop`
+        * `bh.axis._integer_uflow(start, stop)`: `n` evenly spaced bins from `start` to `stop` (no overflow)
+        * `bh.axis._integer_oflow(start, stop)`: `n` evenly spaced bins from `start` to `stop` (no underflow)
+        * `bh.axis._integer_noflow(start, stop)`: `integer` but with no underflow or overflow bins
+        * `bh.axis._integer_growth(start, stop)`: `integer` but grows if a value is added outside the range
     * `bh.axis.variable([start, edge1, edge2, ..., stop], underflow=True, overflow=True)`: Uneven bin spacing
-        * `bh.axis.variable_uoflow([start, edge1, edge2, ..., stop])`: `n` evenly spaced bins from `start` to `stop`
-        * `bh.axis.variable_uflow([start, edge1, edge2, ..., stop])`: `n` evenly spaced bins from `start` to `stop` (no overflow)
-        * `bh.axis.variable_oflow([start, edge1, edge2, ..., stop])`: `n` evenly spaced bins from `start` to `stop` (no underflow)
-        * `bh.axis.variable_noflow([start, edge1, edge2, ..., stop])`: `variable` but with no underflow or overflow bins
+        * `bh.axis._variable_uoflow([start, edge1, edge2, ..., stop])`: `n` evenly spaced bins from `start` to `stop`
+        * `bh.axis._variable_uflow([start, edge1, edge2, ..., stop])`: `n` evenly spaced bins from `start` to `stop` (no overflow)
+        * `bh.axis._variable_oflow([start, edge1, edge2, ..., stop])`: `n` evenly spaced bins from `start` to `stop` (no underflow)
+        * `bh.axis._variable_noflow([start, edge1, edge2, ..., stop])`: `variable` but with no underflow or overflow bins
     * `bh.axis.category([...], growth=False)`: Integer or string categories
-        * `bh.axis.category_int([1, 2, ...])`: Integer bins
-        * `bh.axis.category_int_growth([1, 2, ...])`: Integer bins where new items are added automatically
-        * `bh.axis.category_str(["item1", "item2", ...])`: WIP: String bins
-        * `bh.axis.category_str_growth(["item1", "item2", ...])`: WIP: String bins where new items are added automatically
+        * `bh.axis._category_int([1, 2, ...])`: Integer bins
+        * `bh.axis._category_int_growth([1, 2, ...])`: Integer bins where new items are added automatically
+        * `bh.axis._category_str(["item1", "item2", ...])`: WIP: String bins
+        * `bh.axis._category_str_growth(["item1", "item2", ...])`: WIP: String bins where new items are added automatically
 * Axis features:
     * `.bin(i)`: The bin or a bin view for continuous axis types
         * `.lower()`: The lower value

--- a/docs/_src/images/axis_category.tex
+++ b/docs/_src/images/axis_category.tex
@@ -33,7 +33,7 @@
 \node at (.5, 0) [above] {8};
 \node at (.7, 0) [above] {3};
 \node at (.9, 0) [above] {7};
-\node at (.5,0) [below] {\verb|bh.axis.category_int([2,5,8,3,7])|};
+\node at (.5,0) [below] {\verb|bh.axis._category_int([2,5,8,3,7])|};
 \end{tikzpicture}
 
 \end{document}

--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -71,64 +71,64 @@ namespace axis {
 
 // These match the Python names
 
-using regular_uoflow = bh::axis::regular<double, bh::use_default, metadata_t>;
-using regular_uflow  = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::underflow_t>;
-using regular_oflow  = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::overflow_t>;
-using regular_noflow = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::none_t>;
-using regular_growth = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::growth_t>;
+using _regular_uoflow = bh::axis::regular<double, bh::use_default, metadata_t>;
+using _regular_uflow  = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::underflow_t>;
+using _regular_oflow  = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::overflow_t>;
+using _regular_noflow = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::none_t>;
+using _regular_growth = bh::axis::regular<double, bh::use_default, metadata_t, bh::axis::option::growth_t>;
 
 using circular     = bh::axis::circular<double, metadata_t>;
 using regular_log  = bh::axis::regular<double, bh::axis::transform::log, metadata_t>;
 using regular_sqrt = bh::axis::regular<double, bh::axis::transform::sqrt, metadata_t>;
 using regular_pow  = bh::axis::regular<double, bh::axis::transform::pow, metadata_t>;
 
-using variable_uoflow = bh::axis::variable<double, metadata_t>;
-using variable_uflow  = bh::axis::variable<double, metadata_t, bh::axis::option::underflow_t>;
-using variable_oflow  = bh::axis::variable<double, metadata_t, bh::axis::option::overflow_t>;
-using variable_noflow = bh::axis::variable<double, metadata_t, bh::axis::option::none_t>;
+using _variable_uoflow = bh::axis::variable<double, metadata_t>;
+using _variable_uflow  = bh::axis::variable<double, metadata_t, bh::axis::option::underflow_t>;
+using _variable_oflow  = bh::axis::variable<double, metadata_t, bh::axis::option::overflow_t>;
+using _variable_noflow = bh::axis::variable<double, metadata_t, bh::axis::option::none_t>;
 
-using integer_uoflow = bh::axis::integer<int, metadata_t>;
-using integer_uflow  = bh::axis::integer<int, metadata_t, bh::axis::option::underflow_t>;
-using integer_oflow  = bh::axis::integer<int, metadata_t, bh::axis::option::overflow_t>;
-using integer_noflow = bh::axis::integer<int, metadata_t, bh::axis::option::none_t>;
-using integer_growth = bh::axis::integer<int, metadata_t, bh::axis::option::growth_t>;
+using _integer_uoflow = bh::axis::integer<int, metadata_t>;
+using _integer_uflow  = bh::axis::integer<int, metadata_t, bh::axis::option::underflow_t>;
+using _integer_oflow  = bh::axis::integer<int, metadata_t, bh::axis::option::overflow_t>;
+using _integer_noflow = bh::axis::integer<int, metadata_t, bh::axis::option::none_t>;
+using _integer_growth = bh::axis::integer<int, metadata_t, bh::axis::option::growth_t>;
 
-using category_int        = bh::axis::category<int, metadata_t>;
-using category_int_growth = bh::axis::category<int, metadata_t, bh::axis::option::growth_t>;
+using _category_int        = bh::axis::category<int, metadata_t>;
+using _category_int_growth = bh::axis::category<int, metadata_t, bh::axis::option::growth_t>;
 
-using category_str        = bh::axis::category<std::string, metadata_t>;
-using category_str_growth = bh::axis::category<std::string, metadata_t, bh::axis::option::growth_t>;
+using _category_str        = bh::axis::category<std::string, metadata_t>;
+using _category_str_growth = bh::axis::category<std::string, metadata_t, bh::axis::option::growth_t>;
 
 } // namespace axis
 
 namespace axes {
 
 // The following list is all types supported
-using any = std::vector<bh::axis::variant<axis::regular_uoflow,
-                                          axis::regular_uflow,
-                                          axis::regular_oflow,
-                                          axis::regular_noflow,
-                                          axis::regular_growth,
+using any = std::vector<bh::axis::variant<axis::_regular_uoflow,
+                                          axis::_regular_uflow,
+                                          axis::_regular_oflow,
+                                          axis::_regular_noflow,
+                                          axis::_regular_growth,
                                           axis::circular,
                                           axis::regular_log,
                                           axis::regular_pow,
                                           axis::regular_sqrt,
-                                          axis::variable_uoflow,
-                                          axis::variable_oflow,
-                                          axis::variable_uflow,
-                                          axis::variable_noflow,
-                                          axis::integer_uoflow,
-                                          axis::integer_oflow,
-                                          axis::integer_uflow,
-                                          axis::integer_noflow,
-                                          axis::integer_growth,
-                                          axis::category_int,
-                                          axis::category_int_growth,
-                                          axis::category_str,
-                                          axis::category_str_growth>>;
+                                          axis::_variable_uoflow,
+                                          axis::_variable_oflow,
+                                          axis::_variable_uflow,
+                                          axis::_variable_noflow,
+                                          axis::_integer_uoflow,
+                                          axis::_integer_oflow,
+                                          axis::_integer_uflow,
+                                          axis::_integer_noflow,
+                                          axis::_integer_growth,
+                                          axis::_category_int,
+                                          axis::_category_int_growth,
+                                          axis::_category_str,
+                                          axis::_category_str_growth>>;
 
 // Specialization for some speed improvement
-using regular_uoflow = std::vector<axis::regular_uoflow>;
-using regular_noflow = std::vector<axis::regular_noflow>;
+using _regular_uoflow = std::vector<axis::_regular_uoflow>;
+using _regular_noflow = std::vector<axis::_regular_noflow>;
 
 } // namespace axes

--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -127,8 +127,4 @@ using any = std::vector<bh::axis::variant<axis::_regular_uoflow,
                                           axis::_category_str,
                                           axis::_category_str_growth>>;
 
-// Specialization for some speed improvement
-using _regular_uoflow = std::vector<axis::_regular_uoflow>;
-using _regular_noflow = std::vector<axis::_regular_noflow>;
-
 } // namespace axes

--- a/notebooks/PerformanceComparison.ipynb
+++ b/notebooks/PerformanceComparison.ipynb
@@ -128,7 +128,7 @@
    ],
    "source": [
     "%%timeit\n",
-    "hist = bh.hist.any_int([bh.axis.regular(bins[0], *ranges[0])])\n",
+    "hist = bh.hist._any_int([bh.axis.regular(bins[0], *ranges[0])])\n",
     "hist(vals1d)"
    ]
   },

--- a/notebooks/PerformanceComparison.ipynb
+++ b/notebooks/PerformanceComparison.ipynb
@@ -348,7 +348,7 @@
    ],
    "source": [
     "%%timeit\n",
-    "hist = bh.hist.regular_int_noflow_1d((bh.axis.regular_noflow(bins[0], *ranges[0]),))\n",
+    "hist = bh.hist.regular_int_noflow_1d((bh.axis._regular_noflow(bins[0], *ranges[0]),))\n",
     "hist(vals1d)"
    ]
   },
@@ -380,7 +380,7 @@
     }
    ],
    "source": [
-    "hist = bh.hist.regular_int_noflow_1d((bh.axis.regular_noflow(bins[0], *ranges[0]),))\n",
+    "hist = bh.hist.regular_int_noflow_1d((bh.axis._regular_noflow(bins[0], *ranges[0]),))\n",
     "hist(vals1d)\n",
     "np.asarray(hist)"
    ]
@@ -579,8 +579,8 @@
    ],
    "source": [
     "%%timeit\n",
-    "hist = bh.hist.regular_int_noflow_2d((bh.axis.regular_noflow(bins[0], *ranges[0]),\n",
-    "                               bh.axis.regular_noflow(bins[1], *ranges[1])))\n",
+    "hist = bh.hist.regular_int_noflow_2d((bh.axis._regular_noflow(bins[0], *ranges[0]),\n",
+    "                               bh.axis._regular_noflow(bins[1], *ranges[1])))\n",
     "hist(*vals)"
    ]
   },
@@ -607,8 +607,8 @@
     }
    ],
    "source": [
-    "hist = bh.hist.regular_int_noflow_2d((bh.axis.regular_noflow(bins[0], *ranges[0]),\n",
-    "                               bh.axis.regular_noflow(bins[1], *ranges[1])))\n",
+    "hist = bh.hist.regular_int_noflow_2d((bh.axis._regular_noflow(bins[0], *ranges[0]),\n",
+    "                               bh.axis._regular_noflow(bins[1], *ranges[1])))\n",
     "hist(*vals)\n",
     "np.asarray(hist)"
    ]

--- a/scripts/performance_report.py
+++ b/scripts/performance_report.py
@@ -73,11 +73,11 @@ base = print_timer(setup_1d,
 
 
 print_timer(setup_1d,
-    'hist = bh.hist.any_int([bh.axis._regular_uoflow(bins, *ranges)]); hist.fill(vals)',
+    'hist = bh.hist._any_int([bh.axis._regular_uoflow(bins, *ranges)]); hist.fill(vals)',
     name='Any', storage='int', fill='', flow='yes', base=base)
 
 print_timer(setup_1d,
-    'hist = bh.hist.any_int([bh.axis._regular_noflow(bins, *ranges)]); hist.fill(vals)',
+    'hist = bh.hist._any_int([bh.axis._regular_noflow(bins, *ranges)]); hist.fill(vals)',
     name='Any', storage='int', fill='', flow='no', base=base)
 
 
@@ -117,11 +117,11 @@ base = print_timer(setup_2d,
     name='Numpy', storage='uint64', fill='', flow='no')
 
 print_timer(setup_2d,
-    'hist = bh.hist.any_int([bh.axis._regular_uoflow(bins[0], *ranges[0]), bh.axis._regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals)',
+    'hist = bh.hist._any_int([bh.axis._regular_uoflow(bins[0], *ranges[0]), bh.axis._regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Any', storage='int', fill='', flow='yes', base=base)
 
 print_timer(setup_2d,
-    'hist = bh.hist.any_int([bh.axis._regular_noflow(bins[0], *ranges[0]), bh.axis._regular_noflow(bins[1], *ranges[1])]); hist.fill(*vals)',
+    'hist = bh.hist._any_int([bh.axis._regular_noflow(bins[0], *ranges[0]), bh.axis._regular_noflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Any', storage='int', fill='', flow='no', base=base)
 
 print_timer(setup_2d,

--- a/scripts/performance_report.py
+++ b/scripts/performance_report.py
@@ -73,35 +73,35 @@ base = print_timer(setup_1d,
 
 
 print_timer(setup_1d,
-    'hist = bh.hist.any_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.fill(vals)',
+    'hist = bh.hist.any_int([bh.axis._regular_uoflow(bins, *ranges)]); hist.fill(vals)',
     name='Any', storage='int', fill='', flow='yes', base=base)
 
 print_timer(setup_1d,
-    'hist = bh.hist.any_int([bh.axis.regular_noflow(bins, *ranges)]); hist.fill(vals)',
+    'hist = bh.hist.any_int([bh.axis._regular_noflow(bins, *ranges)]); hist.fill(vals)',
     name='Any', storage='int', fill='', flow='no', base=base)
 
 
 print_timer(setup_1d,
-    'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.fill(vals)',
+    'hist = bh.hist.regular_int([bh.axis._regular_uoflow(bins, *ranges)]); hist.fill(vals)',
     name='Regular', storage='int', fill='', flow='yes', base=base)
 
 print_timer(setup_1d,
-    'hist = bh.hist.regular_noflow_int([bh.axis.regular_noflow(bins, *ranges)]); hist.fill(vals)',
+    'hist = bh.hist._regular_noflow_int([bh.axis._regular_noflow(bins, *ranges)]); hist.fill(vals)',
     name='Regular', storage='int', fill='', flow='no', base=base)
 
 
 print_timer(setup_1d,
-    'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.fill(vals)',
+    'hist = bh.hist.regular_atomic_int([bh.axis._regular_uoflow(bins, *ranges)]); hist.fill(vals)',
     name='Regular', storage='aint', fill='', flow='yes', base=base)
 
 for fill in counts:
     print_timer(setup_1d,
-        'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.fill(vals, atomic={fill})',
+        'hist = bh.hist.regular_atomic_int([bh.axis._regular_uoflow(bins, *ranges)]); hist.fill(vals, atomic={fill})',
         name='Regular', storage='aint', fill=fill, flow='yes', base=base)
 
 for fill in counts:
     print_timer(setup_1d,
-        'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins, *ranges)]); hist.fill(vals, threads={fill})',
+        'hist = bh.hist.regular_int([bh.axis._regular_uoflow(bins, *ranges)]); hist.fill(vals, threads={fill})',
         name='Regular', storage='int', fill=fill, flow='yes', base=base)
 
 
@@ -117,32 +117,32 @@ base = print_timer(setup_2d,
     name='Numpy', storage='uint64', fill='', flow='no')
 
 print_timer(setup_2d,
-    'hist = bh.hist.any_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals)',
+    'hist = bh.hist.any_int([bh.axis._regular_uoflow(bins[0], *ranges[0]), bh.axis._regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Any', storage='int', fill='', flow='yes', base=base)
 
 print_timer(setup_2d,
-    'hist = bh.hist.any_int([bh.axis.regular_noflow(bins[0], *ranges[0]), bh.axis.regular_noflow(bins[1], *ranges[1])]); hist.fill(*vals)',
+    'hist = bh.hist.any_int([bh.axis._regular_noflow(bins[0], *ranges[0]), bh.axis._regular_noflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Any', storage='int', fill='', flow='no', base=base)
 
 print_timer(setup_2d,
-    'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals)',
+    'hist = bh.hist.regular_int([bh.axis._regular_uoflow(bins[0], *ranges[0]), bh.axis._regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Regular', storage='int', fill='', flow='yes', base=base)
 
 print_timer(setup_2d,
-    'hist = bh.hist.regular_noflow_int([bh.axis.regular_noflow(bins[0], *ranges[0]), bh.axis.regular_noflow(bins[1], *ranges[1])]); hist.fill(*vals)',
+    'hist = bh.hist._regular_noflow_int([bh.axis._regular_noflow(bins[0], *ranges[0]), bh.axis._regular_noflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Regular', storage='int', fill='', flow='no', base=base)
 
 
 print_timer(setup_2d,
-    'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals)',
+    'hist = bh.hist.regular_atomic_int([bh.axis._regular_uoflow(bins[0], *ranges[0]), bh.axis._regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals)',
     name='Regular', storage='aint', fill='', flow='yes', base=base)
 
 for fill in counts:
     print_timer(setup_2d,
-        'hist = bh.hist.regular_atomic_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals, atomic={fill})',
+        'hist = bh.hist.regular_atomic_int([bh.axis._regular_uoflow(bins[0], *ranges[0]), bh.axis._regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals, atomic={fill})',
         name='Regular', storage='aint', fill=fill, flow='yes', base=base)
 
 for fill in counts:
     print_timer(setup_2d,
-        'hist = bh.hist.regular_int([bh.axis.regular_uoflow(bins[0], *ranges[0]), bh.axis.regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals, threads={fill})',
+        'hist = bh.hist.regular_int([bh.axis._regular_uoflow(bins[0], *ranges[0]), bh.axis._regular_uoflow(bins[1], *ranges[1])]); hist.fill(*vals, threads={fill})',
         name='Regular', storage='int', fill=fill, flow='yes', base=base)

--- a/src/histogram/axis.cpp
+++ b/src/histogram/axis.cpp
@@ -22,36 +22,36 @@ void register_axes(py::module &ax) {
     // This factory makes a class that can be used to create axes and also be used in is_instance
     py::object factory_meta_py = py::module::import("boost.histogram_utils").attr("FactoryMeta");
 
-    register_axis<axis::regular_uoflow>(ax, "regular_uoflow", "Evenly spaced bins")
-        .def(construct_axes<axis::regular_uoflow, unsigned, double, double>(),
+    register_axis<axis::_regular_uoflow>(ax, "_regular_uoflow", "Evenly spaced bins")
+        .def(construct_axes<axis::_regular_uoflow, unsigned, double, double>(),
              "n"_a,
              "start"_a,
              "stop"_a,
              "metadata"_a = py::str());
 
-    register_axis<axis::regular_uflow>(ax, "regular_uflow", "Evenly spaced bins with underflow")
-        .def(construct_axes<axis::regular_uflow, unsigned, double, double>(),
+    register_axis<axis::_regular_uflow>(ax, "_regular_uflow", "Evenly spaced bins with underflow")
+        .def(construct_axes<axis::_regular_uflow, unsigned, double, double>(),
              "n"_a,
              "start"_a,
              "stop"_a,
              "metadata"_a = py::str());
 
-    register_axis<axis::regular_oflow>(ax, "regular_oflow", "Evenly spaced bins with overflow ")
-        .def(construct_axes<axis::regular_oflow, unsigned, double, double>(),
+    register_axis<axis::_regular_oflow>(ax, "_regular_oflow", "Evenly spaced bins with overflow ")
+        .def(construct_axes<axis::_regular_oflow, unsigned, double, double>(),
              "n"_a,
              "start"_a,
              "stop"_a,
              "metadata"_a = py::str());
 
-    register_axis<axis::regular_noflow>(ax, "regular_noflow", "Evenly spaced bins without over/under flow")
-        .def(construct_axes<axis::regular_noflow, unsigned, double, double>(),
+    register_axis<axis::_regular_noflow>(ax, "_regular_noflow", "Evenly spaced bins without over/under flow")
+        .def(construct_axes<axis::_regular_noflow, unsigned, double, double>(),
              "n"_a,
              "start"_a,
              "stop"_a,
              "metadata"_a = py::str());
 
-    register_axis<axis::regular_growth>(ax, "regular_growth", "Evenly spaced bins that grow as needed")
-        .def(construct_axes<axis::regular_growth, unsigned, double, double>(),
+    register_axis<axis::_regular_growth>(ax, "_regular_growth", "Evenly spaced bins that grow as needed")
+        .def(construct_axes<axis::_regular_growth, unsigned, double, double>(),
              "n"_a,
              "start"_a,
              "stop"_a,
@@ -79,15 +79,15 @@ void register_axes(py::module &ax) {
             }
 
             if(growth) {
-                return py::cast(axis::regular_growth(n, start, stop, metadata), py::return_value_policy::move);
+                return py::cast(axis::_regular_growth(n, start, stop, metadata), py::return_value_policy::move);
             } else if(underflow && overflow) {
-                return py::cast(axis::regular_uoflow(n, start, stop, metadata), py::return_value_policy::move);
+                return py::cast(axis::_regular_uoflow(n, start, stop, metadata), py::return_value_policy::move);
             } else if(underflow && !overflow) {
-                return py::cast(axis::regular_uflow(n, start, stop, metadata), py::return_value_policy::move);
+                return py::cast(axis::_regular_uflow(n, start, stop, metadata), py::return_value_policy::move);
             } else if(!underflow && overflow) {
-                return py::cast(axis::regular_oflow(n, start, stop, metadata), py::return_value_policy::move);
+                return py::cast(axis::_regular_oflow(n, start, stop, metadata), py::return_value_policy::move);
             } else {
-                return py::cast(axis::regular_noflow(n, start, stop, metadata), py::return_value_policy::move);
+                return py::cast(axis::_regular_noflow(n, start, stop, metadata), py::return_value_policy::move);
             }
         },
         "n"_a,
@@ -101,11 +101,11 @@ void register_axes(py::module &ax) {
         "Passing 'flow' will override underflow and overflow at the same time.");
 
     ax.attr("regular") = factory_meta_py(ax.attr("_make_regular"),
-                                         py::make_tuple(ax.attr("regular_uoflow"),
-                                                        ax.attr("regular_uflow"),
-                                                        ax.attr("regular_oflow"),
-                                                        ax.attr("regular_noflow"),
-                                                        ax.attr("regular_growth")));
+                                         py::make_tuple(ax.attr("_regular_uoflow"),
+                                                        ax.attr("_regular_uflow"),
+                                                        ax.attr("_regular_oflow"),
+                                                        ax.attr("_regular_noflow"),
+                                                        ax.attr("_regular_growth")));
 
     register_axis<axis::circular>(ax, "circular", "Evenly spaced bins with wraparound")
         .def(construct_axes<axis::circular, unsigned, double, double>(),
@@ -146,17 +146,17 @@ void register_axes(py::module &ax) {
              "power"_a,
              "metadata"_a = py::str());
 
-    register_axis<axis::variable_uoflow>(ax, "variable_uoflow", "Unevenly spaced bins")
-        .def(construct_axes<axis::variable_uoflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
+    register_axis<axis::_variable_uoflow>(ax, "_variable_uoflow", "Unevenly spaced bins")
+        .def(construct_axes<axis::_variable_uoflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
 
-    register_axis<axis::variable_uflow>(ax, "variable_uflow", "Unevenly spaced bins with underflow")
-        .def(construct_axes<axis::variable_uflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
+    register_axis<axis::_variable_uflow>(ax, "_variable_uflow", "Unevenly spaced bins with underflow")
+        .def(construct_axes<axis::_variable_uflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
 
-    register_axis<axis::variable_oflow>(ax, "variable_oflow", "Unevenly spaced bins with overflow")
-        .def(construct_axes<axis::variable_oflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
+    register_axis<axis::_variable_oflow>(ax, "_variable_oflow", "Unevenly spaced bins with overflow")
+        .def(construct_axes<axis::_variable_oflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
 
-    register_axis<axis::variable_noflow>(ax, "variable_noflow", "Unevenly spaced bins without under/overflow")
-        .def(construct_axes<axis::variable_noflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
+    register_axis<axis::_variable_noflow>(ax, "_variable_noflow", "Unevenly spaced bins without under/overflow")
+        .def(construct_axes<axis::_variable_noflow, std::vector<double>>(), "edges"_a, "metadata"_a = py::str());
 
     ax.def(
         "_make_variable",
@@ -174,13 +174,13 @@ void register_axes(py::module &ax) {
             }
 
             if(underflow && overflow) {
-                return py::cast(axis::variable_uoflow(edges, metadata), py::return_value_policy::move);
+                return py::cast(axis::_variable_uoflow(edges, metadata), py::return_value_policy::move);
             } else if(underflow && !overflow) {
-                return py::cast(axis::variable_uflow(edges, metadata), py::return_value_policy::move);
+                return py::cast(axis::_variable_uflow(edges, metadata), py::return_value_policy::move);
             } else if(!underflow && overflow) {
-                return py::cast(axis::variable_oflow(edges, metadata), py::return_value_policy::move);
+                return py::cast(axis::_variable_oflow(edges, metadata), py::return_value_policy::move);
             } else {
-                return py::cast(axis::variable_noflow(edges, metadata), py::return_value_policy::move);
+                return py::cast(axis::_variable_noflow(edges, metadata), py::return_value_policy::move);
             }
         },
         "edges"_a,
@@ -191,25 +191,25 @@ void register_axes(py::module &ax) {
         "Passing 'flow' will override underflow and overflow at the same time.");
 
     ax.attr("variable") = factory_meta_py(ax.attr("_make_variable"),
-                                          py::make_tuple(ax.attr("variable_uoflow"),
-                                                         ax.attr("variable_uflow"),
-                                                         ax.attr("variable_oflow"),
-                                                         ax.attr("variable_noflow")));
+                                          py::make_tuple(ax.attr("_variable_uoflow"),
+                                                         ax.attr("_variable_uflow"),
+                                                         ax.attr("_variable_oflow"),
+                                                         ax.attr("_variable_noflow")));
 
-    register_axis<axis::integer_uoflow>(ax, "integer_uoflow", "Contigious integers")
-        .def(construct_axes<axis::integer_uoflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
+    register_axis<axis::_integer_uoflow>(ax, "_integer_uoflow", "Contigious integers")
+        .def(construct_axes<axis::_integer_uoflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
 
-    register_axis<axis::integer_uflow>(ax, "integer_uflow", "Contigious integers with underflow")
-        .def(construct_axes<axis::integer_uflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
+    register_axis<axis::_integer_uflow>(ax, "_integer_uflow", "Contigious integers with underflow")
+        .def(construct_axes<axis::_integer_uflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
 
-    register_axis<axis::integer_oflow>(ax, "integer_oflow", "Contigious integers with overflow")
-        .def(construct_axes<axis::integer_oflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
+    register_axis<axis::_integer_oflow>(ax, "_integer_oflow", "Contigious integers with overflow")
+        .def(construct_axes<axis::_integer_oflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
 
-    register_axis<axis::integer_noflow>(ax, "integer_noflow", "Contigious integers with no under/overflow")
-        .def(construct_axes<axis::integer_noflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
+    register_axis<axis::_integer_noflow>(ax, "_integer_noflow", "Contigious integers with no under/overflow")
+        .def(construct_axes<axis::_integer_noflow, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
 
-    register_axis<axis::integer_growth>(ax, "integer_growth", "Contigious integers with growth")
-        .def(construct_axes<axis::integer_growth, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
+    register_axis<axis::_integer_growth>(ax, "_integer_growth", "Contigious integers with growth")
+        .def(construct_axes<axis::_integer_growth, int, int>(), "min"_a, "max"_a, "metadata"_a = py::str());
 
     ax.def(
         "_make_integer",
@@ -227,15 +227,15 @@ void register_axes(py::module &ax) {
             }
 
             if(growth) {
-                return py::cast(axis::integer_growth(start, stop, metadata), py::return_value_policy::move);
+                return py::cast(axis::_integer_growth(start, stop, metadata), py::return_value_policy::move);
             } else if(underflow && overflow) {
-                return py::cast(axis::integer_uoflow(start, stop, metadata), py::return_value_policy::move);
+                return py::cast(axis::_integer_uoflow(start, stop, metadata), py::return_value_policy::move);
             } else if(underflow && !overflow) {
-                return py::cast(axis::integer_uflow(start, stop, metadata), py::return_value_policy::move);
+                return py::cast(axis::_integer_uflow(start, stop, metadata), py::return_value_policy::move);
             } else if(!underflow && overflow) {
-                return py::cast(axis::integer_oflow(start, stop, metadata), py::return_value_policy::move);
+                return py::cast(axis::_integer_oflow(start, stop, metadata), py::return_value_policy::move);
             } else {
-                return py::cast(axis::integer_noflow(start, stop, metadata), py::return_value_policy::move);
+                return py::cast(axis::_integer_noflow(start, stop, metadata), py::return_value_policy::move);
             }
         },
         "start"_a,
@@ -248,25 +248,26 @@ void register_axes(py::module &ax) {
         "Passing 'flow' will override underflow and overflow at the same time.");
 
     ax.attr("integer") = factory_meta_py(ax.attr("_make_integer"),
-                                         py::make_tuple(ax.attr("integer_uoflow"),
-                                                        ax.attr("integer_uflow"),
-                                                        ax.attr("integer_oflow"),
-                                                        ax.attr("integer_noflow"),
-                                                        ax.attr("integer_growth")));
+                                         py::make_tuple(ax.attr("_integer_uoflow"),
+                                                        ax.attr("_integer_uflow"),
+                                                        ax.attr("_integer_oflow"),
+                                                        ax.attr("_integer_noflow"),
+                                                        ax.attr("_integer_growth")));
 
-    register_axis<axis::category_int>(ax, "category_int", "Text label bins")
-        .def(construct_axes<axis::category_int, std::vector<int>>(), "labels"_a, "metadata"_a = py::str());
+    register_axis<axis::_category_int>(ax, "_category_int", "Text label bins")
+        .def(construct_axes<axis::_category_int, std::vector<int>>(), "labels"_a, "metadata"_a = py::str());
 
-    register_axis<axis::category_int_growth>(ax, "category_int_growth", "Text label bins")
-        .def(construct_axes<axis::category_int_growth, std::vector<int>>(), "labels"_a, "metadata"_a = py::str())
+    register_axis<axis::_category_int_growth>(ax, "_category_int_growth", "Text label bins")
+        .def(construct_axes<axis::_category_int_growth, std::vector<int>>(), "labels"_a, "metadata"_a = py::str())
         .def(py::init<>());
 
-    register_axis<axis::category_str>(ax, "category_str", "Text label bins")
-        .def(construct_axes<axis::category_str, std::vector<std::string>>(), "labels"_a, "metadata"_a = py::str());
+    register_axis<axis::_category_str>(ax, "_category_str", "Text label bins")
+        .def(construct_axes<axis::_category_str, std::vector<std::string>>(), "labels"_a, "metadata"_a = py::str());
 
-    register_axis<axis::category_str_growth>(ax, "category_str_growth", "Text label bins")
-        .def(
-            construct_axes<axis::category_str_growth, std::vector<std::string>>(), "labels"_a, "metadata"_a = py::str())
+    register_axis<axis::_category_str_growth>(ax, "_category_str_growth", "Text label bins")
+        .def(construct_axes<axis::_category_str_growth, std::vector<std::string>>(),
+             "labels"_a,
+             "metadata"_a = py::str())
         .def(py::init<>());
 
     ax.def(
@@ -278,17 +279,17 @@ void register_axes(py::module &ax) {
                 auto int_values = py::cast<std::vector<int>>(labels);
 
                 if(growth) {
-                    return py::cast(axis::category_int_growth(int_values, metadata), py::return_value_policy::move);
+                    return py::cast(axis::_category_int_growth(int_values, metadata), py::return_value_policy::move);
                 } else {
-                    return py::cast(axis::category_int(int_values, metadata), py::return_value_policy::move);
+                    return py::cast(axis::_category_int(int_values, metadata), py::return_value_policy::move);
                 }
             } catch(const py::cast_error &) {
                 auto str_values = py::cast<std::vector<std::string>>(labels);
 
                 if(growth) {
-                    return py::cast(axis::category_str_growth(str_values, metadata), py::return_value_policy::move);
+                    return py::cast(axis::_category_str_growth(str_values, metadata), py::return_value_policy::move);
                 } else {
-                    return py::cast(axis::category_str(str_values, metadata), py::return_value_policy::move);
+                    return py::cast(axis::_category_str(str_values, metadata), py::return_value_policy::move);
                 }
             }
         },
@@ -298,8 +299,8 @@ void register_axes(py::module &ax) {
         "Make an category axis with a nice keyword argument for growth. Int and string supported.");
 
     ax.attr("category") = factory_meta_py(ax.attr("_make_category"),
-                                          py::make_tuple(ax.attr("category_int"),
-                                                         ax.attr("category_int_growth"),
-                                                         ax.attr("category_str"),
-                                                         ax.attr("category_str_growth")));
+                                          py::make_tuple(ax.attr("_category_int"),
+                                                         ax.attr("_category_int_growth"),
+                                                         ax.attr("_category_str"),
+                                                         ax.attr("_category_str_growth")));
 }

--- a/src/histogram/general_histograms.cpp
+++ b/src/histogram/general_histograms.cpp
@@ -13,24 +13,24 @@
 
 void register_general_histograms(py::module &hist) {
     register_histogram<axes::any, storage::int_>(
-        hist, "any_int", "N-dimensional histogram for unlimited size data with any axis types.");
+        hist, "_any_int", "N-dimensional histogram for unlimited size data with any axis types.");
 
     register_histogram<axes::any, storage::unlimited>(
-        hist, "any_unlimited", "N-dimensional histogram for unlimited size data with any axis types.");
+        hist, "_any_unlimited", "N-dimensional histogram for unlimited size data with any axis types.");
 
     register_histogram<axes::any, storage::double_>(
-        hist, "any_double", "N-dimensional histogram for real-valued data with weights with any axis types.");
+        hist, "_any_double", "N-dimensional histogram for real-valued data with weights with any axis types.");
 
     register_histogram<axes::any, storage::atomic_int>(
-        hist, "any_atomic_int", "N-dimensional histogram for threadsafe integer data with any axis types.");
+        hist, "_any_atomic_int", "N-dimensional histogram for threadsafe integer data with any axis types.");
 
     register_histogram<axes::any, storage::weight>(
-        hist, "any_weight", "N-dimensional histogram for weighted data with any axis types.");
+        hist, "_any_weight", "N-dimensional histogram for weighted data with any axis types.");
 
     // Requires sampled fills
     register_histogram<axes::any, bh::profile_storage>(
-        hist, "any_profile", "N-dimensional histogram for sampled data with any axis types.");
+        hist, "_any_profile", "N-dimensional histogram for sampled data with any axis types.");
 
     register_histogram<axes::any, bh::weighted_profile_storage>(
-        hist, "any_weighted_profile", "N-dimensional histogram for weighted and sampled data with any axis types.");
+        hist, "_any_weighted_profile", "N-dimensional histogram for weighted and sampled data with any axis types.");
 }

--- a/src/histogram/make_histogram.cpp
+++ b/src/histogram/make_histogram.cpp
@@ -42,10 +42,10 @@ void register_make_histogram(py::module &m, py::module &hist) {
                 if(py::isinstance<py::tuple>(args[i])) {
                     py::tuple arg = py::cast<py::tuple>(args[i]);
                     if(arg.size() == 3) {
-                        args[i] = py::cast(new axis::regular_uoflow(py::cast<unsigned>(arg[0]),
-                                                                    py::cast<double>(arg[1]),
-                                                                    py::cast<double>(arg[2]),
-                                                                    py::str()),
+                        args[i] = py::cast(new axis::_regular_uoflow(py::cast<unsigned>(arg[0]),
+                                                                     py::cast<double>(arg[1]),
+                                                                     py::cast<double>(arg[2]),
+                                                                     py::str()),
                                            py::return_value_policy::take_ownership);
                     } else if(arg.size() == 4) {
                         try {
@@ -54,10 +54,10 @@ void register_make_histogram(py::module &m, py::module &hist) {
                         } catch(const py::cast_error &) {
                         }
 
-                        args[i] = py::cast(new axis::regular_uoflow(py::cast<unsigned>(arg[0]),
-                                                                    py::cast<double>(arg[1]),
-                                                                    py::cast<double>(arg[2]),
-                                                                    py::cast<metadata_t>(arg[3])),
+                        args[i] = py::cast(new axis::_regular_uoflow(py::cast<unsigned>(arg[0]),
+                                                                     py::cast<double>(arg[1]),
+                                                                     py::cast<double>(arg[2]),
+                                                                     py::cast<metadata_t>(arg[3])),
                                            py::return_value_policy::take_ownership);
                     } else {
                         throw py::type_error(

--- a/src/histogram/make_histogram.cpp
+++ b/src/histogram/make_histogram.cpp
@@ -79,9 +79,9 @@ void register_make_histogram(py::module &m, py::module &hist) {
     py::object factory_meta_py = py::module::import("boost.histogram_utils").attr("FactoryMeta");
 
     m.attr("histogram") = factory_meta_py(m.attr("_make_histogram"),
-                                          py::make_tuple(hist.attr("any_double"),
-                                                         hist.attr("any_int"),
-                                                         hist.attr("any_atomic_int"),
-                                                         hist.attr("any_unlimited"),
-                                                         hist.attr("any_weight")));
+                                          py::make_tuple(hist.attr("_any_double"),
+                                                         hist.attr("_any_int"),
+                                                         hist.attr("_any_atomic_int"),
+                                                         hist.attr("_any_unlimited"),
+                                                         hist.attr("_any_weight")));
 }

--- a/tests/speed_numpy.py
+++ b/tests/speed_numpy.py
@@ -25,7 +25,7 @@ def compare_1d(n, distrib):
         t = timer() - t
         best_numpy = min(t, best_numpy)
 
-        h = histogram(regular_uoflow(100, 0, 1))
+        h = histogram(_regular_uoflow(100, 0, 1))
         t = timer()
         h.fill(r)
         t = timer() - t
@@ -51,7 +51,7 @@ def compare_2d(n, distrib):
         t = timer() - t
         best_numpy = min(t, best_numpy)
 
-        h = histogram(regular_uoflow(100, 0, 1), regular_uoflow(100, 0, 1))
+        h = histogram(_regular_uoflow(100, 0, 1), _regular_uoflow(100, 0, 1))
         t = timer()
         h.fill(r[0], r[1])
         t = timer() - t
@@ -79,9 +79,9 @@ def compare_3d(n, distrib):
         t = timer() - t
         best_numpy = min(t, best_numpy)
 
-        h = histogram(regular_uoflow(100, 0, 1),
-                      regular_uoflow(100, 0, 1),
-                      regular_uoflow(100, 0, 1))
+        h = histogram(_regular_uoflow(100, 0, 1),
+                      _regular_uoflow(100, 0, 1),
+                      _regular_uoflow(100, 0, 1))
         t = timer()
         h.fill(r[0], r[1], r[2])
         t = timer() - t
@@ -113,12 +113,12 @@ def compare_6d(n, distrib):
         t = timer() - t
         best_numpy = min(t, best_numpy)
 
-        h = histogram(regular_uoflow(10, 0, 1),
-                      regular_uoflow(10, 0, 1),
-                      regular_uoflow(10, 0, 1),
-                      regular_uoflow(10, 0, 1),
-                      regular_uoflow(10, 0, 1),
-                      regular_uoflow(10, 0, 1))
+        h = histogram(_regular_uoflow(10, 0, 1),
+                      _regular_uoflow(10, 0, 1),
+                      _regular_uoflow(10, 0, 1),
+                      _regular_uoflow(10, 0, 1),
+                      _regular_uoflow(10, 0, 1),
+                      _regular_uoflow(10, 0, 1))
         t = timer()
         h.fill(r[0], r[1], r[2], r[3], r[4], r[5])
         t = timer() - t

--- a/tests/test_axis_internal.py
+++ b/tests/test_axis_internal.py
@@ -6,11 +6,11 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 
-@pytest.mark.parametrize("axtype", [bh.axis.regular_uoflow, bh.axis.regular_uflow, bh.axis.regular_oflow, bh.axis.regular_noflow])
+@pytest.mark.parametrize("axtype", [bh.axis._regular_uoflow, bh.axis._regular_uflow, bh.axis._regular_oflow, bh.axis._regular_noflow])
 @pytest.mark.parametrize("function", [lambda x: x,
                                        lambda x: bh._make_histogram(x).axis(0),
                                        ])
-def test_axis_regular_uoflow(axtype, function):
+def test_axis__regular_uoflow(axtype, function):
     ax = function(axtype(10, 0, 1))
 
     assert 3 == ax.index(.34)
@@ -32,28 +32,28 @@ def test_axis_regular_uoflow(axtype, function):
         assert b.upper() == approx(v + .1)
 
 def test_axis_regular_extents():
-    ax = bh.axis.regular_uoflow(10,0,1)
+    ax = bh.axis._regular_uoflow(10,0,1)
     assert 12 == ax.size(flow=True)
     assert 11 == len(ax.edges())
     assert 13 == len(ax.edges(True))
     assert 10 == len(ax.centers())
     assert ax.options() == bh.axis.options.underflow | bh.axis.options.overflow
 
-    ax = bh.axis.regular_uflow(10,0,1)
+    ax = bh.axis._regular_uflow(10,0,1)
     assert 11 == ax.size(flow=True)
     assert 11 == len(ax.edges())
     assert 12 == len(ax.edges(True))
     assert 10 == len(ax.centers())
     assert ax.options() == bh.axis.options.underflow
 
-    ax = bh.axis.regular_oflow(10,0,1)
+    ax = bh.axis._regular_oflow(10,0,1)
     assert 11 == ax.size(flow=True)
     assert 11 == len(ax.edges())
     assert 12 == len(ax.edges(True))
     assert 10 == len(ax.centers())
     assert ax.options() == bh.axis.options.overflow
 
-    ax = bh.axis.regular_noflow(10,0,1)
+    ax = bh.axis._regular_noflow(10,0,1)
     assert 10 == ax.size(flow=True)
     assert 11 == len(ax.edges())
     assert 11 == len(ax.edges(True))
@@ -61,7 +61,7 @@ def test_axis_regular_extents():
     assert ax.options() == bh.axis.options.none
 
 def test_axis_growth():
-    ax = bh.axis.regular_growth(10,0,1)
+    ax = bh.axis._regular_growth(10,0,1)
     ax.index(.7)
     ax.index(1.2)
     assert ax.size() == 10
@@ -73,7 +73,7 @@ def test_axis_growth():
     assert len(ax.centers()) == 13
 
 def test_axis_growth_cat():
-    ax = bh.axis.category_str_growth(["This"])
+    ax = bh.axis._category_str_growth(["This"])
     assert ax.size() == 1
     ax.update("That")
     assert ax.size() == 2
@@ -97,8 +97,8 @@ def test_axis_circular():
     assert ax.options() == bh.axis.options.circular | bh.axis.options.overflow
 
 normal_axs = [
-    bh.axis.regular_uoflow,
-    bh.axis.regular_noflow,
+    bh.axis._regular_uoflow,
+    bh.axis._regular_noflow,
     bh.axis.circular,
     bh.axis.regular_log,
     bh.axis.regular_sqrt,
@@ -119,14 +119,14 @@ def test_regular_axis_repr(axis):
     assert ax.metadata == 'That'
 
 def test_metadata_compare():
-    ax1 = bh.axis.regular_uoflow(1,2,3, metadata=[1,])
-    ax2 = bh.axis.regular_uoflow(1,2,3, metadata=[1,])
+    ax1 = bh.axis._regular_uoflow(1,2,3, metadata=[1,])
+    ax2 = bh.axis._regular_uoflow(1,2,3, metadata=[1,])
 
     assert ax1 == ax2
 
 def test_metadata_compare_neq():
-    ax1 = bh.axis.regular_uoflow(1,2,3, metadata=[1,])
-    ax2 = bh.axis.regular_uoflow(1,2,3, metadata=[2,])
+    ax1 = bh.axis._regular_uoflow(1,2,3, metadata=[1,])
+    ax2 = bh.axis._regular_uoflow(1,2,3, metadata=[2,])
 
     assert ax1 != ax2
 
@@ -138,7 +138,7 @@ def test_any_metadata(axis):
     assert ax.metadata == 64
 
 def test_cat_str():
-    ax = bh.axis.category_str(["a", "b", "c"])
+    ax = bh.axis._category_str(["a", "b", "c"])
     assert ax.bin(0) == "a"
     assert ax.bin(1) == "b"
     assert ax.bin(2) == "c"
@@ -146,7 +146,7 @@ def test_cat_str():
     assert ax.index("b") == 1
 
 def test_cat_int():
-    ax = bh.axis.category_int([1,2,3])
+    ax = bh.axis._category_int([1,2,3])
     assert ax.bin(0) == 1
     assert ax.bin(1) == 2
     assert ax.bin(2) == 3

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -5,9 +5,9 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
 methods = [
-    bh.hist.any_double,
-    bh.hist.any_unlimited,
-    bh.hist.any_int,
+    bh.hist._any_double,
+    bh.hist._any_unlimited,
+    bh.hist._any_int,
 ]
 
 @pytest.mark.parametrize("hist_func", methods)
@@ -59,7 +59,7 @@ def test_2D_fill_int(hist_func):
 
 def test_edges_histogram():
     edges = (1, 12, 22, 79)
-    hist = bh.hist.any_int([
+    hist = bh.hist._any_int([
         bh.axis.variable(edges)
         ])
 
@@ -72,7 +72,7 @@ def test_edges_histogram():
     assert_array_equal(hist.view(flow=False), [0,2,2])
 
 def test_int_histogram():
-    hist = bh.hist.any_int([
+    hist = bh.hist._any_int([
         bh.axis._integer_uoflow(3,7)
         ])
 
@@ -86,7 +86,7 @@ def test_int_histogram():
 
 
 def test_str_categories_histogram():
-    hist = bh.hist.any_int([
+    hist = bh.hist._any_int([
         bh.axis._category_str(["a", "b", "c"])
         ])
 
@@ -94,7 +94,7 @@ def test_str_categories_histogram():
     # Can't fill yet
 
 def test_growing_histogram():
-    hist = bh.hist.any_int([
+    hist = bh.hist._any_int([
         bh.axis._regular_growth(10,0,1)
         ])
 
@@ -103,7 +103,7 @@ def test_growing_histogram():
     assert hist.size() == 15
 
 def test_numpy_flow():
-    h = bh.hist.any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
+    h = bh.hist._any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
 
     for i in range(10):
         for j in range(5):
@@ -126,7 +126,7 @@ def test_numpy_flow():
 
 
 def test_numpy_compare():
-    h = bh.hist.any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
+    h = bh.hist._any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
 
     xs = []
     ys = []
@@ -148,9 +148,9 @@ def test_numpy_compare():
     assert_allclose(E2, nE2)
 
 def test_project():
-    h = bh.hist.any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
-    h0 = bh.hist.any_int([bh.axis._regular_uoflow(10,0,1)])
-    h1 = bh.hist.any_int([bh.axis._regular_uoflow(5,0,1)])
+    h = bh.hist._any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
+    h0 = bh.hist._any_int([bh.axis._regular_uoflow(10,0,1)])
+    h1 = bh.hist._any_int([bh.axis._regular_uoflow(5,0,1)])
 
     for x,y in ((.3,.3),(.7,.7),(.5,.6),(.23,.92),(.15,.32),(.43,.54)):
         h.fill(x,y)
@@ -173,7 +173,7 @@ def test_sums():
     assert h.sum(flow=True) == 4
 
 def test_int_cat_hist():
-    h = bh.hist.any_int([bh.axis._category_int([1,2,3])])
+    h = bh.hist._any_int([bh.axis._category_int([1,2,3])])
 
     h.fill(1)
     h.fill(2)

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -18,7 +18,7 @@ def test_1D_fill_int(hist_func):
     vals = (.15, .25, .25)
 
     hist = hist_func([
-        bh.axis.regular_uoflow(bins, *ranges)
+        bh.axis._regular_uoflow(bins, *ranges)
         ])
     hist.fill(vals)
 
@@ -39,8 +39,8 @@ def test_2D_fill_int(hist_func):
     vals = ((.15, .25, .25), (.35, .45, .45))
 
     hist = hist_func([
-        bh.axis.regular_uoflow(bins[0], *ranges[0]),
-        bh.axis.regular_uoflow(bins[1], *ranges[1]),
+        bh.axis._regular_uoflow(bins[0], *ranges[0]),
+        bh.axis._regular_uoflow(bins[1], *ranges[1]),
         ])
     hist.fill(*vals)
 
@@ -73,7 +73,7 @@ def test_edges_histogram():
 
 def test_int_histogram():
     hist = bh.hist.any_int([
-        bh.axis.integer_uoflow(3,7)
+        bh.axis._integer_uoflow(3,7)
         ])
 
     vals = (1,2,3,4,5,6,7,8,9)
@@ -87,7 +87,7 @@ def test_int_histogram():
 
 def test_str_categories_histogram():
     hist = bh.hist.any_int([
-        bh.axis.category_str(["a", "b", "c"])
+        bh.axis._category_str(["a", "b", "c"])
         ])
 
     vals = ['a', 'b', 'b', 'c']
@@ -95,7 +95,7 @@ def test_str_categories_histogram():
 
 def test_growing_histogram():
     hist = bh.hist.any_int([
-        bh.axis.regular_growth(10,0,1)
+        bh.axis._regular_growth(10,0,1)
         ])
 
     hist.fill(1.45)
@@ -103,7 +103,7 @@ def test_growing_histogram():
     assert hist.size() == 15
 
 def test_numpy_flow():
-    h = bh.hist.any_int([bh.axis.regular_uoflow(10,0,1), bh.axis.regular_uoflow(5,0,1)])
+    h = bh.hist.any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
 
     for i in range(10):
         for j in range(5):
@@ -126,7 +126,7 @@ def test_numpy_flow():
 
 
 def test_numpy_compare():
-    h = bh.hist.any_int([bh.axis.regular_uoflow(10,0,1), bh.axis.regular_uoflow(5,0,1)])
+    h = bh.hist.any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
 
     xs = []
     ys = []
@@ -148,9 +148,9 @@ def test_numpy_compare():
     assert_allclose(E2, nE2)
 
 def test_project():
-    h = bh.hist.any_int([bh.axis.regular_uoflow(10,0,1), bh.axis.regular_uoflow(5,0,1)])
-    h0 = bh.hist.any_int([bh.axis.regular_uoflow(10,0,1)])
-    h1 = bh.hist.any_int([bh.axis.regular_uoflow(5,0,1)])
+    h = bh.hist.any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
+    h0 = bh.hist.any_int([bh.axis._regular_uoflow(10,0,1)])
+    h1 = bh.hist.any_int([bh.axis._regular_uoflow(5,0,1)])
 
     for x,y in ((.3,.3),(.7,.7),(.5,.6),(.23,.92),(.15,.32),(.43,.54)):
         h.fill(x,y)
@@ -166,14 +166,14 @@ def test_project():
     assert_array_equal(h.project(1), h1)
 
 def test_sums():
-    h = bh.histogram(bh.axis.regular_uoflow(4,0,1))
+    h = bh.histogram(bh.axis._regular_uoflow(4,0,1))
     h.fill([.1,.2,.3,10])
 
     assert h.sum() == 3
     assert h.sum(flow=True) == 4
 
 def test_int_cat_hist():
-    h = bh.hist.any_int([bh.axis.category_int([1,2,3])])
+    h = bh.hist.any_int([bh.axis._category_int([1,2,3])])
 
     h.fill(1)
     h.fill(2)

--- a/tests/test_make_axis.py
+++ b/tests/test_make_axis.py
@@ -4,41 +4,41 @@ import boost.histogram as bh
 
 def test_make_regular_normal():
     ax_reg = bh.axis.regular(10, 0, 1)
-    assert isinstance(ax_reg, bh.axis.regular_uoflow)
+    assert isinstance(ax_reg, bh.axis._regular_uoflow)
     assert isinstance(ax_reg, bh.axis.regular)
 
-def test_make_regular_uoflow():
+def test_make__regular_uoflow():
     ax_reg = bh.axis.regular(10, 0, 1, flow=True)
-    assert isinstance(ax_reg, bh.axis.regular_uoflow)
+    assert isinstance(ax_reg, bh.axis._regular_uoflow)
     assert isinstance(ax_reg, bh.axis.regular)
 
-def test_make_regular_noflow():
+def test_make__regular_noflow():
     ax_reg = bh.axis.regular(10, 0, 1, flow=False)
-    assert isinstance(ax_reg, bh.axis.regular_noflow)
+    assert isinstance(ax_reg, bh.axis._regular_noflow)
     assert isinstance(ax_reg, bh.axis.regular)
 
-def test_make_regular_growth():
+def test_make__regular_growth():
     ax_reg = bh.axis.regular(10, 0, 1, growth=True)
-    assert isinstance(ax_reg, bh.axis.regular_growth)
+    assert isinstance(ax_reg, bh.axis._regular_growth)
     assert isinstance(ax_reg, bh.axis.regular)
 
-def test_make_category_int():
+def test_make__category_int():
     ax = bh.axis.category([1,2,3])
-    assert isinstance(ax, bh.axis.category_int)
+    assert isinstance(ax, bh.axis._category_int)
     assert isinstance(ax, bh.axis.category)
 
-def test_make_category_int_growth():
+def test_make__category_int_growth():
     ax = bh.axis.category([1,2,3], growth=True)
-    assert isinstance(ax, bh.axis.category_int_growth)
+    assert isinstance(ax, bh.axis._category_int_growth)
     assert isinstance(ax, bh.axis.category)
 
-def test_make_category_str():
+def test_make__category_str():
     ax = bh.axis.category(["one", "two"])
-    assert isinstance(ax, bh.axis.category_str)
+    assert isinstance(ax, bh.axis._category_str)
     assert isinstance(ax, bh.axis.category)
 
-def test_make_category_str_growth():
+def test_make__category_str_growth():
     ax = bh.axis.category(["one", "two"], growth=True)
-    assert isinstance(ax, bh.axis.category_str_growth)
+    assert isinstance(ax, bh.axis._category_str_growth)
     assert isinstance(ax, bh.axis.category)
 

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -4,9 +4,9 @@ import math
 
 import boost.histogram as bh
 
-@pytest.mark.parametrize("axis,extent", ((bh.axis.regular_uoflow, 2),
+@pytest.mark.parametrize("axis,extent", ((bh.axis._regular_uoflow, 2),
                                          (lambda *x: x, 2),
-                                         (bh.axis.regular_noflow, 0)))
+                                         (bh.axis._regular_noflow, 0)))
 def test_make_regular_1D(axis, extent):
     hist = bh._make_histogram(axis(3,2,5))
 
@@ -20,7 +20,7 @@ def test_shortcuts():
     assert hist.rank() == 2
     for i in range(2):
         assert isinstance(hist.axis(i), bh.axis.regular)
-        assert isinstance(hist.axis(i), bh.axis.regular_uoflow)
+        assert isinstance(hist.axis(i), bh.axis._regular_uoflow)
         assert not isinstance(hist.axis(i), bh.axis.variable)
 
 
@@ -35,8 +35,8 @@ def test_shortcuts_with_metadata():
 
 
 
-@pytest.mark.parametrize("axis,extent", ((bh.axis.regular_uoflow, 2),
-                                         (bh.axis.regular_noflow, 0)))
+@pytest.mark.parametrize("axis,extent", ((bh.axis._regular_uoflow, 2),
+                                         (bh.axis._regular_noflow, 0)))
 def test_make_regular_2D(axis, extent):
     hist = bh._make_histogram(axis(3,2,5),
                              axis(5,1,6))
@@ -56,8 +56,8 @@ def test_make_regular_2D(axis, extent):
                                      bh.storage.unlimited(),
                                      bh.storage.weight()))
 def test_make_any_hist(storage):
-    hist = bh._make_histogram(bh.axis.regular_uoflow(5,1,2),
-                             bh.axis.regular_noflow(6,2,3),
+    hist = bh._make_histogram(bh.axis._regular_uoflow(5,1,2),
+                             bh.axis._regular_noflow(6,2,3),
                              bh.axis.circular(8,3,4),
                              storage=storage)
 
@@ -74,8 +74,8 @@ def test_make_any_hist(storage):
 
 def test_make_any_hist_storage():
 
-    assert float != type(bh._make_histogram(bh.axis.regular_uoflow(5,1,2), storage=bh.storage.int()).at(0))
-    assert float == type(bh._make_histogram(bh.axis.regular_uoflow(5,1,2), storage=bh.storage.double()).at(0))
+    assert float != type(bh._make_histogram(bh.axis._regular_uoflow(5,1,2), storage=bh.storage.int()).at(0))
+    assert float == type(bh._make_histogram(bh.axis._regular_uoflow(5,1,2), storage=bh.storage.double()).at(0))
 
 def test_issue_axis_bin_swan():
     hist = bh._make_histogram(bh.axis.regular_sqrt(10,0,10, metadata='x'),
@@ -92,17 +92,17 @@ def test_issue_axis_bin_swan():
 
 
 options = (
-        (bh.hist.any_unlimited, bh.axis.regular_uoflow(5,1,2), bh.storage.unlimited),
-        (bh.hist.any_int, bh.axis.regular_uoflow(5,1,2), bh.storage.int),
-        (bh.hist.any_atomic_int, bh.axis.regular_uoflow(5,1,2), bh.storage.atomic_int),
-        (bh.hist.any_int, bh.axis.regular_noflow(5,1,2), bh.storage.int),
-        (bh.hist.any_double, bh.axis.regular_uoflow(5,1,2), bh.storage.double),
-        (bh.hist.any_weight, bh.axis.regular_uoflow(5,1,2), bh.storage.weight),
-        (bh.hist.any_int, bh.axis.integer_uoflow(0,5), bh.storage.int),
-        (bh.hist.any_atomic_int, bh.axis.integer_uoflow(0,5), bh.storage.atomic_int),
-        (bh.hist.any_double, bh.axis.integer_uoflow(0,5), bh.storage.double),
-        (bh.hist.any_unlimited, bh.axis.integer_uoflow(0,5), bh.storage.unlimited),
-        (bh.hist.any_weight, bh.axis.integer_uoflow(0,5), bh.storage.weight),
+        (bh.hist.any_unlimited, bh.axis._regular_uoflow(5,1,2), bh.storage.unlimited),
+        (bh.hist.any_int, bh.axis._regular_uoflow(5,1,2), bh.storage.int),
+        (bh.hist.any_atomic_int, bh.axis._regular_uoflow(5,1,2), bh.storage.atomic_int),
+        (bh.hist.any_int, bh.axis._regular_noflow(5,1,2), bh.storage.int),
+        (bh.hist.any_double, bh.axis._regular_uoflow(5,1,2), bh.storage.double),
+        (bh.hist.any_weight, bh.axis._regular_uoflow(5,1,2), bh.storage.weight),
+        (bh.hist.any_int, bh.axis._integer_uoflow(0,5), bh.storage.int),
+        (bh.hist.any_atomic_int, bh.axis._integer_uoflow(0,5), bh.storage.atomic_int),
+        (bh.hist.any_double, bh.axis._integer_uoflow(0,5), bh.storage.double),
+        (bh.hist.any_unlimited, bh.axis._integer_uoflow(0,5), bh.storage.unlimited),
+        (bh.hist.any_weight, bh.axis._integer_uoflow(0,5), bh.storage.weight),
         )
 
 @pytest.mark.parametrize("histclass, ax, storage", options)
@@ -115,5 +115,5 @@ def test_make_selection(histclass, ax, storage):
 
 
 def test_make_selection_special():
-    histogram = bh._make_histogram(bh.axis.regular_uoflow(5,1,2), bh.axis.regular_noflow(10,1,2))
+    histogram = bh._make_histogram(bh.axis._regular_uoflow(5,1,2), bh.axis._regular_noflow(10,1,2))
     assert isinstance(histogram, bh.hist.any_int)

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -92,17 +92,17 @@ def test_issue_axis_bin_swan():
 
 
 options = (
-        (bh.hist.any_unlimited, bh.axis._regular_uoflow(5,1,2), bh.storage.unlimited),
-        (bh.hist.any_int, bh.axis._regular_uoflow(5,1,2), bh.storage.int),
-        (bh.hist.any_atomic_int, bh.axis._regular_uoflow(5,1,2), bh.storage.atomic_int),
-        (bh.hist.any_int, bh.axis._regular_noflow(5,1,2), bh.storage.int),
-        (bh.hist.any_double, bh.axis._regular_uoflow(5,1,2), bh.storage.double),
-        (bh.hist.any_weight, bh.axis._regular_uoflow(5,1,2), bh.storage.weight),
-        (bh.hist.any_int, bh.axis._integer_uoflow(0,5), bh.storage.int),
-        (bh.hist.any_atomic_int, bh.axis._integer_uoflow(0,5), bh.storage.atomic_int),
-        (bh.hist.any_double, bh.axis._integer_uoflow(0,5), bh.storage.double),
-        (bh.hist.any_unlimited, bh.axis._integer_uoflow(0,5), bh.storage.unlimited),
-        (bh.hist.any_weight, bh.axis._integer_uoflow(0,5), bh.storage.weight),
+        (bh.hist._any_unlimited, bh.axis._regular_uoflow(5,1,2), bh.storage.unlimited),
+        (bh.hist._any_int, bh.axis._regular_uoflow(5,1,2), bh.storage.int),
+        (bh.hist._any_atomic_int, bh.axis._regular_uoflow(5,1,2), bh.storage.atomic_int),
+        (bh.hist._any_int, bh.axis._regular_noflow(5,1,2), bh.storage.int),
+        (bh.hist._any_double, bh.axis._regular_uoflow(5,1,2), bh.storage.double),
+        (bh.hist._any_weight, bh.axis._regular_uoflow(5,1,2), bh.storage.weight),
+        (bh.hist._any_int, bh.axis._integer_uoflow(0,5), bh.storage.int),
+        (bh.hist._any_atomic_int, bh.axis._integer_uoflow(0,5), bh.storage.atomic_int),
+        (bh.hist._any_double, bh.axis._integer_uoflow(0,5), bh.storage.double),
+        (bh.hist._any_unlimited, bh.axis._integer_uoflow(0,5), bh.storage.unlimited),
+        (bh.hist._any_weight, bh.axis._integer_uoflow(0,5), bh.storage.weight),
         )
 
 @pytest.mark.parametrize("histclass, ax, storage", options)
@@ -116,4 +116,4 @@ def test_make_selection(histclass, ax, storage):
 
 def test_make_selection_special():
     histogram = bh._make_histogram(bh.axis._regular_uoflow(5,1,2), bh.axis._regular_noflow(10,1,2))
-    assert isinstance(histogram, bh.hist.any_int)
+    assert isinstance(histogram, bh.hist._any_int)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -36,19 +36,19 @@ def test_accumulators(accum, args, copy_fn):
 
 
 axes_creations = (
-        (bh.axis.regular_uoflow,      (4, 2, 4)),
-        (bh.axis.regular_growth,      (4, 2, 4)),
-        (bh.axis.regular_noflow,      (4, 2, 4)),
+        (bh.axis._regular_uoflow,      (4, 2, 4)),
+        (bh.axis._regular_growth,      (4, 2, 4)),
+        (bh.axis._regular_noflow,      (4, 2, 4)),
         (bh.axis.regular_log,         (4, 2, 4)),
         (bh.axis.regular_sqrt,        (4, 2, 4)),
         (bh.axis.regular_pow,         (4, 2, 4, 0.5)),
         (bh.axis.circular,            (4, 2, 4)),
         (bh.axis.variable,            ([1, 2, 3, 4],)),
-        (bh.axis.integer_uoflow,      (1, 4)),
-        (bh.axis.category_int,        ([1, 2, 3],)),
-        (bh.axis.category_int_growth, ([1, 2, 3],)),
-        (bh.axis.category_str,        (["1", "2", "3"],)),
-        (bh.axis.category_str_growth, (["1", "2", "3"],)),
+        (bh.axis._integer_uoflow,      (1, 4)),
+        (bh.axis._category_int,        ([1, 2, 3],)),
+        (bh.axis._category_int_growth, ([1, 2, 3],)),
+        (bh.axis._category_str,        (["1", "2", "3"],)),
+        (bh.axis._category_str_growth, (["1", "2", "3"],)),
         )
 
 
@@ -72,7 +72,7 @@ def test_metadata_str(axis, args, copy_fn):
 # Special test: Deepcopy should change metadata id, copy should not
 @pytest.mark.parametrize("metadata", ({1:2}, [1,2,3]))
 def test_compare_copy_axis(metadata):
-    orig = bh.axis.regular_noflow(4,0,2, metadata=metadata)
+    orig = bh.axis._regular_noflow(4,0,2, metadata=metadata)
     new = copy.copy(orig)
     dnew = copy.deepcopy(orig)
 
@@ -83,7 +83,7 @@ def test_compare_copy_axis(metadata):
 # Special test: Deepcopy should change metadata id, copy should not
 @pytest.mark.parametrize("metadata", ({1:2}, [1,2,3]))
 def test_compare_copy_hist(metadata):
-    orig = bh._make_histogram(bh.axis.regular_noflow(4,0,2, metadata=metadata))
+    orig = bh._make_histogram(bh.axis._regular_noflow(4,0,2, metadata=metadata))
     new = copy.copy(orig)
     dnew = copy.deepcopy(orig)
 
@@ -126,7 +126,7 @@ def test_histogram_regular(copy_fn):
 
 @pytest.mark.parametrize("copy_fn", copies)
 def test_histogram_fancy(copy_fn):
-    hist = bh.histogram(bh.axis.regular_noflow(4,1,2), bh.axis.integer_uoflow(0, 6))
+    hist = bh.histogram(bh.axis._regular_noflow(4,1,2), bh.axis._integer_uoflow(0, 6))
 
     new = copy_fn(hist)
     assert hist == new

--- a/tests/test_public_axis.py
+++ b/tests/test_public_axis.py
@@ -1,18 +1,13 @@
 import pytest
 from pytest import approx
 
-from boost.histogram.axis import (regular, _regular_growth,
-                                  _regular_uoflow, _regular_uflow,
-                                  _regular_oflow, _regular_noflow,
+import boost.histogram.axis as bha
+from boost.histogram.axis import (regular, 
                                   regular_log, regular_sqrt,
                                   regular_pow, circular,
                                   variable,
-                                  _variable_uoflow, _variable_uflow,
-                                  _variable_oflow, _variable_noflow,
-                                  integer, _integer_growth,
-                                  _integer_uoflow, _integer_oflow,
-                                  _integer_uflow, _integer_noflow,
-                                  _category_int as category)
+                                  integer,
+                                  category)
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
@@ -63,75 +58,75 @@ class Axis(ABC):
 class TestRegular(Axis):
 
     def test_shortcut(self):
-        assert isinstance(regular(1,2,3), _regular_uoflow)
+        assert isinstance(regular(1,2,3), bha._regular_uoflow)
         assert isinstance(regular(1,2,3), regular)
 
-        assert isinstance(regular(1,2,3, overflow=False), _regular_uflow)
+        assert isinstance(regular(1,2,3, overflow=False), bha._regular_uflow)
         assert isinstance(regular(1,2,3, overflow=False), regular)
 
-        assert isinstance(regular(1,2,3, underflow=False), _regular_oflow)
+        assert isinstance(regular(1,2,3, underflow=False), bha._regular_oflow)
         assert isinstance(regular(1,2,3, underflow=False), regular)
 
-        assert isinstance(regular(1,2,3, flow=False), _regular_noflow)
+        assert isinstance(regular(1,2,3, flow=False), bha._regular_noflow)
         assert isinstance(regular(1,2,3, flow=False), regular)
 
-        assert isinstance(regular(1,2,3, underflow=False, overflow=False), _regular_noflow)
-        assert isinstance(regular(1,2,3, underflow=False, overflow=False, flow=True), _regular_uoflow)
+        assert isinstance(regular(1,2,3, underflow=False, overflow=False), bha._regular_noflow)
+        assert isinstance(regular(1,2,3, underflow=False, overflow=False, flow=True), bha._regular_uoflow)
 
-        assert isinstance(regular(1,2,3, growth=True), _regular_growth)
+        assert isinstance(regular(1,2,3, growth=True), bha._regular_growth)
         assert isinstance(regular(1,2,3, growth=True), regular)
 
 
     def test_init(self):
         # Should not throw
-        _regular_uoflow(1, 1.0, 2.0)
-        _regular_uoflow(1, 1.0, 2.0, metadata="ra")
-        _regular_noflow(1, 1.0, 2.0)
-        _regular_noflow(1, 1.0, 2.0, metadata="ra")
+        regular(1, 1.0, 2.0, flow=True)
+        regular(1, 1.0, 2.0, flow=True, metadata="ra")
+        regular(1, 1.0, 2.0, flow=False)
+        regular(1, 1.0, 2.0, flow=False, metadata="ra")
         regular_log(1, 1.0, 2.0)
         regular_sqrt(1, 1.0, 2.0)
         regular_pow(1, 1.0, 2.0, 1.5)
 
         with pytest.raises(TypeError):
-            _regular_uoflow()
+            regular()
         with pytest.raises(TypeError):
-            _regular_uoflow()
+            bha._regular_uoflow()
         with pytest.raises(TypeError):
-            _regular_uoflow(1)
+            regular(1)
         with pytest.raises(TypeError):
-            _regular_uoflow(1, 1.0)
+            regular(1, 1.0)
         with pytest.raises(ValueError):
-            _regular_uoflow(0, 1.0, 2.0)
+            regular(0, 1.0, 2.0)
         with pytest.raises(TypeError):
-            _regular_uoflow("1", 1.0, 2.0)
+            regular("1", 1.0, 2.0)
         with pytest.raises(Exception):
-            _regular_uoflow(-1, 1.0, 2.0)
+            regular(-1, 1.0, 2.0)
         # CLASSIC
         #with pytest.raises(ValueError):
-        _regular_uoflow(1, 2.0, 1.0)
+        regular(1, 2.0, 1.0)
 
         with pytest.raises(ValueError):
-            _regular_uoflow(1, 1.0, 1.0)
+            regular(1, 1.0, 1.0)
 
         with pytest.raises(TypeError):
-            _regular_uoflow(1, 1.0, 2.0, metadata=0)
+            regular(1, 1.0, 2.0, metadata=0)
 
 
 
-        with pytest.raises(TypeError):
-            _regular_uoflow(1, 1.0, 2.0, bad_keyword="ra")
+        with pytest.raises(KeyError):
+            regular(1, 1.0, 2.0, bad_keyword="ra")
         with pytest.raises(TypeError):
             regular_pow(1, 1.0, 2.0)
 
-        a = _regular_uoflow(4, 1.0, 2.0)
-        assert a == _regular_uoflow(4, 1.0, 2.0)
-        assert a != _regular_uoflow(3, 1.0, 2.0)
-        assert a != _regular_uoflow(4, 1.1, 2.0)
-        assert a != _regular_uoflow(4, 1.0, 2.1)
+        a = regular(4, 1.0, 2.0)
+        assert a == regular(4, 1.0, 2.0)
+        assert a != regular(3, 1.0, 2.0)
+        assert a != regular(4, 1.1, 2.0)
+        assert a != regular(4, 1.0, 2.1)
 
 
     def test_len(self):
-        a = _regular_uoflow(4, 1.0, 2.0)
+        a = regular(4, 1.0, 2.0)
         # CLASSIC: Not explicit
         # assert len(a) == 4
 
@@ -139,16 +134,16 @@ class TestRegular(Axis):
         assert a.size(flow=True) == 6
 
     def test_repr(self):
-        ax = _regular_uoflow(4, 1.1, 2.2)
+        ax = regular(4, 1.1, 2.2)
         assert repr(ax) == "regular(4, 1.1, 2.2, options=underflow | overflow)"
 
-        ax = _regular_uoflow(4, 1.1, 2.2, metadata='ra')
+        ax = regular(4, 1.1, 2.2, metadata='ra')
         assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra", options=underflow | overflow)'
 
-        ax = _regular_noflow(4, 1.1, 2.2)
+        ax = regular(4, 1.1, 2.2, flow=False)
         assert repr(ax) == "regular(4, 1.1, 2.2, options=none)"
 
-        ax = _regular_noflow(4, 1.1, 2.2, metadata='ra')
+        ax = regular(4, 1.1, 2.2, metadata='ra', flow=False)
         assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra", options=none)'
 
         ax = regular_log(4, 1.1, 2.2)
@@ -163,7 +158,7 @@ class TestRegular(Axis):
 
     def test_getitem(self):
         v = [1.0, 1.25, 1.5, 1.75, 2.0]
-        a = _regular_uoflow(4, 1.0, 2.0)
+        a = regular(4, 1.0, 2.0)
         for i in range(4):
             a.bin(i).lower() == approx(v[i])
             a.bin(i).upper() == approx(v[i+1])
@@ -183,14 +178,14 @@ class TestRegular(Axis):
 
     def test_iter(self):
         v = np.array([1.0, 1.25, 1.5, 1.75, 2.0])
-        a = _regular_uoflow(4, 1.0, 2.0)
+        a = regular(4, 1.0, 2.0)
         assert_array_equal(a.edges(), v)
 
         c = (v[:-1] + v[1:])/2
         assert_allclose(a.centers(), c)
 
     def test_index(self):
-        a = _regular_uoflow(4, 1.0, 2.0)
+        a = regular(4, 1.0, 2.0)
 
         assert a.index(-1) == -1
         assert a.index(0.99) == -1
@@ -206,7 +201,7 @@ class TestRegular(Axis):
         assert a.index(20) == 4
 
     def test_reversed_index(self):
-        a = _regular_uoflow(4, 2.0, 1.0)
+        a = regular(4, 2.0, 1.0)
 
         assert a.index(-1) == 4
         assert a.index(0.99) == 4
@@ -361,20 +356,20 @@ class TestCircular(Axis):
 
 class TestVariable(Axis):
     def test_shortcut(self):
-        assert isinstance(variable([1,2,3]), _variable_uoflow)
+        assert isinstance(variable([1,2,3]), bha._variable_uoflow)
         assert isinstance(variable([1,2,3]), variable)
 
-        assert isinstance(variable([1,2,3], overflow=False), _variable_uflow)
+        assert isinstance(variable([1,2,3], overflow=False), bha._variable_uflow)
         assert isinstance(variable([1,2,3], overflow=False), variable)
 
-        assert isinstance(variable([1,2,3], underflow=False), _variable_oflow)
+        assert isinstance(variable([1,2,3], underflow=False), bha._variable_oflow)
         assert isinstance(variable([1,2,3], underflow=False), variable)
 
-        assert isinstance(variable([1,2,3], flow=False), _variable_noflow)
+        assert isinstance(variable([1,2,3], flow=False), bha._variable_noflow)
         assert isinstance(variable([1,2,3], flow=False), variable)
 
-        assert isinstance(variable([1,2,3], underflow=False, overflow=False), _variable_noflow)
-        assert isinstance(variable([1,2,3], underflow=False, overflow=False, flow=True), _variable_uoflow)
+        assert isinstance(variable([1,2,3], underflow=False, overflow=False), bha._variable_noflow)
+        assert isinstance(variable([1,2,3], underflow=False, overflow=False, flow=True), bha._variable_uoflow)
 
     def test_init(self):
         variable([0, 1])
@@ -457,74 +452,75 @@ class TestVariable(Axis):
 
 class TestInteger:
     def test_shortcut(self):
-        assert isinstance(integer(1, 3), _integer_uoflow)
+        assert isinstance(integer(1, 3), bha._integer_uoflow)
         assert isinstance(integer(1, 3), integer)
 
-        assert isinstance(integer(1, 3, overflow=False), _integer_uflow)
+        assert isinstance(integer(1, 3, overflow=False), bha._integer_uflow)
         assert isinstance(integer(1, 3, overflow=False), integer)
 
-        assert isinstance(integer(1, 3, underflow=False), _integer_oflow)
+        assert isinstance(integer(1, 3, underflow=False), bha._integer_oflow)
         assert isinstance(integer(1, 3, underflow=False), integer)
 
-        assert isinstance(integer(1, 3, flow=False), _integer_noflow)
+        assert isinstance(integer(1, 3, flow=False), bha._integer_noflow)
         assert isinstance(integer(1, 3, flow=False), integer)
 
-        assert isinstance(integer(1, 3, underflow=False, overflow=False), _integer_noflow)
-        assert isinstance(integer(1, 3, underflow=False, overflow=False, flow=True), _integer_uoflow)
+        assert isinstance(integer(1, 3, underflow=False, overflow=False), bha._integer_noflow)
+        assert isinstance(integer(1, 3, underflow=False, overflow=False, flow=True), bha._integer_uoflow)
 
-        assert isinstance(integer(1, 3, growth=True), _integer_growth)
+        assert isinstance(integer(1, 3, growth=True), bha._integer_growth)
         assert isinstance(integer(1, 3, growth=True), integer)
 
     def test_init(self):
-        _integer_uoflow(-1, 2)
-        _integer_noflow(-1, 2)
-        _integer_growth(-1, 2)
+        integer(-1, 2, flow=True)
+        integer(-1, 2, flow=False)
+        integer(-1, 2 , growth=True)
+        
         with pytest.raises(TypeError):
-            _integer_uoflow()
+            integer()
         with pytest.raises(TypeError):
-            _integer_uoflow(1)
+            integer(1)
         with pytest.raises(TypeError):
-            _integer_uoflow("1", 2)
+            integer("1", 2)
         with pytest.raises(ValueError):
-            _integer_uoflow(2, -1)
+            integer(2, -1)
 
         with pytest.raises(TypeError):
-            _integer_uoflow(1, 2, 3)
+            integer(1, 2, 3)
 
-        assert _integer_uoflow(-1, 2) == _integer_uoflow(-1, 2)
-        assert _integer_uoflow(-1, 2) != _integer_uoflow(-1, 2, metadata="Other")
-        assert _integer_noflow(-1, 2) != _integer_uoflow(-1, 2)
+        assert integer(-1, 2) == integer(-1, 2)
+        assert integer(-1, 2) != integer(-1, 2, metadata="Other")
+        assert integer(-1, 2, flow=True) != integer(-1, 2, flow=False)
 
     def test_len(self):
-        assert _integer_uoflow(-1, 3).size() ==  4
-        assert _integer_uoflow(-1, 3).size(flow=True) ==  6
-        assert _integer_noflow(-1, 3).size() ==  4
-        assert _integer_noflow(-1, 3).size(flow=True) ==  4
-        assert _integer_growth(-1, 3).size() ==  4
-        assert _integer_growth(-1, 3).size(flow=True) ==  4
+        assert integer(-1, 3, flow=True).size() == 4
+        assert integer(-1, 3, flow=True).size(flow=True) == 6
+        assert integer(-1, 3, flow=False).size() == 4
+        assert integer(-1, 3, flow=False).size(flow=True) == 4
+        assert integer(-1, 3, growth=True).size() == 4
+        assert integer(-1, 3, growth=True).size(flow=True) == 4
 
     def test_repr(self):
-        a = _integer_uoflow(-1, 1)
+        a = integer(-1, 1)
         assert repr(a) == 'integer(-1, 1, options=underflow | overflow)'
 
-        a = _integer_uoflow(-1, 1, metadata="hi")
+        a = integer(-1, 1, metadata="hi")
         assert repr(a) == 'integer(-1, 1, metadata="hi", options=underflow | overflow)'
 
-        a = _integer_noflow(-1, 1)
+        a = integer(-1, 1, flow=False)
         assert repr(a) == 'integer(-1, 1, options=none)'
 
-        a = _integer_growth(-1, 1)
+        a = integer(-1, 1, growth=True)
         assert repr(a) == 'integer(-1, 1, options=growth)'
 
     def test_label(self):
-        a = _integer_uoflow(-1, 2, metadata="foo")
+        a = integer(-1, 2, metadata="foo")
         assert a.metadata == "foo"
         a.metadata = "bar"
         assert a.metadata == "bar"
 
     def test_getitem(self):
         v = [-1, 0, 1, 2, 3]
-        a = _integer_uoflow(-1, 3)
+        a = integer(-1, 3)
         for i in range(5):
             assert a.bin(i) == v[i]
         assert a.bin(-1) == -2 ** 31
@@ -532,11 +528,11 @@ class TestInteger:
 
     def test_iter(self):
         v = np.array([-1, 0, 1, 2])
-        a = _integer_uoflow(-1, 3)
+        a = integer(-1, 3)
         assert_array_equal(a.bins(), v)
 
     def test_index(self):
-        a = _integer_uoflow(-1, 3)
+        a = integer(-1, 3)
         assert a.index(-3) == -1
         assert a.index(-2) == -1
         assert a.index(-1) == 0
@@ -552,11 +548,13 @@ class TestCategory(Axis):
     def test_init(self):
         category([1, 2, 3])
         category([1, 2, 3], metadata="ca")
+        
+        # Basic string support
+        category(["1"])
+
         with pytest.raises(TypeError):
             category()
-        with pytest.raises(TypeError):
-            category(["1"])
-        with pytest.raises(TypeError):
+        with pytest.raises(RuntimeError):
             category([1, "2"])
         with pytest.raises(TypeError):
             category([1, 2], metadata=1)

--- a/tests/test_public_axis.py
+++ b/tests/test_public_axis.py
@@ -1,18 +1,18 @@
 import pytest
 from pytest import approx
 
-from boost.histogram.axis import (regular, regular_growth,
-                                  regular_uoflow, regular_uflow,
-                                  regular_oflow, regular_noflow,
+from boost.histogram.axis import (regular, _regular_growth,
+                                  _regular_uoflow, _regular_uflow,
+                                  _regular_oflow, _regular_noflow,
                                   regular_log, regular_sqrt,
                                   regular_pow, circular,
                                   variable,
-                                  variable_uoflow, variable_uflow,
-                                  variable_oflow, variable_noflow,
-                                  integer, integer_growth,
-                                  integer_uoflow, integer_oflow,
-                                  integer_uflow, integer_noflow,
-                                  category_int as category)
+                                  _variable_uoflow, _variable_uflow,
+                                  _variable_oflow, _variable_noflow,
+                                  integer, _integer_growth,
+                                  _integer_uoflow, _integer_oflow,
+                                  _integer_uflow, _integer_noflow,
+                                  _category_int as category)
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
@@ -24,7 +24,7 @@ ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
 
 # histogram -> boost.histogram
 # regular(..., noflow=False) -> regular_ouflow(...)
-# regular(..., noflow=True) -> regular_noflow(...)
+# regular(..., noflow=True) -> _regular_noflow(...)
 # label -> metadata
 # len(ax) -> ax.size(flow=False)
 # ax.extent() -> ax.size(flow=True)
@@ -63,75 +63,75 @@ class Axis(ABC):
 class TestRegular(Axis):
 
     def test_shortcut(self):
-        assert isinstance(regular(1,2,3), regular_uoflow)
+        assert isinstance(regular(1,2,3), _regular_uoflow)
         assert isinstance(regular(1,2,3), regular)
 
-        assert isinstance(regular(1,2,3, overflow=False), regular_uflow)
+        assert isinstance(regular(1,2,3, overflow=False), _regular_uflow)
         assert isinstance(regular(1,2,3, overflow=False), regular)
 
-        assert isinstance(regular(1,2,3, underflow=False), regular_oflow)
+        assert isinstance(regular(1,2,3, underflow=False), _regular_oflow)
         assert isinstance(regular(1,2,3, underflow=False), regular)
 
-        assert isinstance(regular(1,2,3, flow=False), regular_noflow)
+        assert isinstance(regular(1,2,3, flow=False), _regular_noflow)
         assert isinstance(regular(1,2,3, flow=False), regular)
 
-        assert isinstance(regular(1,2,3, underflow=False, overflow=False), regular_noflow)
-        assert isinstance(regular(1,2,3, underflow=False, overflow=False, flow=True), regular_uoflow)
+        assert isinstance(regular(1,2,3, underflow=False, overflow=False), _regular_noflow)
+        assert isinstance(regular(1,2,3, underflow=False, overflow=False, flow=True), _regular_uoflow)
 
-        assert isinstance(regular(1,2,3, growth=True), regular_growth)
+        assert isinstance(regular(1,2,3, growth=True), _regular_growth)
         assert isinstance(regular(1,2,3, growth=True), regular)
 
 
     def test_init(self):
         # Should not throw
-        regular_uoflow(1, 1.0, 2.0)
-        regular_uoflow(1, 1.0, 2.0, metadata="ra")
-        regular_noflow(1, 1.0, 2.0)
-        regular_noflow(1, 1.0, 2.0, metadata="ra")
+        _regular_uoflow(1, 1.0, 2.0)
+        _regular_uoflow(1, 1.0, 2.0, metadata="ra")
+        _regular_noflow(1, 1.0, 2.0)
+        _regular_noflow(1, 1.0, 2.0, metadata="ra")
         regular_log(1, 1.0, 2.0)
         regular_sqrt(1, 1.0, 2.0)
         regular_pow(1, 1.0, 2.0, 1.5)
 
         with pytest.raises(TypeError):
-            regular_uoflow()
+            _regular_uoflow()
         with pytest.raises(TypeError):
-            regular_uoflow()
+            _regular_uoflow()
         with pytest.raises(TypeError):
-            regular_uoflow(1)
+            _regular_uoflow(1)
         with pytest.raises(TypeError):
-            regular_uoflow(1, 1.0)
+            _regular_uoflow(1, 1.0)
         with pytest.raises(ValueError):
-            regular_uoflow(0, 1.0, 2.0)
+            _regular_uoflow(0, 1.0, 2.0)
         with pytest.raises(TypeError):
-            regular_uoflow("1", 1.0, 2.0)
+            _regular_uoflow("1", 1.0, 2.0)
         with pytest.raises(Exception):
-            regular_uoflow(-1, 1.0, 2.0)
+            _regular_uoflow(-1, 1.0, 2.0)
         # CLASSIC
         #with pytest.raises(ValueError):
-        regular_uoflow(1, 2.0, 1.0)
+        _regular_uoflow(1, 2.0, 1.0)
 
         with pytest.raises(ValueError):
-            regular_uoflow(1, 1.0, 1.0)
+            _regular_uoflow(1, 1.0, 1.0)
 
         with pytest.raises(TypeError):
-            regular_uoflow(1, 1.0, 2.0, metadata=0)
+            _regular_uoflow(1, 1.0, 2.0, metadata=0)
 
 
 
         with pytest.raises(TypeError):
-            regular_uoflow(1, 1.0, 2.0, bad_keyword="ra")
+            _regular_uoflow(1, 1.0, 2.0, bad_keyword="ra")
         with pytest.raises(TypeError):
             regular_pow(1, 1.0, 2.0)
 
-        a = regular_uoflow(4, 1.0, 2.0)
-        assert a == regular_uoflow(4, 1.0, 2.0)
-        assert a != regular_uoflow(3, 1.0, 2.0)
-        assert a != regular_uoflow(4, 1.1, 2.0)
-        assert a != regular_uoflow(4, 1.0, 2.1)
+        a = _regular_uoflow(4, 1.0, 2.0)
+        assert a == _regular_uoflow(4, 1.0, 2.0)
+        assert a != _regular_uoflow(3, 1.0, 2.0)
+        assert a != _regular_uoflow(4, 1.1, 2.0)
+        assert a != _regular_uoflow(4, 1.0, 2.1)
 
 
     def test_len(self):
-        a = regular_uoflow(4, 1.0, 2.0)
+        a = _regular_uoflow(4, 1.0, 2.0)
         # CLASSIC: Not explicit
         # assert len(a) == 4
 
@@ -139,16 +139,16 @@ class TestRegular(Axis):
         assert a.size(flow=True) == 6
 
     def test_repr(self):
-        ax = regular_uoflow(4, 1.1, 2.2)
+        ax = _regular_uoflow(4, 1.1, 2.2)
         assert repr(ax) == "regular(4, 1.1, 2.2, options=underflow | overflow)"
 
-        ax = regular_uoflow(4, 1.1, 2.2, metadata='ra')
+        ax = _regular_uoflow(4, 1.1, 2.2, metadata='ra')
         assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra", options=underflow | overflow)'
 
-        ax = regular_noflow(4, 1.1, 2.2)
+        ax = _regular_noflow(4, 1.1, 2.2)
         assert repr(ax) == "regular(4, 1.1, 2.2, options=none)"
 
-        ax = regular_noflow(4, 1.1, 2.2, metadata='ra')
+        ax = _regular_noflow(4, 1.1, 2.2, metadata='ra')
         assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra", options=none)'
 
         ax = regular_log(4, 1.1, 2.2)
@@ -163,7 +163,7 @@ class TestRegular(Axis):
 
     def test_getitem(self):
         v = [1.0, 1.25, 1.5, 1.75, 2.0]
-        a = regular_uoflow(4, 1.0, 2.0)
+        a = _regular_uoflow(4, 1.0, 2.0)
         for i in range(4):
             a.bin(i).lower() == approx(v[i])
             a.bin(i).upper() == approx(v[i+1])
@@ -183,14 +183,14 @@ class TestRegular(Axis):
 
     def test_iter(self):
         v = np.array([1.0, 1.25, 1.5, 1.75, 2.0])
-        a = regular_uoflow(4, 1.0, 2.0)
+        a = _regular_uoflow(4, 1.0, 2.0)
         assert_array_equal(a.edges(), v)
 
         c = (v[:-1] + v[1:])/2
         assert_allclose(a.centers(), c)
 
     def test_index(self):
-        a = regular_uoflow(4, 1.0, 2.0)
+        a = _regular_uoflow(4, 1.0, 2.0)
 
         assert a.index(-1) == -1
         assert a.index(0.99) == -1
@@ -206,7 +206,7 @@ class TestRegular(Axis):
         assert a.index(20) == 4
 
     def test_reversed_index(self):
-        a = regular_uoflow(4, 2.0, 1.0)
+        a = _regular_uoflow(4, 2.0, 1.0)
 
         assert a.index(-1) == 4
         assert a.index(0.99) == 4
@@ -361,20 +361,20 @@ class TestCircular(Axis):
 
 class TestVariable(Axis):
     def test_shortcut(self):
-        assert isinstance(variable([1,2,3]), variable_uoflow)
+        assert isinstance(variable([1,2,3]), _variable_uoflow)
         assert isinstance(variable([1,2,3]), variable)
 
-        assert isinstance(variable([1,2,3], overflow=False), variable_uflow)
+        assert isinstance(variable([1,2,3], overflow=False), _variable_uflow)
         assert isinstance(variable([1,2,3], overflow=False), variable)
 
-        assert isinstance(variable([1,2,3], underflow=False), variable_oflow)
+        assert isinstance(variable([1,2,3], underflow=False), _variable_oflow)
         assert isinstance(variable([1,2,3], underflow=False), variable)
 
-        assert isinstance(variable([1,2,3], flow=False), variable_noflow)
+        assert isinstance(variable([1,2,3], flow=False), _variable_noflow)
         assert isinstance(variable([1,2,3], flow=False), variable)
 
-        assert isinstance(variable([1,2,3], underflow=False, overflow=False), variable_noflow)
-        assert isinstance(variable([1,2,3], underflow=False, overflow=False, flow=True), variable_uoflow)
+        assert isinstance(variable([1,2,3], underflow=False, overflow=False), _variable_noflow)
+        assert isinstance(variable([1,2,3], underflow=False, overflow=False, flow=True), _variable_uoflow)
 
     def test_init(self):
         variable([0, 1])
@@ -457,74 +457,74 @@ class TestVariable(Axis):
 
 class TestInteger:
     def test_shortcut(self):
-        assert isinstance(integer(1, 3), integer_uoflow)
+        assert isinstance(integer(1, 3), _integer_uoflow)
         assert isinstance(integer(1, 3), integer)
 
-        assert isinstance(integer(1, 3, overflow=False), integer_uflow)
+        assert isinstance(integer(1, 3, overflow=False), _integer_uflow)
         assert isinstance(integer(1, 3, overflow=False), integer)
 
-        assert isinstance(integer(1, 3, underflow=False), integer_oflow)
+        assert isinstance(integer(1, 3, underflow=False), _integer_oflow)
         assert isinstance(integer(1, 3, underflow=False), integer)
 
-        assert isinstance(integer(1, 3, flow=False), integer_noflow)
+        assert isinstance(integer(1, 3, flow=False), _integer_noflow)
         assert isinstance(integer(1, 3, flow=False), integer)
 
-        assert isinstance(integer(1, 3, underflow=False, overflow=False), integer_noflow)
-        assert isinstance(integer(1, 3, underflow=False, overflow=False, flow=True), integer_uoflow)
+        assert isinstance(integer(1, 3, underflow=False, overflow=False), _integer_noflow)
+        assert isinstance(integer(1, 3, underflow=False, overflow=False, flow=True), _integer_uoflow)
 
-        assert isinstance(integer(1, 3, growth=True), integer_growth)
+        assert isinstance(integer(1, 3, growth=True), _integer_growth)
         assert isinstance(integer(1, 3, growth=True), integer)
 
     def test_init(self):
-        integer_uoflow(-1, 2)
-        integer_noflow(-1, 2)
-        integer_growth(-1, 2)
+        _integer_uoflow(-1, 2)
+        _integer_noflow(-1, 2)
+        _integer_growth(-1, 2)
         with pytest.raises(TypeError):
-            integer_uoflow()
+            _integer_uoflow()
         with pytest.raises(TypeError):
-            integer_uoflow(1)
+            _integer_uoflow(1)
         with pytest.raises(TypeError):
-            integer_uoflow("1", 2)
+            _integer_uoflow("1", 2)
         with pytest.raises(ValueError):
-            integer_uoflow(2, -1)
+            _integer_uoflow(2, -1)
 
         with pytest.raises(TypeError):
-            integer_uoflow(1, 2, 3)
+            _integer_uoflow(1, 2, 3)
 
-        assert integer_uoflow(-1, 2) == integer_uoflow(-1, 2)
-        assert integer_uoflow(-1, 2) != integer_uoflow(-1, 2, metadata="Other")
-        assert integer_noflow(-1, 2) != integer_uoflow(-1, 2)
+        assert _integer_uoflow(-1, 2) == _integer_uoflow(-1, 2)
+        assert _integer_uoflow(-1, 2) != _integer_uoflow(-1, 2, metadata="Other")
+        assert _integer_noflow(-1, 2) != _integer_uoflow(-1, 2)
 
     def test_len(self):
-        assert integer_uoflow(-1, 3).size() ==  4
-        assert integer_uoflow(-1, 3).size(flow=True) ==  6
-        assert integer_noflow(-1, 3).size() ==  4
-        assert integer_noflow(-1, 3).size(flow=True) ==  4
-        assert integer_growth(-1, 3).size() ==  4
-        assert integer_growth(-1, 3).size(flow=True) ==  4
+        assert _integer_uoflow(-1, 3).size() ==  4
+        assert _integer_uoflow(-1, 3).size(flow=True) ==  6
+        assert _integer_noflow(-1, 3).size() ==  4
+        assert _integer_noflow(-1, 3).size(flow=True) ==  4
+        assert _integer_growth(-1, 3).size() ==  4
+        assert _integer_growth(-1, 3).size(flow=True) ==  4
 
     def test_repr(self):
-        a = integer_uoflow(-1, 1)
+        a = _integer_uoflow(-1, 1)
         assert repr(a) == 'integer(-1, 1, options=underflow | overflow)'
 
-        a = integer_uoflow(-1, 1, metadata="hi")
+        a = _integer_uoflow(-1, 1, metadata="hi")
         assert repr(a) == 'integer(-1, 1, metadata="hi", options=underflow | overflow)'
 
-        a = integer_noflow(-1, 1)
+        a = _integer_noflow(-1, 1)
         assert repr(a) == 'integer(-1, 1, options=none)'
 
-        a = integer_growth(-1, 1)
+        a = _integer_growth(-1, 1)
         assert repr(a) == 'integer(-1, 1, options=growth)'
 
     def test_label(self):
-        a = integer_uoflow(-1, 2, metadata="foo")
+        a = _integer_uoflow(-1, 2, metadata="foo")
         assert a.metadata == "foo"
         a.metadata = "bar"
         assert a.metadata == "bar"
 
     def test_getitem(self):
         v = [-1, 0, 1, 2, 3]
-        a = integer_uoflow(-1, 3)
+        a = _integer_uoflow(-1, 3)
         for i in range(5):
             assert a.bin(i) == v[i]
         assert a.bin(-1) == -2 ** 31
@@ -532,11 +532,11 @@ class TestInteger:
 
     def test_iter(self):
         v = np.array([-1, 0, 1, 2])
-        a = integer_uoflow(-1, 3)
+        a = _integer_uoflow(-1, 3)
         assert_array_equal(a.bins(), v)
 
     def test_index(self):
-        a = integer_uoflow(-1, 3)
+        a = _integer_uoflow(-1, 3)
         assert a.index(-3) == -1
         assert a.index(-2) == -1
         assert a.index(-1) == 0

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -3,12 +3,12 @@ from pytest import approx
 
 
 from boost.histogram import histogram
-from boost.histogram.axis import (regular_uoflow, regular_noflow,
+from boost.histogram.axis import (_regular_uoflow, _regular_noflow,
                                   regular_log, regular_sqrt,
                                   regular_pow, circular,
-                                  variable, integer_uoflow,
-                                  integer_noflow, integer_growth,
-                                  category_int as category)
+                                  variable, _integer_uoflow,
+                                  _integer_noflow, _integer_growth,
+                                  _category_int as category)
 # TODO: import the public names only, not private ones (and make private names actually private)
 import boost.histogram as bh
 
@@ -26,7 +26,7 @@ except ImportError:
 
 def test_init():
     histogram()
-    histogram(integer_uoflow(-1, 1))
+    histogram(_integer_uoflow(-1, 1))
     with pytest.raises(RuntimeError):
         histogram(1)
     with pytest.raises(RuntimeError):
@@ -34,27 +34,27 @@ def test_init():
     with pytest.raises(RuntimeError):
         histogram([])
     with pytest.raises(RuntimeError):
-        histogram(regular_uoflow)
+        histogram(_regular_uoflow)
     with pytest.raises(TypeError):
-        histogram(regular_uoflow())
+        histogram(_regular_uoflow())
     with pytest.raises(RuntimeError):
-        histogram([integer_uoflow(-1, 1)])
+        histogram([_integer_uoflow(-1, 1)])
     with pytest.raises(RuntimeError):
-        histogram([integer_uoflow(-1, 1), integer_uoflow(-1, 1)])
+        histogram([_integer_uoflow(-1, 1), _integer_uoflow(-1, 1)])
     with pytest.raises(KeyError):
-        histogram(integer_uoflow(-1, 1), unknown_keyword="nh")
+        histogram(_integer_uoflow(-1, 1), unknown_keyword="nh")
 
-    h = histogram(integer_uoflow(-1, 2))
+    h = histogram(_integer_uoflow(-1, 2))
     assert h.rank() == 1
-    assert h.axis(0) == integer_uoflow(-1, 2)
+    assert h.axis(0) == _integer_uoflow(-1, 2)
     assert h.axis(0).size(flow=True) == 5
     assert h.axis(0).size() == 3
-    assert h != histogram(regular_uoflow(1, -1, 1))
-    assert h != histogram(integer_uoflow(-1, 1, metadata="ia"))
+    assert h != histogram(_regular_uoflow(1, -1, 1))
+    assert h != histogram(_integer_uoflow(-1, 1, metadata="ia"))
 
 
 def test_copy():
-    a = histogram(integer_uoflow(-1, 1))
+    a = histogram(_integer_uoflow(-1, 1))
     import copy
     b = copy.copy(a)
     assert a == b
@@ -67,7 +67,7 @@ def test_copy():
 
 def test_fill_int_1d():
 
-    h = histogram(integer_uoflow(-1, 2))
+    h = histogram(_integer_uoflow(-1, 2))
     assert isinstance(h, bh.hist.any_int)
     assert isinstance(h, histogram)
 
@@ -103,7 +103,7 @@ def test_fill_int_1d():
 
 @pytest.mark.parametrize("flow", [True, False])
 def test_fill_1d(flow):
-    h = histogram(regular_uoflow(3, -1, 2) if flow else regular_noflow(3, -1, 2))
+    h = histogram(_regular_uoflow(3, -1, 2) if flow else _regular_noflow(3, -1, 2))
     with pytest.raises(ValueError):
         h.fill()
     with pytest.raises(ValueError):
@@ -136,7 +136,7 @@ def test_fill_1d(flow):
         assert get(h, 3) == 1
 
 def test_growth():
-    h = histogram(integer_uoflow(-1, 2))
+    h = histogram(_integer_uoflow(-1, 2))
     h.fill(-1)
     h.fill(1)
     h.fill(1)
@@ -154,8 +154,8 @@ def test_growth():
 
 @pytest.mark.parametrize("flow", [True, False])
 def test_fill_2d(flow):
-    h = histogram((integer_uoflow if flow else integer_noflow)(-1, 2),
-                  (regular_uoflow if flow else regular_noflow)(4, -2, 2))
+    h = histogram((_integer_uoflow if flow else _integer_noflow)(-1, 2),
+                  (_regular_uoflow if flow else _regular_noflow)(4, -2, 2))
     h.fill(-1, -2)
     h.fill(-1, -1)
     h.fill(0, 0)
@@ -184,8 +184,8 @@ def test_fill_2d(flow):
 
 @pytest.mark.parametrize("flow", [True, False])
 def test_add_2d(flow):
-    h = histogram((integer_uoflow if flow else integer_noflow)(-1, 2),
-                  (regular_uoflow if flow else regular_noflow)(4, -2, 2))
+    h = histogram((_integer_uoflow if flow else _integer_noflow)(-1, 2),
+                  (_regular_uoflow if flow else _regular_noflow)(4, -2, 2))
     assert isinstance(h, histogram)
 
     h.fill(-1, -2)
@@ -209,8 +209,8 @@ def test_add_2d(flow):
             assert h.at(i, j) == 2 * m[i][j]
 
 def test_add_2d_bad():
-    a = histogram(integer_uoflow(-1, 1))
-    b = histogram(regular_uoflow(3, -1, 1))
+    a = histogram(_integer_uoflow(-1, 1))
+    b = histogram(_regular_uoflow(3, -1, 1))
 
     with pytest.raises(ValueError):
         a += b
@@ -220,8 +220,8 @@ def test_add_2d_bad():
 @pytest.mark.skip()
 @pytest.mark.parametrize("flow", [True, False])
 def test_add_2d_w(flow):
-    h = histogram((integer_uoflow if flow else integer_noflow)(-1, 2),
-                  (regular_uoflow if flow else regular_noflow)(4, -2, 2))
+    h = histogram((_integer_uoflow if flow else _integer_noflow)(-1, 2),
+                  (_regular_uoflow if flow else _regular_noflow)(4, -2, 2))
     h.fill(-1, -2)
     h.fill(-1, -1)
     h.fill(0, 0)
@@ -236,8 +236,8 @@ def test_add_2d_w(flow):
          [0, 1, 0, 0, 0, 0],
          [0, 0, 0, 0, 0, 0]]
 
-    h2 = histogram((integer_uoflow if flow else integer_noflow)(-1, 2),
-                  (regular_uoflow if flow else regular_noflow)(4, -2, 2))
+    h2 = histogram((_integer_uoflow if flow else _integer_noflow)(-1, 2),
+                  (_regular_uoflow if flow else _regular_noflow)(4, -2, 2))
     h2(0, 0, weight=0)
 
     h2 += h
@@ -250,7 +250,7 @@ def test_add_2d_w(flow):
             assert h.at(i, j) == 2 * m[i][j]
 
 def test_repr():
-    h = histogram(regular_uoflow(3, 0, 1), integer_uoflow(0, 1))
+    h = histogram(_regular_uoflow(3, 0, 1), _integer_uoflow(0, 1))
     hr = repr(h)
     assert hr == '''histogram(
   regular(3, 0, 1, options=underflow | overflow),
@@ -273,7 +273,7 @@ def test_repr():
 )'''
 
 def test_axis():
-    axes = (regular_uoflow(10, 0, 1), integer_uoflow(0, 1))
+    axes = (_regular_uoflow(10, 0, 1), _integer_uoflow(0, 1))
     h = histogram(*axes)
     for i, a in enumerate(axes):
         assert h.axis(i) == a
@@ -287,11 +287,11 @@ def test_axis():
 # CLASSIC: This used to only fail when accessing, now fails in creation
 def test_overflow():
     with pytest.raises(RuntimeError):
-        h = histogram(*[regular_uoflow(1, 0, 1) for i in range(50)])
+        h = histogram(*[_regular_uoflow(1, 0, 1) for i in range(50)])
 
 
 def test_out_of_range():
-    h = histogram(regular_uoflow(3, 0, 1))
+    h = histogram(_regular_uoflow(3, 0, 1))
     h.fill(-1)
     h.fill(2)
     assert h.at(-1) == 1
@@ -307,7 +307,7 @@ def test_out_of_range():
 
 # CLASSIC: This used to have variance
 def test_operators():
-    h = histogram(integer_uoflow(0, 2))
+    h = histogram(_integer_uoflow(0, 2))
     h.fill(0)
     h += h
     assert h.at(0) == 2
@@ -317,25 +317,25 @@ def test_operators():
     assert h.at(1) == 0
     assert (h + h).at(0) == (h * 2).at(0)
     assert (h + h).at(0) == (2 * h).at(0)
-    h2 = histogram(regular_uoflow(2, 0, 2))
+    h2 = histogram(_regular_uoflow(2, 0, 2))
     with pytest.raises(ValueError):
         h + h2
 
 # CLASSIC: reduce_to -> project,
 def test_project():
-    h = histogram(integer_uoflow(0, 2), integer_uoflow(1, 4))
+    h = histogram(_integer_uoflow(0, 2), _integer_uoflow(1, 4))
     h.fill(0, 1)
     h.fill(0, 2)
     h.fill(1, 3)
 
     h0 = h.project(0)
     assert h0.rank() == 1
-    assert h0.axis(0) == integer_uoflow(0, 2)
+    assert h0.axis(0) == _integer_uoflow(0, 2)
     assert [h0.at(i) for i in range(2)] == [2, 1]
 
     h1 = h.project(1)
     assert h1.rank() == 1
-    assert h1.axis(0) == integer_uoflow(1, 4)
+    assert h1.axis(0) == _integer_uoflow(1, 4)
     assert [h1.at(i) for i in range(3)] == [1, 1, 1]
 
     with pytest.raises(ValueError):
@@ -345,19 +345,19 @@ def test_project():
         h.project(2, 1)
 
 def test_shrink_1d():
-    h = histogram(regular_uoflow(20, 1, 5))
+    h = histogram(_regular_uoflow(20, 1, 5))
     h.fill(1.1)
     hs = h.shrink(0, 1, 2)
     assert_array_equal(hs.view(), [1,0,0,0,0])
 
 def test_rebin_1d():
-    h = histogram(regular_uoflow(20, 1, 5))
+    h = histogram(_regular_uoflow(20, 1, 5))
     h.fill(1.1)
     hs = h.rebin(0, 4)
     assert_array_equal(hs.view(), [1,0,0,0,0])
 
 def test_shrink_rebin_1d():
-    h = histogram(regular_uoflow(20, 0, 4))
+    h = histogram(_regular_uoflow(20, 0, 4))
     h.fill(1.1)
     hs = h.shrink_and_rebin(0, 1, 3, 2)
     assert_array_equal(hs.view(), [1,0,0,0,0])
@@ -366,8 +366,8 @@ def test_shrink_rebin_1d():
 # CLASSIC: This used to have metadata too, but that does not compare equal
 def test_pickle_0():
     a = histogram(category([0, 1, 2]),
-                  integer_uoflow(0, 20),
-                  regular_noflow(20, 0.0, 20.0),
+                  _integer_uoflow(0, 20),
+                  _regular_noflow(20, 0.0, 20.0),
                   variable([0.0, 1.0, 2.0]),
                   circular(4, 2*np.pi))
     for i in range(a.axis(0).size(flow=True)):
@@ -397,8 +397,8 @@ def test_pickle_0():
 @pytest.mark.skip(message="Requires weighted fills / type")
 def test_pickle_1():
     a = histogram(category([0, 1, 2]),
-                  integer_uoflow(0, 3, metadata='ia'),
-                  regular_noflow(4, 0.0, 4.0),
+                  _integer_uoflow(0, 3, metadata='ia'),
+                  _regular_noflow(4, 0.0, 4.0),
                   variable([0.0, 1.0, 2.0]))
     assert isinstance(a, bh.hist.any_int)
     assert isinstance(a, histogram)
@@ -429,7 +429,7 @@ def test_pickle_1():
 # Numpy tests
 
 def test_numpy_conversion_0():
-    a = histogram(integer_noflow(0, 3))
+    a = histogram(_integer_noflow(0, 3))
     a.fill(0)
     for i in range(5):
         a.fill(1)
@@ -457,7 +457,7 @@ def test_numpy_conversion_0():
 
 @pytest.mark.skip(message="Requires weighted fills / type")
 def test_numpy_conversion_1():
-    a = histogram(integer_uoflow(0, 3))
+    a = histogram(_integer_uoflow(0, 3))
     for i in range(10):
         a.fill(1, weight=3)
     c = np.array(a)  # a copy
@@ -467,9 +467,9 @@ def test_numpy_conversion_1():
     assert_array_equal(v, c)
 
 def test_numpy_conversion_2():
-    a = histogram(integer_noflow(0, 2),
-                  integer_noflow(0, 3),
-                  integer_noflow(0, 4))
+    a = histogram(_integer_noflow(0, 2),
+                  _integer_noflow(0, 3),
+                  _integer_noflow(0, 4))
     r = np.zeros((2, 3, 4), dtype=np.int8)
     for i in range(a.axis(0).size(flow=True)):
         for j in range(a.axis(1).size(flow=True)):
@@ -494,9 +494,9 @@ def test_numpy_conversion_2():
 
 @pytest.mark.skip(message="Requires weighted fills / type")
 def test_numpy_conversion_3():
-    a = histogram(integer_uoflow(0, 2),
-                  integer_uoflow(0, 3),
-                  integer_uoflow(0, 4))
+    a = histogram(_integer_uoflow(0, 2),
+                  _integer_uoflow(0, 3),
+                  _integer_uoflow(0, 4))
     r = np.zeros((2, 4, 5, 6))
     for i in range(a.axis(0).size(flow=True)):
         for j in range(a.axis(1).size(flow=True)):
@@ -518,8 +518,8 @@ def test_numpy_conversion_3():
     assert_array_equal(v, r)
 
 def test_numpy_conversion_4():
-    a = histogram(integer_noflow(0, 2),
-                  integer_noflow(0, 4))
+    a = histogram(_integer_noflow(0, 2),
+                  _integer_noflow(0, 4))
     a1 = np.asarray(a)
     assert a1.dtype == np.uint64 # CLASSIC: np.uint8
     assert a1.shape == (2, 4)
@@ -534,8 +534,8 @@ def test_numpy_conversion_4():
 
 @pytest.mark.skip(message="This require multiprecision storage")
 def test_numpy_conversion_5():
-    a = histogram(integer_noflow(0, 3),
-                  integer_noflow(0, 2))
+    a = histogram(_integer_noflow(0, 3),
+                  _integer_noflow(0, 2))
     a.fill(0, 0)
     for i in range(80):
         a = a + a
@@ -559,8 +559,8 @@ def test_numpy_conversion_5():
     assert a1[2, 1] == 5
 
 def test_numpy_conversion_6():
-    a = integer_uoflow(0, 2)
-    b = regular_uoflow(2, 0, 2)
+    a = _integer_uoflow(0, 2)
+    b = _regular_uoflow(2, 0, 2)
     c = variable([0, 1, 2])
     ref = np.array((0., 1., 2.))
     assert_array_equal(a.bins(), [0, 1])
@@ -578,7 +578,7 @@ def test_numpy_conversion_6():
 def test_fill_with_numpy_array_0():
     def ar(*args):
         return np.array(args, dtype=float)
-    a = histogram(integer_noflow(0, 3))
+    a = histogram(_integer_noflow(0, 3))
     a.fill(ar(-1, 0, 1, 2, 1))
     a.fill((4, -1, 0, 1, 2))
     assert a.at(0) == 2
@@ -597,8 +597,8 @@ def test_fill_with_numpy_array_0():
     with pytest.raises(ValueError):
         a.at(1, 2)
 
-    a = histogram(integer_noflow(0, 2),
-                  regular_noflow(2, 0, 2))
+    a = histogram(_integer_noflow(0, 2),
+                  _regular_noflow(2, 0, 2))
     a.fill(ar(-1, 0, 1), ar(-1., 1., 0.1))
     assert a.at(0, 0) == 0
     assert a.at(0, 1) == 1
@@ -619,7 +619,7 @@ def test_fill_with_numpy_array_0():
     with pytest.raises(ValueError):
         a.at(1, 2, 3)
 
-    a = histogram(integer_noflow(0, 3))
+    a = histogram(_integer_noflow(0, 3))
     a.fill(ar(0, 0, 1, 2, 1, 0, 2, 2))
     assert a.at(0) == 3
     assert a.at(1) == 2
@@ -629,7 +629,7 @@ def test_fill_with_numpy_array_0():
 def test_fill_with_numpy_array_1():
     def ar(*args):
         return np.array(args, dtype=float)
-    a = histogram(integer_uoflow(0, 3))
+    a = histogram(_integer_uoflow(0, 3))
     v = ar(-1, 0, 1, 2, 3, 4)
     w = ar( 2, 3, 4, 5, 6, 7)  # noqa
     a.fill(v, weight=w)
@@ -660,14 +660,14 @@ def test_fill_with_numpy_array_1():
     with pytest.raises(ValueError):
         a.fill((1, 2), weight=([1, 1], [2, 2]))
 
-    a = histogram(integer_noflow(0, 2),
-                  regular_noflow(2, 0, 2))
+    a = histogram(_integer_noflow(0, 2),
+                  _regular_noflow(2, 0, 2))
     a.fill((-1, 0, 1), (-1, 1, 0.1))
     assert a.at(0, 0) == 0
     assert a.at(0, 1) == 1
     assert a.at(1, 0) == 1
     assert a.at(1, 1) == 0
-    a = histogram(integer_noflow(0, 3))
+    a = histogram(_integer_noflow(0, 3))
     a.fill((0, 0, 1, 2))
     a.fill((1, 0, 2, 2))
     assert a.at(0) == 3

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -68,7 +68,7 @@ def test_copy():
 def test_fill_int_1d():
 
     h = histogram(_integer_uoflow(-1, 2))
-    assert isinstance(h, bh.hist.any_int)
+    assert isinstance(h, bh.hist._any_int)
     assert isinstance(h, histogram)
 
     with pytest.raises(ValueError):
@@ -400,7 +400,7 @@ def test_pickle_1():
                   _integer_uoflow(0, 3, metadata='ia'),
                   _regular_noflow(4, 0.0, 4.0),
                   variable([0.0, 1.0, 2.0]))
-    assert isinstance(a, bh.hist.any_int)
+    assert isinstance(a, bh.hist._any_int)
     assert isinstance(a, histogram)
 
     for i in range(a.axis(0).size(flow=True)):

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -3,12 +3,11 @@ from pytest import approx
 
 
 from boost.histogram import histogram
-from boost.histogram.axis import (_regular_uoflow, _regular_noflow,
+from boost.histogram.axis import (regular, integer,
                                   regular_log, regular_sqrt,
                                   regular_pow, circular,
-                                  variable, _integer_uoflow,
-                                  _integer_noflow, _integer_growth,
-                                  _category_int as category)
+                                  variable,
+                                  category)
 # TODO: import the public names only, not private ones (and make private names actually private)
 import boost.histogram as bh
 
@@ -26,7 +25,7 @@ except ImportError:
 
 def test_init():
     histogram()
-    histogram(_integer_uoflow(-1, 1))
+    histogram(integer(-1, 1))
     with pytest.raises(RuntimeError):
         histogram(1)
     with pytest.raises(RuntimeError):
@@ -34,27 +33,27 @@ def test_init():
     with pytest.raises(RuntimeError):
         histogram([])
     with pytest.raises(RuntimeError):
-        histogram(_regular_uoflow)
+        histogram(regular)
     with pytest.raises(TypeError):
-        histogram(_regular_uoflow())
+        histogram(regular())
     with pytest.raises(RuntimeError):
-        histogram([_integer_uoflow(-1, 1)])
+        histogram([integer(-1, 1)])
     with pytest.raises(RuntimeError):
-        histogram([_integer_uoflow(-1, 1), _integer_uoflow(-1, 1)])
+        histogram([integer(-1, 1), integer(-1, 1)])
     with pytest.raises(KeyError):
-        histogram(_integer_uoflow(-1, 1), unknown_keyword="nh")
+        histogram(integer(-1, 1), unknown_keyword="nh")
 
-    h = histogram(_integer_uoflow(-1, 2))
+    h = histogram(integer(-1, 2))
     assert h.rank() == 1
-    assert h.axis(0) == _integer_uoflow(-1, 2)
+    assert h.axis(0) == integer(-1, 2)
     assert h.axis(0).size(flow=True) == 5
     assert h.axis(0).size() == 3
-    assert h != histogram(_regular_uoflow(1, -1, 1))
-    assert h != histogram(_integer_uoflow(-1, 1, metadata="ia"))
+    assert h != histogram(regular(1, -1, 1))
+    assert h != histogram(integer(-1, 1, metadata="ia"))
 
 
 def test_copy():
-    a = histogram(_integer_uoflow(-1, 1))
+    a = histogram(integer(-1, 1))
     import copy
     b = copy.copy(a)
     assert a == b
@@ -67,7 +66,7 @@ def test_copy():
 
 def test_fill_int_1d():
 
-    h = histogram(_integer_uoflow(-1, 2))
+    h = histogram(integer(-1, 2))
     assert isinstance(h, bh.hist._any_int)
     assert isinstance(h, histogram)
 
@@ -103,7 +102,7 @@ def test_fill_int_1d():
 
 @pytest.mark.parametrize("flow", [True, False])
 def test_fill_1d(flow):
-    h = histogram(_regular_uoflow(3, -1, 2) if flow else _regular_noflow(3, -1, 2))
+    h = histogram(regular(3, -1, 2, flow=flow))
     with pytest.raises(ValueError):
         h.fill()
     with pytest.raises(ValueError):
@@ -136,7 +135,7 @@ def test_fill_1d(flow):
         assert get(h, 3) == 1
 
 def test_growth():
-    h = histogram(_integer_uoflow(-1, 2))
+    h = histogram(integer(-1, 2))
     h.fill(-1)
     h.fill(1)
     h.fill(1)
@@ -154,8 +153,8 @@ def test_growth():
 
 @pytest.mark.parametrize("flow", [True, False])
 def test_fill_2d(flow):
-    h = histogram((_integer_uoflow if flow else _integer_noflow)(-1, 2),
-                  (_regular_uoflow if flow else _regular_noflow)(4, -2, 2))
+    h = histogram(integer(-1, 2, flow=flow),
+                  regular(4, -2, 2, flow=flow))
     h.fill(-1, -2)
     h.fill(-1, -1)
     h.fill(0, 0)
@@ -184,8 +183,8 @@ def test_fill_2d(flow):
 
 @pytest.mark.parametrize("flow", [True, False])
 def test_add_2d(flow):
-    h = histogram((_integer_uoflow if flow else _integer_noflow)(-1, 2),
-                  (_regular_uoflow if flow else _regular_noflow)(4, -2, 2))
+    h = histogram(integer(-1, 2, flow=flow),
+                  regular(4, -2, 2, flow=flow))
     assert isinstance(h, histogram)
 
     h.fill(-1, -2)
@@ -209,8 +208,8 @@ def test_add_2d(flow):
             assert h.at(i, j) == 2 * m[i][j]
 
 def test_add_2d_bad():
-    a = histogram(_integer_uoflow(-1, 1))
-    b = histogram(_regular_uoflow(3, -1, 1))
+    a = histogram(integer(-1, 1))
+    b = histogram(regular(3, -1, 1))
 
     with pytest.raises(ValueError):
         a += b
@@ -220,8 +219,8 @@ def test_add_2d_bad():
 @pytest.mark.skip()
 @pytest.mark.parametrize("flow", [True, False])
 def test_add_2d_w(flow):
-    h = histogram((_integer_uoflow if flow else _integer_noflow)(-1, 2),
-                  (_regular_uoflow if flow else _regular_noflow)(4, -2, 2))
+    h = histogram(integer(-1, 2, flow=flow),
+                  regular(4, -2, 2, flow=flow))
     h.fill(-1, -2)
     h.fill(-1, -1)
     h.fill(0, 0)
@@ -236,8 +235,8 @@ def test_add_2d_w(flow):
          [0, 1, 0, 0, 0, 0],
          [0, 0, 0, 0, 0, 0]]
 
-    h2 = histogram((_integer_uoflow if flow else _integer_noflow)(-1, 2),
-                  (_regular_uoflow if flow else _regular_noflow)(4, -2, 2))
+    h2 = histogram(integer(-1, 2, flow=flow),
+                   regular(4, -2, 2, flow=flow))
     h2(0, 0, weight=0)
 
     h2 += h
@@ -250,7 +249,7 @@ def test_add_2d_w(flow):
             assert h.at(i, j) == 2 * m[i][j]
 
 def test_repr():
-    h = histogram(_regular_uoflow(3, 0, 1), _integer_uoflow(0, 1))
+    h = histogram(regular(3, 0, 1), integer(0, 1))
     hr = repr(h)
     assert hr == '''histogram(
   regular(3, 0, 1, options=underflow | overflow),
@@ -273,7 +272,7 @@ def test_repr():
 )'''
 
 def test_axis():
-    axes = (_regular_uoflow(10, 0, 1), _integer_uoflow(0, 1))
+    axes = (regular(10, 0, 1), integer(0, 1))
     h = histogram(*axes)
     for i, a in enumerate(axes):
         assert h.axis(i) == a
@@ -287,11 +286,11 @@ def test_axis():
 # CLASSIC: This used to only fail when accessing, now fails in creation
 def test_overflow():
     with pytest.raises(RuntimeError):
-        h = histogram(*[_regular_uoflow(1, 0, 1) for i in range(50)])
+        h = histogram(*[regular(1, 0, 1) for i in range(50)])
 
 
 def test_out_of_range():
-    h = histogram(_regular_uoflow(3, 0, 1))
+    h = histogram(regular(3, 0, 1))
     h.fill(-1)
     h.fill(2)
     assert h.at(-1) == 1
@@ -307,7 +306,7 @@ def test_out_of_range():
 
 # CLASSIC: This used to have variance
 def test_operators():
-    h = histogram(_integer_uoflow(0, 2))
+    h = histogram(integer(0, 2))
     h.fill(0)
     h += h
     assert h.at(0) == 2
@@ -317,25 +316,25 @@ def test_operators():
     assert h.at(1) == 0
     assert (h + h).at(0) == (h * 2).at(0)
     assert (h + h).at(0) == (2 * h).at(0)
-    h2 = histogram(_regular_uoflow(2, 0, 2))
+    h2 = histogram(regular(2, 0, 2))
     with pytest.raises(ValueError):
         h + h2
 
 # CLASSIC: reduce_to -> project,
 def test_project():
-    h = histogram(_integer_uoflow(0, 2), _integer_uoflow(1, 4))
+    h = histogram(integer(0, 2), integer(1, 4))
     h.fill(0, 1)
     h.fill(0, 2)
     h.fill(1, 3)
 
     h0 = h.project(0)
     assert h0.rank() == 1
-    assert h0.axis(0) == _integer_uoflow(0, 2)
+    assert h0.axis(0) == integer(0, 2)
     assert [h0.at(i) for i in range(2)] == [2, 1]
 
     h1 = h.project(1)
     assert h1.rank() == 1
-    assert h1.axis(0) == _integer_uoflow(1, 4)
+    assert h1.axis(0) == integer(1, 4)
     assert [h1.at(i) for i in range(3)] == [1, 1, 1]
 
     with pytest.raises(ValueError):
@@ -345,19 +344,19 @@ def test_project():
         h.project(2, 1)
 
 def test_shrink_1d():
-    h = histogram(_regular_uoflow(20, 1, 5))
+    h = histogram(regular(20, 1, 5))
     h.fill(1.1)
     hs = h.shrink(0, 1, 2)
     assert_array_equal(hs.view(), [1,0,0,0,0])
 
 def test_rebin_1d():
-    h = histogram(_regular_uoflow(20, 1, 5))
+    h = histogram(regular(20, 1, 5))
     h.fill(1.1)
     hs = h.rebin(0, 4)
     assert_array_equal(hs.view(), [1,0,0,0,0])
 
 def test_shrink_rebin_1d():
-    h = histogram(_regular_uoflow(20, 0, 4))
+    h = histogram(regular(20, 0, 4))
     h.fill(1.1)
     hs = h.shrink_and_rebin(0, 1, 3, 2)
     assert_array_equal(hs.view(), [1,0,0,0,0])
@@ -366,8 +365,8 @@ def test_shrink_rebin_1d():
 # CLASSIC: This used to have metadata too, but that does not compare equal
 def test_pickle_0():
     a = histogram(category([0, 1, 2]),
-                  _integer_uoflow(0, 20),
-                  _regular_noflow(20, 0.0, 20.0),
+                  integer(0, 20),
+                  regular(20, 0.0, 20.0, flow=False),
                   variable([0.0, 1.0, 2.0]),
                   circular(4, 2*np.pi))
     for i in range(a.axis(0).size(flow=True)):
@@ -397,8 +396,8 @@ def test_pickle_0():
 @pytest.mark.skip(message="Requires weighted fills / type")
 def test_pickle_1():
     a = histogram(category([0, 1, 2]),
-                  _integer_uoflow(0, 3, metadata='ia'),
-                  _regular_noflow(4, 0.0, 4.0),
+                  integer(0, 3, metadata='ia'),
+                  regular(4, 0.0, 4.0, flow=False),
                   variable([0.0, 1.0, 2.0]))
     assert isinstance(a, bh.hist._any_int)
     assert isinstance(a, histogram)
@@ -429,7 +428,7 @@ def test_pickle_1():
 # Numpy tests
 
 def test_numpy_conversion_0():
-    a = histogram(_integer_noflow(0, 3))
+    a = histogram(integer(0, 3, flow=False))
     a.fill(0)
     for i in range(5):
         a.fill(1)
@@ -457,7 +456,7 @@ def test_numpy_conversion_0():
 
 @pytest.mark.skip(message="Requires weighted fills / type")
 def test_numpy_conversion_1():
-    a = histogram(_integer_uoflow(0, 3))
+    a = histogram(integer(0, 3))
     for i in range(10):
         a.fill(1, weight=3)
     c = np.array(a)  # a copy
@@ -467,9 +466,9 @@ def test_numpy_conversion_1():
     assert_array_equal(v, c)
 
 def test_numpy_conversion_2():
-    a = histogram(_integer_noflow(0, 2),
-                  _integer_noflow(0, 3),
-                  _integer_noflow(0, 4))
+    a = histogram(integer(0, 2, flow=False),
+                  integer(0, 3, flow=False),
+                  integer(0, 4, flow=False))
     r = np.zeros((2, 3, 4), dtype=np.int8)
     for i in range(a.axis(0).size(flow=True)):
         for j in range(a.axis(1).size(flow=True)):
@@ -494,9 +493,9 @@ def test_numpy_conversion_2():
 
 @pytest.mark.skip(message="Requires weighted fills / type")
 def test_numpy_conversion_3():
-    a = histogram(_integer_uoflow(0, 2),
-                  _integer_uoflow(0, 3),
-                  _integer_uoflow(0, 4))
+    a = histogram(integer(0, 2),
+                  integer(0, 3),
+                  integer(0, 4))
     r = np.zeros((2, 4, 5, 6))
     for i in range(a.axis(0).size(flow=True)):
         for j in range(a.axis(1).size(flow=True)):
@@ -518,8 +517,8 @@ def test_numpy_conversion_3():
     assert_array_equal(v, r)
 
 def test_numpy_conversion_4():
-    a = histogram(_integer_noflow(0, 2),
-                  _integer_noflow(0, 4))
+    a = histogram(integer(0, 2, flow=False),
+                  integer(0, 4, flow=False))
     a1 = np.asarray(a)
     assert a1.dtype == np.uint64 # CLASSIC: np.uint8
     assert a1.shape == (2, 4)
@@ -534,8 +533,8 @@ def test_numpy_conversion_4():
 
 @pytest.mark.skip(message="This require multiprecision storage")
 def test_numpy_conversion_5():
-    a = histogram(_integer_noflow(0, 3),
-                  _integer_noflow(0, 2))
+    a = histogram(integer(0, 3, flow=False),
+                  integer(0, 2, flow=False))
     a.fill(0, 0)
     for i in range(80):
         a = a + a
@@ -559,8 +558,8 @@ def test_numpy_conversion_5():
     assert a1[2, 1] == 5
 
 def test_numpy_conversion_6():
-    a = _integer_uoflow(0, 2)
-    b = _regular_uoflow(2, 0, 2)
+    a = integer(0, 2)
+    b = regular(2, 0, 2)
     c = variable([0, 1, 2])
     ref = np.array((0., 1., 2.))
     assert_array_equal(a.bins(), [0, 1])
@@ -578,7 +577,7 @@ def test_numpy_conversion_6():
 def test_fill_with_numpy_array_0():
     def ar(*args):
         return np.array(args, dtype=float)
-    a = histogram(_integer_noflow(0, 3))
+    a = histogram(integer(0, 3, flow=False))
     a.fill(ar(-1, 0, 1, 2, 1))
     a.fill((4, -1, 0, 1, 2))
     assert a.at(0) == 2
@@ -597,8 +596,8 @@ def test_fill_with_numpy_array_0():
     with pytest.raises(ValueError):
         a.at(1, 2)
 
-    a = histogram(_integer_noflow(0, 2),
-                  _regular_noflow(2, 0, 2))
+    a = histogram(integer(0, 2, flow=False),
+                  regular(2, 0, 2, flow=False))
     a.fill(ar(-1, 0, 1), ar(-1., 1., 0.1))
     assert a.at(0, 0) == 0
     assert a.at(0, 1) == 1
@@ -619,7 +618,7 @@ def test_fill_with_numpy_array_0():
     with pytest.raises(ValueError):
         a.at(1, 2, 3)
 
-    a = histogram(_integer_noflow(0, 3))
+    a = histogram(integer(0, 3, flow=False))
     a.fill(ar(0, 0, 1, 2, 1, 0, 2, 2))
     assert a.at(0) == 3
     assert a.at(1) == 2
@@ -629,7 +628,7 @@ def test_fill_with_numpy_array_0():
 def test_fill_with_numpy_array_1():
     def ar(*args):
         return np.array(args, dtype=float)
-    a = histogram(_integer_uoflow(0, 3))
+    a = histogram(integer(0, 3))
     v = ar(-1, 0, 1, 2, 3, 4)
     w = ar( 2, 3, 4, 5, 6, 7)  # noqa
     a.fill(v, weight=w)
@@ -660,14 +659,14 @@ def test_fill_with_numpy_array_1():
     with pytest.raises(ValueError):
         a.fill((1, 2), weight=([1, 1], [2, 2]))
 
-    a = histogram(_integer_noflow(0, 2),
-                  _regular_noflow(2, 0, 2))
+    a = histogram(integer(0, 2, flow=False),
+                  regular(2, 0, 2, flow=False))
     a.fill((-1, 0, 1), (-1, 1, 0.1))
     assert a.at(0, 0) == 0
     assert a.at(0, 1) == 1
     assert a.at(1, 0) == 1
     assert a.at(1, 1) == 0
-    a = histogram(_integer_noflow(0, 3))
+    a = histogram(integer(0, 3, flow=False))
     a.fill((0, 0, 1, 2))
     a.fill((1, 0, 2, 2))
     assert a.at(0) == 3


### PR DESCRIPTION
This PR renames the rest of the axes and the histograms to private names; the only publicly supported way to create a histogram or axis is through the creation tools like `histogram()` and `regular()`.