### PR TITLE
Fancy indexing, reduce from Boost.Histogram

### DIFF
--- a/.ci/azure-test-pipeline.yml
+++ b/.ci/azure-test-pipeline.yml
@@ -9,12 +9,22 @@ variables:
 
 jobs:
 
-- job: ClangFormat
+- job: Formatting
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
     - script: scripts/check_style_docker.sh
       displayName: Check format
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.7'
+        architecture: 'x64'
+    - script: python -m pip install black
+      displayName: Install Python formatter
+    - script: python -m black tests/test_*.py
+      displayName: Run Python formatter
+    - script: git diff --exit-code --color
+      displayName: Python format changes
 
 - job: LinuxSDist
   pool:

--- a/README.md
+++ b/README.md
@@ -95,9 +95,7 @@ counts = hist.view()
     * `.at(i, j, ...)`: Get the bin contents as a location 
     * `.sum()`: The total count of all bins
     * `.project(ax1, ax2, ...)`: Project down to listed axis (numbers)
-    * `.shrink(ax, lower, upper)`: Remove bins outside a range on a listed axis (number)
-    * `.rebin(ax, merge)`: Combine `merge` number of bins on a listed axis (number)
-    * `.shring_and_rebin(ax, lower, upper, merge)`: Shrink and rebin at the same time
+    * `.reduce(ax, reduce_option, ...)`: shrink, rebin, or slice, or any combination
     * `.indexed(flow=False)`: Iterate over the bins with a special "indexed" iterator
         * `ind.content`: The contents of a bin (set or get)
         * `ind.bin(N)`: The Nth bin (has the normal `.center`, `.lower`, `.upper`, and `.width`)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,10 @@
 Welcome to boost-histogram's documentation!
 ===========================================
 
+Boost-histogram (`source <https://github.com/scikit-hep/boost-histogram>`_) is a Python package providing Python bindings for Boost.Histogram_ (`source <https://github.com/boostorg/histogram>`_).
+
+.. _Boost.Histogram: https://www.boost.org/doc/libs/1_71_0/libs/histogram/doc/html/index.html
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
@@ -13,6 +17,7 @@ Welcome to boost-histogram's documentation!
    usage/installation
    usage/quickstart
    usage/axes
+   usage/indexing
 
 
 

--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -1,0 +1,137 @@
+Indexing
+========
+
+This is the proposal for Histogram indexing that was implemented in boost-histogram.
+
+Access:
+^^^^^^^
+
+.. code:: python
+
+   v = h[b] # Returns bin contents, indexed by bin number
+   v = h[loc(b)] # Returns the bin containing the value
+
+Slicing:
+^^^^^^^^
+
+.. code:: python
+
+   h == h[:]             # Slice over everything
+   h2 = h[a:b]           # Slice of histogram (includes flow bins)
+   h2 = h[:b]            # Leaving out endpoints is okay
+   h2 = h[loc(v):]       # Slices can be in data coordinates, too
+   h2 = h[::project]     # Projection operations
+   h2 = h[::rebin(2)]    # Modification operations (rebin)
+   h2 = h[a:b:rebin(2)]  # Modifications can combine with slices
+   h2 = h[0:end:project] # Special end functor is easy to write
+   h2 = h[a:b, ...]      # Ellipsis work just like normal numpy
+
+   # Not yet supported!
+   h2 = h[a:b:project] # Adding endpoints to projection operations removes under or overflow from the calculation
+   h2 = h[0:len(h2.axis(0)):project] # Projection without flow bins
+
+Setting (Not yet supported)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: python
+
+   h[...] = np.ndarray(...) # Setting with an array or histogram sets the contents if the sizes match
+                            # Overflow can optionally be included
+   h[b] = v                 # Single values work too
+
+All of this generalizes to multiple dimensions. ``loc(v)`` could return
+categorical bins, but slicing on categories would (currently) not be
+allowed. These all return histograms, so flow bins are always preserved
+- the one exception is projection; since this removes an axis, the only
+use for the slice edges is to be explicit on what part you are
+interested for the projection. So an explicit (non-empty) slice here
+will case the relevant flow bin to be excluded (not currently supported).
+
+``loc``, ``project``, and ``rebin`` all live inside the histogramming
+package (like boost-histogram), but are completely general and can be created by a
+user using an explicit API (below).
+
+Invalid syntax:
+^^^^^^^^^^^^^^^
+
+.. code:: python
+
+   h[v, a:b] # You cannot mix slices and bin contents access (h is an integer)
+   h[1.0] # Floats are not allowed, just like numpy
+   h[::2] # Skipping is not (currently) supported
+   h[..., None] # None == np.newaxis is not supported
+
+Rejected proposals or proposals for future consideration, maybe ``hist``-only:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: python
+
+   h2 = h[1j:2j] # Adding a j suffix to a number could be used in place of `loc(x)`
+   h2 = h[1.0] # Floats in place of `loc(x)`: too easy to make a mistake
+
+--------------
+
+Implementation notes
+--------------------
+
+loc, rebin, and project are *not* tags, or special types, but rather
+APIs for classes. New versions of these could be added, and
+implementations could be shared among Histogram libraries. For clarity,
+the following code is written in Python 3.6+. `Prototype
+here <https://gist.github.com/henryiii/d545a673ea2b3225cb985c9c02ac958b>`__.
+`Extra doc
+here <https://docs.google.com/document/d/1bJKA7Y0QXf46w53UFizJ4bnZlVIkb4aCqx6m2hoN0HM/edit#heading=h.jvegm6z8f387>`__.
+
+Note that the API comes in two forms; the ``__call__`` operator form is more powerful, slower, optional, and is not supported by boost.histogram.
+
+Basic implementation (WIP):
+
+.. code:: python
+
+   class loc:
+       "When used in the start or stop of a Histogram's slice, x is taken to be the position in data coordinates."
+       def __init__(self, x):
+           self.value = x
+
+   # Other flags, such as callable functions, could be added and detected later.
+
+   class project:
+       "When used in the step of a Histogram's slice, project sums over and eliminates what remains of the axis after slicing."
+       projection = True
+       def __new__(cls, binning, axis, counts):
+         return None, numpy.add.reduce(counts, axis=axis)
+
+
+
+   class rebin:
+       "When used in the step of a Histogram's slice, rebin(n) combines bins, scaling their widths by a factor of n. If the number of bins is not divisible by n, the remainder is added to the overflow bin."
+       projection = False
+       def __init__(self, factor):
+           self.factor = factor
+
+       # Optional and not used by boost-histogram
+       def __call__(self, binning, axis, counts):
+           factor = self.factor
+           if isinstance(binning, Regular):
+               indexes = (numpy.arange(0, binning.num, factor),)
+
+               num, remainder = divmod(binning.num, factor)
+               high, hasover = binning.high, binning.hasover
+
+               if binning.hasunder:
+                   indexes[0][:] += 1
+                   indexes = ([0],) + indexes
+
+               if remainder == 0:
+                   if binning.hasover:
+                       indexes = indexes + ([binning.num + int(binning.hasunder)],)
+               else:
+                   high = binning.left(indexes[-1][-1])
+                   hasover = True
+
+               binning = Regular(num, binning.low, high, hasunder=binning.hasunder, hasover=hasover)
+               counts = numpy.add.reduceat(counts, numpy.concatenate(indexes), axis=axis)
+               return binning, counts
+
+           else:
+               raise NotImplementedError(type(binning))

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -136,42 +136,16 @@ py::class_<bh::histogram<A, S>> register_histogram(py::module &m, const char *na
             },
             "flow"_a = false)
 
-        /* Broken: Does not work if any string axes present (even just in variant) */
         .def(
-            "rebin",
-            [](const histogram_t &self, unsigned axis, unsigned merge) {
-                return bh::algorithm::reduce(self, bh::algorithm::rebin(axis, merge));
+            "reduce",
+            [](const histogram_t &self, py::args args) {
+                return bh::algorithm::reduce(self, py::cast<std::vector<bh::algorithm::reduce_option>>(args));
             },
-            "axis"_a,
-            "merge"_a,
-            "Rebin by merging bins. You must select an axis.")
-
-        .def(
-            "shrink",
-            [](const histogram_t &self, unsigned axis, double lower, double upper) {
-                return bh::algorithm::reduce(self, bh::algorithm::shrink(axis, lower, upper));
-            },
-            "axis"_a,
-            "lower"_a,
-            "upper"_a,
-            "Shrink an axis. You must select an axis.")
-
-        .def(
-            "shrink_and_rebin",
-            [](const histogram_t &self, unsigned axis, double lower, double upper, unsigned merge) {
-                return bh::algorithm::reduce(self, bh::algorithm::shrink_and_rebin(axis, lower, upper, merge));
-            },
-            "axis"_a,
-            "lower"_a,
-            "upper"_a,
-            "merge"_a,
-            "Shrink an axis and rebin. You must select an axis.")
+            "Reduce based on one or more reduce_option")
 
         .def(
             "project",
             [](const histogram_t &self, py::args values) {
-                // If static
-                // histogram<any_axis> any = self;
                 return bh::algorithm::project(self, py::cast<std::vector<unsigned>>(values));
             },
             "Project to a single axis or several axes on a multidiminsional histogram")

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -96,7 +96,7 @@ py::class_<bh::histogram<A, S>> register_histogram(py::module &m, const char *na
 
         .def(
             "axis",
-            [](histogram_t &self, int i) {
+            [](const histogram_t &self, int i) {
                 unsigned ii = i < 0 ? self.rank() - (unsigned)std::abs(i) : (unsigned)i;
                 if(ii < self.rank())
                     return self.axis(ii);
@@ -109,7 +109,7 @@ py::class_<bh::histogram<A, S>> register_histogram(py::module &m, const char *na
 
         .def(
             "at",
-            [](histogram_t &self, py::args &args) {
+            [](const histogram_t &self, py::args &args) {
                 // Optimize for no dynamic?
                 auto int_args = py::cast<std::vector<int>>(args);
                 return self.at(int_args);
@@ -117,6 +117,19 @@ py::class_<bh::histogram<A, S>> register_histogram(py::module &m, const char *na
             "Access bin counter at indices")
 
         .def("__repr__", shift_to_string<histogram_t>())
+    
+        .def("__getitem__", [](const histogram_t &self, py::object index) {
+            py::list tmpindexes;
+            tmpindexes.append(index);
+            py::tuple indexes = py::cast<py::tuple>(py::isinstance<py::tuple>(index) ? index : tmpindexes);
+            
+            if(indexes.size() != self.rank())
+                throw std::out_of_range("You must provide the same number of indexes as the rank of the histogram");
+            
+            auto int_args = py::cast<std::vector<int>>(indexes);
+            return self.at(int_args);
+            
+        })
 
         .def(
             "sum",

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -18,6 +18,7 @@
 #include <boost/histogram/python/indexed.hpp>
 #include <boost/histogram/python/kwargs.hpp>
 #include <boost/histogram/python/serializion.hpp>
+#include <boost/histogram/python/shared_histogram.hpp>
 #include <boost/histogram/python/storage.hpp>
 #include <boost/histogram/python/variant.hpp>
 #include <boost/histogram/unsafe_access.hpp>
@@ -136,51 +137,12 @@ py::class_<bh::histogram<A, S>> register_histogram(py::module &m, const char *na
                 } catch(const py::cast_error &) {
                 }
 
-                std::vector<bh::algorithm::reduce_option> slices;
-                for(unsigned int i = 0; i < indexes.size(); i++) {
-                    auto ind = indexes[i];
-                    if(!py::isinstance<py::slice>(ind))
-                        throw std::out_of_range(
-                            "Invalid arguments as an index, use all integers or all slices, and do not mix");
-
-                    py::object start = ind.attr("start");
-                    py::object stop  = ind.attr("stop");
-                    py::object step  = ind.attr("step");
-
-                    // : means take all from axis
-                    if(start.is_none() && stop.is_none() && step.is_none()) {
-                        continue;
-                    } else {
-                        // Start can be none, integer, or loc(double)
-                        bh::axis::index_type begin
-                            = start.is_none() ? 0
-                                              : (py::hasattr(start, "value")
-                                                     ? self.axis().index(py::cast<double>(start.attr("value")))
-                                                     : py::cast<bh::axis::index_type>(start));
-
-                        // Stop can be none, integer, or loc(double)
-                        bh::axis::index_type end = stop.is_none()
-                                                       ? self.axis(i).size()
-                                                       : (py::hasattr(stop, "value")
-                                                              ? self.axis().index(py::cast<double>(stop.attr("value")))
-                                                              : py::cast<bh::axis::index_type>(stop));
-
-                        unsigned merge = 1;
-                        if(step.is_none()) {
-                            merge = 1;
-                        } else if(!py::hasattr(step, "projection")) {
-                            throw std::out_of_range("The third argument to a slice must be rebin or projection");
-                        } else if(py::cast<bool>(step.attr("projection")) == true) {
-                            throw std::out_of_range("Currently projection is not supported");
-                        } else {
-                            if(!py::hasattr(step, "factor"))
-                                throw std::out_of_range("Invalid rebin, must have .factor set to an integer");
-                            merge = py::cast<unsigned>(step.attr("factor"));
-                        }
-
-                        slices.push_back(bh::algorithm::slice_and_rebin(i, begin, end, merge));
-                    }
-                }
+                std::vector<bh::algorithm::reduce_option> slices = get_slices(
+                    indexes,
+                    [&self](bh::axis::index_type i, double val) {
+                        return self.axis(static_cast<unsigned>(i)).index(val);
+                    },
+                    [&self](bh::axis::index_type i) { return self.axis(static_cast<unsigned>(i)).size(); });
 
                 return bh::algorithm::reduce(self, slices);
                 // Ellipsis is not yet supported

--- a/include/boost/histogram/python/serializion.hpp
+++ b/include/boost/histogram/python/serializion.hpp
@@ -5,8 +5,7 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef BOOST_HISTOGRAM_PICKLE_HPP
-#define BOOST_HISTOGRAM_PICKLE_HPP
+#pragma once
 
 #include <boost/histogram/python/pybind11.hpp>
 
@@ -192,5 +191,3 @@ void serialize(Archive &ar, histogram<A, S> &h, unsigned /* version */) {
 
 } // namespace histogram
 } // namespace boost
-
-#endif

--- a/include/boost/histogram/python/shared_histogram.hpp
+++ b/include/boost/histogram/python/shared_histogram.hpp
@@ -9,9 +9,10 @@
 
 #include <boost/histogram/algorithm/reduce.hpp>
 #include <functional>
+#include <tuple>
 #include <vector>
 
-std::vector<bh::algorithm::reduce_option>
+std::tuple<std::vector<bh::algorithm::reduce_option>, std::vector<unsigned>>
 get_slices(py::tuple index,
            std::function<bh::axis::index_type(bh::axis::index_type, double)> index_self,
            std::function<bh::axis::index_type(bh::axis::index_type)> size_self);

--- a/include/boost/histogram/python/shared_histogram.hpp
+++ b/include/boost/histogram/python/shared_histogram.hpp
@@ -1,0 +1,17 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/python/pybind11.hpp>
+
+#include <boost/histogram/algorithm/reduce.hpp>
+#include <functional>
+#include <vector>
+
+std::vector<bh::algorithm::reduce_option>
+get_slices(py::tuple index,
+           std::function<bh::axis::index_type(bh::axis::index_type, double)> index_self,
+           std::function<bh::axis::index_type(bh::axis::index_type)> size_self);

--- a/include/boost/histogram/python/shared_histogram.hpp
+++ b/include/boost/histogram/python/shared_histogram.hpp
@@ -15,3 +15,5 @@ std::vector<bh::algorithm::reduce_option>
 get_slices(py::tuple index,
            std::function<bh::axis::index_type(bh::axis::index_type, double)> index_self,
            std::function<bh::axis::index_type(bh::axis::index_type)> size_self);
+
+py::list expand_ellipsis(py::list indexes, py::size_t rank);

--- a/include/boost/histogram/python/typetools.hpp
+++ b/include/boost/histogram/python/typetools.hpp
@@ -1,3 +1,8 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
 #pragma once
 
 namespace boost {

--- a/include/boost/histogram/python/variant.hpp
+++ b/include/boost/histogram/python/variant.hpp
@@ -1,0 +1,18 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/python/pybind11.hpp>
+
+#include <boost/variant2/variant.hpp>
+
+/// Register boost::variant2::variant as a variant for PyBind11
+namespace pybind11 {
+namespace detail {
+template <class... Ts>
+struct type_caster<boost::variant2::variant<Ts...>> : variant_caster<boost::variant2::variant<Ts...>> {};
+} // namespace detail
+} // namespace pybind11

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,12 @@ ext_modules = [
     Extension(
         'boost.histogram',
         ['src/module.cpp',
-         'src/utils.cpp',
          'src/histogram/version.cpp',
+         'src/histogram/utils.cpp',
          'src/histogram/algorithm.cpp',
          'src/histogram/axis.cpp',
          'src/histogram/polymorphic_bin.cpp',
+         'src/histogram/shared_histogram.cpp',
          'src/histogram/general_histograms.cpp',
          'src/histogram/make_histogram.cpp',
          'src/histogram/storage.cpp',

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ ext_modules = [
         'boost.histogram',
         ['src/module.cpp',
          'src/histogram/version.cpp',
+         'src/histogram/algorithm.cpp',
          'src/histogram/axis.cpp',
          'src/histogram/polymorphic_bin.cpp',
          'src/histogram/general_histograms.cpp',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ ext_modules = [
     Extension(
         'boost.histogram',
         ['src/module.cpp',
+         'src/utils.cpp',
          'src/histogram/version.cpp',
          'src/histogram/algorithm.cpp',
          'src/histogram/axis.cpp',

--- a/src/histogram/algorithm.cpp
+++ b/src/histogram/algorithm.cpp
@@ -1,0 +1,92 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#include <boost/histogram/python/pybind11.hpp>
+
+#include <boost/histogram/algorithm/reduce.hpp>
+
+void register_algorithms(py::module &algorithm) {
+    algorithm.def(
+        "sum",
+        [](py::object item, bool flow) { return item.attr("sum")("flow"_a = flow); },
+        "Sum a histogram",
+        "histogram"_a,
+        "flow"_a = false);
+
+    algorithm.def(
+        "reduce",
+        [](py::object item, py::args args) { return item.attr("reduce")(args); },
+        "Reduce a histogram with one or more reduce_options",
+        "histogram"_a);
+
+    py::class_<bh::algorithm::reduce_option>(algorithm, "reduce_option")
+        .def(py::init<unsigned, bool, bh::axis::index_type, bh::axis::index_type, bool, double, double, unsigned>(),
+             "iaxis"_a,
+             "indices_set"_a,
+             "begin"_a,
+             "end"_a,
+             "values_set"_a,
+             "lower"_a,
+             "upper"_a,
+             "merge"_a,
+             "Constructor for reduce_option; use creation functions instead.")
+        .def("__repr__", [](const bh::algorithm::reduce_option &self) {
+            return py::str("reduce_option(iaxis={}, indices_set={}, begin={}, end={}, values_set={}, lower={}, "
+                           "upper={}, merge={})")
+                .format(self.iaxis,
+                        self.indices_set,
+                        self.begin,
+                        self.end,
+                        self.values_set,
+                        self.lower,
+                        self.upper,
+                        self.merge);
+        });
+
+    algorithm.def("shrink_and_rebin",
+                  py::overload_cast<unsigned, double, double, unsigned>(&bh::algorithm::shrink_and_rebin),
+                  "iaxis"_a,
+                  "lower"_a,
+                  "upper"_a,
+                  "merge"_a,
+                  "Shrink and rebin option to be used in reduce().\n"
+                  "\n"
+                  "To shrink and rebin in one command. Equivalent to passing both the shrink() and the\n"
+                  "rebin() option for the same axis to reduce.\n"
+                  "\n"
+                  ":param iaxis: which axis to operate on.\n"
+                  ":param lower: lowest bound that should be kept.\n"
+                  ":param upper: highest bound that should be kept. If upper is inside bin interval, the whole "
+                  "interval is removed.\n"
+                  ":param merge: how many adjacent bins to merge into one.");
+
+    algorithm.def("slice_and_rebin",
+                  py::overload_cast<unsigned, bh::axis::index_type, bh::axis::index_type, unsigned>(
+                      &bh::algorithm::slice_and_rebin),
+                  "iaxis"_a,
+                  "begin"_a,
+                  "end"_a,
+                  "merge"_a,
+                  "Slice and rebin option to be used in reduce().\n"
+                  "\n"
+                  "To slice and rebin in one command. Equivalent to passing both the slice() and the\n"
+                  "rebin() option for the same axis to reduce.\n"
+                  "\n"
+                  ":param iaxis: which axis to operate on.\n"
+                  ":param begin: first index that should be kept.\n"
+                  ":param end: one past the last index that should be kept.\n"
+                  ":param merge: how many adjacent bins to merge into one.");
+
+    algorithm.def("rebin", py::overload_cast<unsigned, unsigned>(&bh::algorithm::rebin), "iaxis"_a, "merge"_a);
+
+    algorithm.def(
+        "shrink", py::overload_cast<unsigned, double, double>(&bh::algorithm::shrink), "iaxis"_a, "lower"_a, "upper"_a);
+
+    algorithm.def("slice",
+                  py::overload_cast<unsigned, bh::axis::index_type, bh::axis::index_type>(&bh::algorithm::slice),
+                  "iaxis"_a,
+                  "begin"_a,
+                  "end"_a);
+}

--- a/src/histogram/algorithm.cpp
+++ b/src/histogram/algorithm.cpp
@@ -21,6 +21,13 @@ void register_algorithms(py::module &algorithm) {
         "Reduce a histogram with one or more reduce_options",
         "histogram"_a);
 
+    algorithm.def(
+        "indexed",
+        [](py::object item, bool flow) { return item.attr("indexed")("flow"_a = flow); },
+        "histogram"_a,
+        "flow"_a = false,
+        "Set up an iterator, returns a special accessor for bin info and content");
+
     py::class_<bh::algorithm::reduce_option>(algorithm, "reduce_option")
         .def(py::init<unsigned, bool, bh::axis::index_type, bh::axis::index_type, bool, double, double, unsigned>(),
              "iaxis"_a,

--- a/src/histogram/shared_histogram.cpp
+++ b/src/histogram/shared_histogram.cpp
@@ -1,0 +1,56 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#include <boost/histogram/python/shared_histogram.hpp>
+
+std::vector<bh::algorithm::reduce_option>
+get_slices(py::tuple indexes,
+           std::function<bh::axis::index_type(bh::axis::index_type, double)> index_self,
+           std::function<bh::axis::index_type(bh::axis::index_type)> size_self) {
+    std::vector<bh::algorithm::reduce_option> slices;
+    for(bh::axis::index_type i = 0; static_cast<unsigned>(i) < indexes.size(); i++) {
+        auto ind = indexes[static_cast<pybind11::size_t>(i)];
+        if(!py::isinstance<py::slice>(ind))
+            throw std::out_of_range("Invalid arguments as an index, use all integers or all slices, and do not mix");
+
+        py::object start = ind.attr("start");
+        py::object stop  = ind.attr("stop");
+        py::object step  = ind.attr("step");
+
+        // : means take all from axis
+        if(start.is_none() && stop.is_none() && step.is_none()) {
+            continue;
+        } else {
+            // Start can be none, integer, or loc(double)
+            bh::axis::index_type begin
+                = start.is_none() ? 0
+                                  : (py::hasattr(start, "value") ? index_self(i, py::cast<double>(start.attr("value")))
+                                                                 : py::cast<bh::axis::index_type>(start));
+
+            // Stop can be none, integer, or loc(double)
+            bh::axis::index_type end
+                = stop.is_none() ? size_self(i)
+                                 : (py::hasattr(stop, "value") ? index_self(i, py::cast<double>(stop.attr("value")))
+                                                               : py::cast<bh::axis::index_type>(stop));
+
+            unsigned merge = 1;
+            if(step.is_none()) {
+                merge = 1;
+            } else if(!py::hasattr(step, "projection")) {
+                throw std::out_of_range("The third argument to a slice must be rebin or projection");
+            } else if(py::cast<bool>(step.attr("projection")) == true) {
+                throw std::out_of_range("Currently projection is not supported");
+            } else {
+                if(!py::hasattr(step, "factor"))
+                    throw std::out_of_range("Invalid rebin, must have .factor set to an integer");
+                merge = py::cast<unsigned>(step.attr("factor"));
+            }
+
+            slices.push_back(bh::algorithm::slice_and_rebin(static_cast<unsigned>(i), begin, end, merge));
+        }
+    }
+
+    return slices;
+}

--- a/src/histogram/utils.cpp
+++ b/src/histogram/utils.cpp
@@ -23,9 +23,9 @@ void register_utils(py::module &m) {
         .def_property_readonly_static("projection", [](py::object /* self */) { return false; })
         .def_readwrite("factor", &rebin::factor);
 
-    py::class_<project>(m, "_project").def(py::init<>()).def_property_readonly_static("projection", []() {
-        return true;
-    });
+    py::class_<project>(m, "_project")
+        .def(py::init<>())
+        .def_property_readonly_static("projection", [](py::object /* self */) { return true; });
 
     m.attr("project") = project{};
 }

--- a/src/histogram/utils.cpp
+++ b/src/histogram/utils.cpp
@@ -1,0 +1,31 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#include <boost/histogram/python/pybind11.hpp>
+
+struct loc {
+    double value;
+};
+
+struct rebin {
+    unsigned factor;
+};
+
+struct project {};
+
+void register_utils(py::module &m) {
+    py::class_<loc>(m, "loc").def(py::init<double>()).def_readwrite("value", &loc::value);
+
+    py::class_<rebin>(m, "rebin")
+        .def(py::init<unsigned>())
+        .def_property_readonly_static("projection", []() { return false; })
+        .def_readwrite("factor", &rebin::factor);
+
+    py::class_<project>(m, "_project").def(py::init<>()).def_property_readonly_static("projection", []() {
+        return true;
+    });
+
+    m.attr("project") = project{};
+}

--- a/src/histogram/utils.cpp
+++ b/src/histogram/utils.cpp
@@ -20,7 +20,7 @@ void register_utils(py::module &m) {
 
     py::class_<rebin>(m, "rebin")
         .def(py::init<unsigned>())
-        .def_property_readonly_static("projection", []() { return false; })
+        .def_property_readonly_static("projection", [](py::object /* self */) { return false; })
         .def_readwrite("factor", &rebin::factor);
 
     py::class_<project>(m, "_project").def(py::init<>()).def_property_readonly_static("projection", []() {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -14,6 +14,7 @@ void register_polymorphic_bin(py::module &);
 void register_general_histograms(py::module &);
 void register_make_histogram(py::module &, py::module &);
 void register_accumulators(py::module &);
+void register_utils(py::module &);
 
 PYBIND11_MODULE(histogram, m) {
     register_version(m);
@@ -36,4 +37,6 @@ PYBIND11_MODULE(histogram, m) {
 
     py::module algorithm = m.def_submodule("algorithm");
     register_algorithms(algorithm);
+
+    register_utils(m);
 }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -6,6 +6,7 @@
 #include <boost/histogram/python/pybind11.hpp>
 
 void register_version(py::module &);
+void register_algorithms(py::module &);
 void register_storages(py::module &);
 void register_axes(py::module &);
 void register_axes_options(py::module &);
@@ -32,4 +33,7 @@ PYBIND11_MODULE(histogram, m) {
 
     py::module accumulators = m.def_submodule("accumulators");
     register_accumulators(accumulators);
+
+    py::module algorithm = m.def_submodule("algorithm");
+    register_algorithms(algorithm);
 }

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -17,29 +17,27 @@ def test_weighted_sum():
     assert v.variance == 4.75
 
     v = bh.accumulators.weighted_sum()
-    v([1,2,3], [4,5,6])
+    v([1, 2, 3], [4, 5, 6])
 
     assert v.value == 6
     assert v.variance == 15
 
 
-
 def test_weighted_mean():
     v = bh.accumulators.weighted_mean()
-    v(1,4)
-    v(2,1)
+    v(1, 4)
+    v(2, 1)
 
     assert v.sum_of_weights == 3.0
     assert v.variance == 4.5
     assert v.value == 2.0
 
     v = bh.accumulators.weighted_mean()
-    v([1,2],[4,1])
+    v([1, 2], [4, 1])
 
     assert v.sum_of_weights == 3.0
     assert v.variance == 4.5
     assert v.value == 2.0
-
 
 
 def test_mean():
@@ -53,7 +51,7 @@ def test_mean():
     assert v.value == 2
 
     v = bh.accumulators.mean()
-    v([1,2,3])
+    v([1, 2, 3])
 
     assert v.count == 3
     assert v.variance == 1
@@ -69,6 +67,5 @@ def test_sum():
     assert v.value == 6
 
     v = bh.accumulators.sum()
-    v([1,2,3])
+    v([1, 2, 3])
     assert v.value == 6
-

--- a/tests/test_axis_internal.py
+++ b/tests/test_axis_internal.py
@@ -6,71 +6,82 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 
-@pytest.mark.parametrize("axtype", [bh.axis._regular_uoflow, bh.axis._regular_uflow, bh.axis._regular_oflow, bh.axis._regular_noflow])
-@pytest.mark.parametrize("function", [lambda x: x,
-                                       lambda x: bh._make_histogram(x).axis(0),
-                                       ])
+@pytest.mark.parametrize(
+    "axtype",
+    [
+        bh.axis._regular_uoflow,
+        bh.axis._regular_uflow,
+        bh.axis._regular_oflow,
+        bh.axis._regular_noflow,
+    ],
+)
+@pytest.mark.parametrize(
+    "function", [lambda x: x, lambda x: bh._make_histogram(x).axis(0)]
+)
 def test_axis__regular_uoflow(axtype, function):
     ax = function(axtype(10, 0, 1))
 
-    assert 3 == ax.index(.34)
-    assert 2 == ax.index(.26)
-    assert -1 == ax.index(-.23)
+    assert 3 == ax.index(0.34)
+    assert 2 == ax.index(0.26)
+    assert -1 == ax.index(-0.23)
     assert -1 == ax.index(-5.23)
     assert 10 == ax.index(1.01)
     assert 10 == ax.index(23)
 
     assert 10 == ax.size()
 
-    assert ax.bin(3).lower() == approx(.3)
-    assert ax.bin(3).upper() == approx(.4)
-    assert ax.bin(3).width() == approx(.1)
-    assert ax.bin(3).center() == approx(.35)
+    assert ax.bin(3).lower() == approx(0.3)
+    assert ax.bin(3).upper() == approx(0.4)
+    assert ax.bin(3).width() == approx(0.1)
+    assert ax.bin(3).center() == approx(0.35)
 
-    for b, v in zip(ax.bins(), np.arange(10)/10.0):
+    for b, v in zip(ax.bins(), np.arange(10) / 10.0):
         assert b.lower() == approx(v)
-        assert b.upper() == approx(v + .1)
+        assert b.upper() == approx(v + 0.1)
+
 
 def test_axis_regular_extents():
-    ax = bh.axis._regular_uoflow(10,0,1)
+    ax = bh.axis._regular_uoflow(10, 0, 1)
     assert 12 == ax.size(flow=True)
     assert 11 == len(ax.edges())
     assert 13 == len(ax.edges(True))
     assert 10 == len(ax.centers())
     assert ax.options() == bh.axis.options.underflow | bh.axis.options.overflow
 
-    ax = bh.axis._regular_uflow(10,0,1)
+    ax = bh.axis._regular_uflow(10, 0, 1)
     assert 11 == ax.size(flow=True)
     assert 11 == len(ax.edges())
     assert 12 == len(ax.edges(True))
     assert 10 == len(ax.centers())
     assert ax.options() == bh.axis.options.underflow
 
-    ax = bh.axis._regular_oflow(10,0,1)
+    ax = bh.axis._regular_oflow(10, 0, 1)
     assert 11 == ax.size(flow=True)
     assert 11 == len(ax.edges())
     assert 12 == len(ax.edges(True))
     assert 10 == len(ax.centers())
     assert ax.options() == bh.axis.options.overflow
 
-    ax = bh.axis._regular_noflow(10,0,1)
+    ax = bh.axis._regular_noflow(10, 0, 1)
     assert 10 == ax.size(flow=True)
     assert 11 == len(ax.edges())
     assert 11 == len(ax.edges(True))
     assert 10 == len(ax.centers())
     assert ax.options() == bh.axis.options.none
 
+
 def test_axis_growth():
-    ax = bh.axis._regular_growth(10,0,1)
-    ax.index(.7)
+    ax = bh.axis._regular_growth(10, 0, 1)
+    ax.index(0.7)
     ax.index(1.2)
     assert ax.size() == 10
     assert len(ax.centers()) == 10
     assert len(ax.edges()) == 11
-    assert ax.update(1.21) == (12,-3)
+    assert ax.update(1.21) == (12, -3)
     assert ax.size() == 13
     assert len(ax.edges()) == 14
     assert len(ax.centers()) == 13
+
 
 def test_axis_growth_cat():
     ax = bh.axis._category_str_growth(["This"])
@@ -80,21 +91,24 @@ def test_axis_growth_cat():
     assert ax.bin(0) == "This"
     assert ax.bin(1) == "That"
 
-@pytest.mark.parametrize("offset", [-1,0,1,2])
+
+@pytest.mark.parametrize("offset", [-1, 0, 1, 2])
 def test_axis_circular_offset(offset):
     ax = bh.axis.circular(10, 0, 1)
     assert 11 == len(ax.edges())
 
-    assert 3 == ax.index(.34 + offset)
-    assert 2 == ax.index(.26 + offset)
+    assert 3 == ax.index(0.34 + offset)
+    assert 2 == ax.index(0.26 + offset)
 
-    assert_array_equal([2,3], ax.index([.26 + offset, .34 + offset]))
+    assert_array_equal([2, 3], ax.index([0.26 + offset, 0.34 + offset]))
+
 
 def test_axis_circular():
     ax = bh.axis.circular(10, 0, 1)
 
-    assert .1 == ax.value(1)
+    assert 0.1 == ax.value(1)
     assert ax.options() == bh.axis.options.circular | bh.axis.options.overflow
+
 
 normal_axs = [
     bh.axis._regular_uoflow,
@@ -104,38 +118,43 @@ normal_axs = [
     bh.axis.regular_sqrt,
 ]
 
+
 @pytest.mark.parametrize("axis", normal_axs)
 def test_regular_axis_repr(axis):
-    ax = axis(2,3,4)
-    assert 'object at' not in repr(ax)
+    ax = axis(2, 3, 4)
+    assert "object at" not in repr(ax)
 
-    ax = axis(7,2,4, metadata='This')
-    assert 'This' in repr(ax)
-    assert ax.metadata == 'This'
+    ax = axis(7, 2, 4, metadata="This")
+    assert "This" in repr(ax)
+    assert ax.metadata == "This"
 
-    ax.metadata = 'That'
-    ax = axis(7,2,4, metadata='That')
-    assert 'That' in repr(ax)
-    assert ax.metadata == 'That'
+    ax.metadata = "That"
+    ax = axis(7, 2, 4, metadata="That")
+    assert "That" in repr(ax)
+    assert ax.metadata == "That"
+
 
 def test_metadata_compare():
-    ax1 = bh.axis._regular_uoflow(1,2,3, metadata=[1,])
-    ax2 = bh.axis._regular_uoflow(1,2,3, metadata=[1,])
+    ax1 = bh.axis._regular_uoflow(1, 2, 3, metadata=[1])
+    ax2 = bh.axis._regular_uoflow(1, 2, 3, metadata=[1])
 
     assert ax1 == ax2
 
+
 def test_metadata_compare_neq():
-    ax1 = bh.axis._regular_uoflow(1,2,3, metadata=[1,])
-    ax2 = bh.axis._regular_uoflow(1,2,3, metadata=[2,])
+    ax1 = bh.axis._regular_uoflow(1, 2, 3, metadata=[1])
+    ax2 = bh.axis._regular_uoflow(1, 2, 3, metadata=[2])
 
     assert ax1 != ax2
 
+
 @pytest.mark.parametrize("axis", normal_axs)
 def test_any_metadata(axis):
-    ax = axis(2,3,4, metadata={"one": "1"})
+    ax = axis(2, 3, 4, metadata={"one": "1"})
     assert ax.metadata == {"one": "1"}
     ax.metadata = 64
     assert ax.metadata == 64
+
 
 def test_cat_str():
     ax = bh.axis._category_str(["a", "b", "c"])
@@ -145,8 +164,9 @@ def test_cat_str():
 
     assert ax.index("b") == 1
 
+
 def test_cat_int():
-    ax = bh.axis._category_int([1,2,3])
+    ax = bh.axis._category_int([1, 2, 3])
     assert ax.bin(0) == 1
     assert ax.bin(1) == 2
     assert ax.bin(2) == 3

--- a/tests/test_basic_import.py
+++ b/tests/test_basic_import.py
@@ -1,8 +1,10 @@
 import boost.histogram as bh
 import boost.histogram_version as bhv
 
+
 def test_import():
     assert bh
+
 
 def test_version():
     assert bh.__version__ == bhv.__version__

--- a/tests/test_benchmark_1d.py
+++ b/tests/test_benchmark_1d.py
@@ -7,22 +7,24 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
 
-bins=100
-ranges=(-1,1)
+bins = 100
+ranges = (-1, 1)
 bins = np.asarray(bins).astype(np.int64)
 ranges = np.asarray(ranges).astype(np.float64)
 
-edges = np.linspace(ranges[0], ranges[1], bins+1)
+edges = np.linspace(ranges[0], ranges[1], bins + 1)
 
 np.random.seed(42)
 vals = np.random.normal(size=[10000000]).astype(np.float32)
 
 answer, _ = np.histogram(vals, bins=bins, range=ranges)
 
-@pytest.mark.benchmark(group='1d-fills')
+
+@pytest.mark.benchmark(group="1d-fills")
 def test_numpy_perf_1d(benchmark):
     result, _ = benchmark(np.histogram, vals, bins=bins, range=ranges)
     assert_array_equal(result, answer)
+
 
 def make_and_run_hist(flow, storage):
     histo = bh.histogram(regular(bins, *ranges, flow=flow), storage=storage())
@@ -30,15 +32,17 @@ def make_and_run_hist(flow, storage):
     return histo.view()
 
 
-@pytest.mark.benchmark(group='1d-fills')
+@pytest.mark.benchmark(group="1d-fills")
 @pytest.mark.parametrize("flow", (True, False))
-@pytest.mark.parametrize("storage", (bh.storage.int,
-                                     bh.storage.double,
-                                     bh.storage.unlimited,
-                                     # bh.storage.weight,
-                                     ))
+@pytest.mark.parametrize(
+    "storage",
+    (
+        bh.storage.int,
+        bh.storage.double,
+        bh.storage.unlimited,
+        # bh.storage.weight,
+    ),
+)
 def test_1d(benchmark, flow, storage):
     result = benchmark(make_and_run_hist, flow, storage)
     assert_allclose(result[:-1], answer[:-1], atol=2)
-
-

--- a/tests/test_benchmark_2d.py
+++ b/tests/test_benchmark_2d.py
@@ -6,40 +6,50 @@ from numpy.testing import assert_array_equal
 import boost.histogram as bh
 from boost.histogram.axis import regular
 
-bins=(100, 100)
-ranges=((-1,1),(-1,1))
+bins = (100, 100)
+ranges = ((-1, 1), (-1, 1))
 bins = np.asarray(bins).astype(np.int64)
 ranges = np.asarray(ranges).astype(np.float64)
 
-edges = (np.linspace(ranges[0,0], ranges[0,1], bins[0]+1),
-         np.linspace(ranges[1,0], ranges[1,1], bins[1]+1))
+edges = (
+    np.linspace(ranges[0, 0], ranges[0, 1], bins[0] + 1),
+    np.linspace(ranges[1, 0], ranges[1, 1], bins[1] + 1),
+)
 
 np.random.seed(42)
 vals = np.random.normal(size=[2, 1000000]).astype(np.float64)
 
 answer, _, _ = np.histogram2d(*vals, bins=bins, range=ranges)
 
-@pytest.mark.benchmark(group='2d-fills')
+
+@pytest.mark.benchmark(group="2d-fills")
 def test_numpy_perf_2d(benchmark):
     result, _, _ = benchmark(np.histogram2d, *vals, bins=bins, range=ranges)
     assert_array_equal(result, answer)
 
+
 def make_and_run_hist(flow, storage):
 
-    histo = bh.histogram(regular(bins[0], *ranges[0], flow=flow),
-                         regular(bins[1], *ranges[1], flow=flow),
-                         storage=storage())
+    histo = bh.histogram(
+        regular(bins[0], *ranges[0], flow=flow),
+        regular(bins[1], *ranges[1], flow=flow),
+        storage=storage(),
+    )
     histo.fill(*vals)
     return histo.view()
 
-@pytest.mark.benchmark(group='2d-fills')
+
+@pytest.mark.benchmark(group="2d-fills")
 @pytest.mark.parametrize("flow", (True, False))
-@pytest.mark.parametrize("storage", (bh.storage.int,
-                                     bh.storage.double,
-                                     bh.storage.unlimited,
-                                     #bh.storage.weight,
-                                     ))
+@pytest.mark.parametrize(
+    "storage",
+    (
+        bh.storage.int,
+        bh.storage.double,
+        bh.storage.unlimited,
+        # bh.storage.weight,
+    ),
+)
 def test_2d(benchmark, flow, storage):
     result = benchmark(make_and_run_hist, flow, storage)
-    assert_array_equal(result[:-1,:-1], answer[:-1,:-1])
-
+    assert_array_equal(result[:-1, :-1], answer[:-1, :-1])

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -4,25 +4,20 @@ import boost.histogram as bh
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
-methods = [
-    bh.hist._any_double,
-    bh.hist._any_unlimited,
-    bh.hist._any_int,
-]
+methods = [bh.hist._any_double, bh.hist._any_unlimited, bh.hist._any_int]
+
 
 @pytest.mark.parametrize("hist_func", methods)
 def test_1D_fill_int(hist_func):
     bins = 10
     ranges = (0, 1)
 
-    vals = (.15, .25, .25)
+    vals = (0.15, 0.25, 0.25)
 
-    hist = hist_func([
-        bh.axis._regular_uoflow(bins, *ranges)
-        ])
+    hist = hist_func([bh.axis._regular_uoflow(bins, *ranges)])
     hist.fill(vals)
 
-    H =  np.array([0, 1, 2, 0, 0, 0, 0, 0, 0, 0])
+    H = np.array([0, 1, 2, 0, 0, 0, 0, 0, 0, 0])
 
     assert_array_equal(np.asarray(hist), H)
     assert_array_equal(hist.view(flow=False), H)
@@ -31,17 +26,20 @@ def test_1D_fill_int(hist_func):
     assert hist.axis(0).size() == bins
     assert hist.axis(0).size(flow=True) == bins + 2
 
+
 @pytest.mark.parametrize("hist_func", methods)
 def test_2D_fill_int(hist_func):
     bins = (10, 15)
     ranges = ((0, 3), (0, 2))
 
-    vals = ((.15, .25, .25), (.35, .45, .45))
+    vals = ((0.15, 0.25, 0.25), (0.35, 0.45, 0.45))
 
-    hist = hist_func([
-        bh.axis._regular_uoflow(bins[0], *ranges[0]),
-        bh.axis._regular_uoflow(bins[1], *ranges[1]),
-        ])
+    hist = hist_func(
+        [
+            bh.axis._regular_uoflow(bins[0], *ranges[0]),
+            bh.axis._regular_uoflow(bins[1], *ranges[1]),
+        ]
+    )
     hist.fill(*vals)
 
     H = np.histogram2d(*vals, bins=bins, range=ranges)[0]
@@ -59,57 +57,54 @@ def test_2D_fill_int(hist_func):
 
 def test_edges_histogram():
     edges = (1, 12, 22, 79)
-    hist = bh.hist._any_int([
-        bh.axis.variable(edges)
-        ])
+    hist = bh.hist._any_int([bh.axis.variable(edges)])
 
-    vals = (13,15,24,29)
+    vals = (13, 15, 24, 29)
     hist.fill(vals)
 
     bins = np.asarray(hist)
-    assert_array_equal(bins, [0,2,2])
-    assert_array_equal(hist.view(flow=True), [0,0,2,2,0])
-    assert_array_equal(hist.view(flow=False), [0,2,2])
+    assert_array_equal(bins, [0, 2, 2])
+    assert_array_equal(hist.view(flow=True), [0, 0, 2, 2, 0])
+    assert_array_equal(hist.view(flow=False), [0, 2, 2])
+
 
 def test_int_histogram():
-    hist = bh.hist._any_int([
-        bh.axis._integer_uoflow(3,7)
-        ])
+    hist = bh.hist._any_int([bh.axis._integer_uoflow(3, 7)])
 
-    vals = (1,2,3,4,5,6,7,8,9)
+    vals = (1, 2, 3, 4, 5, 6, 7, 8, 9)
     hist.fill(vals)
 
     bins = np.asarray(hist)
-    assert_array_equal(bins, [1,1,1,1])
-    assert_array_equal(hist.view(flow=False), [1,1,1,1])
-    assert_array_equal(hist.view(flow=True), [2,1,1,1,1,3])
+    assert_array_equal(bins, [1, 1, 1, 1])
+    assert_array_equal(hist.view(flow=False), [1, 1, 1, 1])
+    assert_array_equal(hist.view(flow=True), [2, 1, 1, 1, 1, 3])
 
 
 def test_str_categories_histogram():
-    hist = bh.hist._any_int([
-        bh.axis._category_str(["a", "b", "c"])
-        ])
+    hist = bh.hist._any_int([bh.axis._category_str(["a", "b", "c"])])
 
-    vals = ['a', 'b', 'b', 'c']
+    vals = ["a", "b", "b", "c"]
     # Can't fill yet
 
+
 def test_growing_histogram():
-    hist = bh.hist._any_int([
-        bh.axis._regular_growth(10,0,1)
-        ])
+    hist = bh.hist._any_int([bh.axis._regular_growth(10, 0, 1)])
 
     hist.fill(1.45)
 
     assert hist.size() == 15
 
+
 def test_numpy_flow():
-    h = bh.hist._any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
+    h = bh.hist._any_int(
+        [bh.axis._regular_uoflow(10, 0, 1), bh.axis._regular_uoflow(5, 0, 1)]
+    )
 
     for i in range(10):
         for j in range(5):
-            x,y = h.axis(0).bin(i).center(), h.axis(1).bin(j).center()
-            v = i + j*10 + 1;
-            h.fill([x]*v,[y]*v)
+            x, y = h.axis(0).bin(i).center(), h.axis(1).bin(j).center()
+            v = i + j * 10 + 1
+            h.fill([x] * v, [y] * v)
 
     flow_true = h.to_numpy(True)[0][1:-1, 1:-1]
     flow_false = h.to_numpy(False)[0]
@@ -124,36 +119,47 @@ def test_numpy_flow():
     assert_array_equal(view_flow_default, view_flow_false)
 
 
-
 def test_numpy_compare():
-    h = bh.hist._any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
+    h = bh.hist._any_int(
+        [bh.axis._regular_uoflow(10, 0, 1), bh.axis._regular_uoflow(5, 0, 1)]
+    )
 
     xs = []
     ys = []
     for i in range(10):
         for j in range(5):
-            x,y = h.axis(0).bin(i).center(), h.axis(1).bin(j).center()
-            v = i + j*10 + 1;
-            xs += [x]*v
-            ys += [y]*v
+            x, y = h.axis(0).bin(i).center(), h.axis(1).bin(j).center()
+            v = i + j * 10 + 1
+            xs += [x] * v
+            ys += [y] * v
 
     h.fill(xs, ys)
 
     H, E1, E2 = h.to_numpy()
 
-    nH, nE1, nE2 = np.histogram2d(xs, ys, bins=(10,5), range=((0,1),(0,1)))
+    nH, nE1, nE2 = np.histogram2d(xs, ys, bins=(10, 5), range=((0, 1), (0, 1)))
 
     assert_array_equal(H, nH)
     assert_allclose(E1, nE1)
     assert_allclose(E2, nE2)
 
-def test_project():
-    h = bh.hist._any_int([bh.axis._regular_uoflow(10,0,1), bh.axis._regular_uoflow(5,0,1)])
-    h0 = bh.hist._any_int([bh.axis._regular_uoflow(10,0,1)])
-    h1 = bh.hist._any_int([bh.axis._regular_uoflow(5,0,1)])
 
-    for x,y in ((.3,.3),(.7,.7),(.5,.6),(.23,.92),(.15,.32),(.43,.54)):
-        h.fill(x,y)
+def test_project():
+    h = bh.hist._any_int(
+        [bh.axis._regular_uoflow(10, 0, 1), bh.axis._regular_uoflow(5, 0, 1)]
+    )
+    h0 = bh.hist._any_int([bh.axis._regular_uoflow(10, 0, 1)])
+    h1 = bh.hist._any_int([bh.axis._regular_uoflow(5, 0, 1)])
+
+    for x, y in (
+        (0.3, 0.3),
+        (0.7, 0.7),
+        (0.5, 0.6),
+        (0.23, 0.92),
+        (0.15, 0.32),
+        (0.43, 0.54),
+    ):
+        h.fill(x, y)
         h0.fill(x)
         h1.fill(y)
 
@@ -165,20 +171,22 @@ def test_project():
     assert_array_equal(h.project(0), h0)
     assert_array_equal(h.project(1), h1)
 
+
 def test_sums():
-    h = bh.histogram(bh.axis._regular_uoflow(4,0,1))
-    h.fill([.1,.2,.3,10])
+    h = bh.histogram(bh.axis._regular_uoflow(4, 0, 1))
+    h.fill([0.1, 0.2, 0.3, 10])
 
     assert h.sum() == 3
     assert h.sum(flow=True) == 4
 
+
 def test_int_cat_hist():
-    h = bh.hist._any_int([bh.axis._category_int([1,2,3])])
+    h = bh.hist._any_int([bh.axis._category_int([1, 2, 3])])
 
     h.fill(1)
     h.fill(2)
     h.fill(2.2)
     h.fill(3)
 
-    assert_array_equal(h.view(), [1,2,1])
+    assert_array_equal(h.view(), [1, 2, 1])
     assert h.sum() == 4

--- a/tests/test_indexed.py
+++ b/tests/test_indexed.py
@@ -5,10 +5,11 @@ import numpy as np
 from numpy.testing import assert_allclose
 import itertools
 
-def test_1d_center():
-    h = bh.histogram(bh.axis.regular(4,0,1))
 
-    results = np.r_[.125:.875:4j]
+def test_1d_center():
+    h = bh.histogram(bh.axis.regular(4, 0, 1))
+
+    results = np.r_[0.125:0.875:4j]
 
     for ind, answer in zip(h.indexed(), results):
         a_bin, = ind.bins()
@@ -21,9 +22,9 @@ def test_1d_center():
 def test_2d_any_center():
 
     # This iterates in the opposite order as boost-histogram
-    results = itertools.product(np.r_[0:4], np.r_[.125:.875:4j])
+    results = itertools.product(np.r_[0:4], np.r_[0.125:0.875:4j])
 
-    h = bh.histogram(bh.axis.regular(4,0,1), bh.axis.integer(0,4))
+    h = bh.histogram(bh.axis.regular(4, 0, 1), bh.axis.integer(0, 4))
 
     for ind, answer in zip(h.indexed(), results):
         a, b = ind.centers()
@@ -37,45 +38,51 @@ def test_2d_any_center():
 
 def test_2d_function():
 
-    gridx, gridy = np.mgrid[.125:.875:4j, .25:1.75:4j]
+    gridx, gridy = np.mgrid[0.125:0.875:4j, 0.25:1.75:4j]
 
     def f(x, y):
-        return 1+x**3 - 7*y**4
+        return 1 + x ** 3 - 7 * y ** 4
 
     result = f(gridx, gridy)
 
-
-    h = bh.histogram(bh.axis.regular(4,0,1), bh.axis.regular(4,0,2), storage=bh.storage.double())
+    h = bh.histogram(
+        bh.axis.regular(4, 0, 1), bh.axis.regular(4, 0, 2), storage=bh.storage.double()
+    )
 
     for ind in h.indexed():
         ind.content = f(*ind.centers())
 
     assert_allclose(h, result)
 
+
 def benchmark_1d_indexed(func):
-    hist = bh.histogram(bh.axis.regular(100,0,1), storage=bh.storage.double())
+    hist = bh.histogram(bh.axis.regular(100, 0, 1), storage=bh.storage.double())
     for ind in hist.indexed():
         ind.content = func(*ind.centers())
     return hist
 
+
 def benchmark_1d_ufunc(func):
-    hist = bh.histogram(bh.axis.regular(100,0,1), storage=bh.storage.double())
+    hist = bh.histogram(bh.axis.regular(100, 0, 1), storage=bh.storage.double())
     view = np.asarray(hist)
     vals = func(hist.centers())
     view[:] = func(hist.centers())
     return hist
     # TODO: .view() seems to make a copy
 
-def func(x):
-    return x**2
 
-@pytest.mark.benchmark(group='1D indexed')
+def func(x):
+    return x ** 2
+
+
+@pytest.mark.benchmark(group="1D indexed")
 def test_1d_indexed(benchmark):
     res = benchmark(benchmark_1d_indexed, func)
 
     hist = benchmark_1d_ufunc(func)
     assert_allclose(hist, res)
 
-@pytest.mark.benchmark(group='1D indexed')
+
+@pytest.mark.benchmark(group="1D indexed")
 def test_1d_ufunc(benchmark):
     benchmark(benchmark_1d_ufunc, func)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -32,4 +32,15 @@ def test_2D_get_bin():
         h[1]
 
 
+def test_get_1D_histogram():
+    h = bh.histogram(bh.axis.regular(10, 0, 1))
+    h.fill([.25, .25, .25, .15])
+
+    h2 = h[:]
+
+    assert h == h2
+
+    h.fill(.75)
+
+    assert h != h2
 

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -2,10 +2,11 @@ import boost.histogram as bh
 
 import pytest
 
+
 def test_1D_get_bin():
 
     h = bh.histogram(bh.axis.regular(10, 0, 1))
-    h.fill([.25, .25, .25, .15])
+    h.fill([0.25, 0.25, 0.25, 0.15])
 
     assert h[0] == 0
     assert h[1] == 1
@@ -14,19 +15,20 @@ def test_1D_get_bin():
     assert h.view()[2] == h[2]
 
     with pytest.raises(IndexError):
-        h[1,2]
+        h[1, 2]
+
 
 def test_2D_get_bin():
 
     h = bh.histogram(bh.axis.regular(10, 0, 1), bh.axis.regular(10, 0, 1))
-    h.fill(.15, [.25, .25, .25, .15])
+    h.fill(0.15, [0.25, 0.25, 0.25, 0.15])
 
-    assert h[0,0] == 0
-    assert h[0,1] == 0
-    assert h[1,1] == 1
-    assert h[1,2] == 3
+    assert h[0, 0] == 0
+    assert h[0, 1] == 0
+    assert h[1, 1] == 1
+    assert h[1, 2] == 3
 
-    assert h.view()[1,2] == h[1,2]
+    assert h.view()[1, 2] == h[1, 2]
 
     with pytest.raises(IndexError):
         h[1]
@@ -34,50 +36,51 @@ def test_2D_get_bin():
 
 def test_get_1D_histogram():
     h = bh.histogram(bh.axis.regular(10, 0, 1))
-    h.fill([.25, .25, .25, .15])
+    h.fill([0.25, 0.25, 0.25, 0.15])
 
     h2 = h[:]
 
     assert h == h2
 
-    h.fill(.75)
+    h.fill(0.75)
 
     assert h != h2
 
+
 def test_get_1D_slice():
     h1 = bh.histogram(bh.axis.regular(10, 0, 1))
-    h2 = bh.histogram(bh.axis.regular(5, 0, .5))
-    h1.fill([.25, .25, .25, .15])
-    h2.fill([.25, .25, .25, .15])
+    h2 = bh.histogram(bh.axis.regular(5, 0, 0.5))
+    h1.fill([0.25, 0.25, 0.25, 0.15])
+    h2.fill([0.25, 0.25, 0.25, 0.15])
 
     assert h1 != h2
     assert h1[:5] == h2
-    assert h1[:bh.loc(.5)] == h2
+    assert h1[: bh.loc(0.5)] == h2
     assert h1[2:4] == h2[2:4]
-    assert h1[bh.loc(.2):bh.loc(.4)] == h2[bh.loc(.2):bh.loc(.4)]
+    assert h1[bh.loc(0.2) : bh.loc(0.4)] == h2[bh.loc(0.2) : bh.loc(0.4)]
 
     assert len(h1[2:4].view()) == 2
-    assert len(h1[2:4:bh.rebin(2)].view()) == 1
+    assert len(h1[2 : 4 : bh.rebin(2)].view()) == 1
 
 
 def test_ellipsis():
 
     h = bh.histogram(bh.axis.regular(10, 0, 1), bh.axis.regular(10, 0, 1))
-    
+
     assert h == h[...]
-    assert h == h[:,...]
-    assert h == h[...,:]
-    assert h == h[:,:,...]
-    assert h == h[:,...,:]
-    assert h == h[...,:,:]
+    assert h == h[:, ...]
+    assert h == h[..., :]
+    assert h == h[:, :, ...]
+    assert h == h[:, ..., :]
+    assert h == h[..., :, :]
 
     with pytest.raises(IndexError):
-        h[:,:,:,...]
+        h[:, :, :, ...]
     with pytest.raises(IndexError):
-        h[:,:,...,:]
+        h[:, :, ..., :]
     with pytest.raises(IndexError):
-        h[...,:,:,:]
+        h[..., :, :, :]
     with pytest.raises(IndexError):
-        h[...,...]
+        h[..., ...]
 
-    assert h[2:4,...] == h[2:4,:]
+    assert h[2:4, ...] == h[2:4, :]

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -12,6 +12,10 @@ def test_1D_get_bin():
     assert h[1] == 1
     assert h[2] == 3
 
+    assert h[bh.loc(0)] == 0
+    assert h[bh.loc(0.1)] == 1
+    assert h[bh.loc(0.2)] == 3
+
     assert h.view()[2] == h[2]
 
     with pytest.raises(IndexError):
@@ -27,6 +31,7 @@ def test_2D_get_bin():
     assert h[0, 1] == 0
     assert h[1, 1] == 1
     assert h[1, 2] == 3
+    assert h[bh.loc(0.1), bh.loc(0.2)] == 3
 
     assert h.view()[1, 2] == h[1, 2]
 

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -44,3 +44,40 @@ def test_get_1D_histogram():
 
     assert h != h2
 
+def test_get_1D_slice():
+    h1 = bh.histogram(bh.axis.regular(10, 0, 1))
+    h2 = bh.histogram(bh.axis.regular(5, 0, .5))
+    h1.fill([.25, .25, .25, .15])
+    h2.fill([.25, .25, .25, .15])
+
+    assert h1 != h2
+    assert h1[:5] == h2
+    assert h1[:bh.loc(.5)] == h2
+    assert h1[2:4] == h2[2:4]
+    assert h1[bh.loc(.2):bh.loc(.4)] == h2[bh.loc(.2):bh.loc(.4)]
+
+    assert len(h1[2:4].view()) == 2
+    assert len(h1[2:4:bh.rebin(2)].view()) == 1
+
+
+def test_ellipsis():
+
+    h = bh.histogram(bh.axis.regular(10, 0, 1), bh.axis.regular(10, 0, 1))
+    
+    assert h == h[...]
+    assert h == h[:,...]
+    assert h == h[...,:]
+    assert h == h[:,:,...]
+    assert h == h[:,...,:]
+    assert h == h[...,:,:]
+
+    with pytest.raises(IndexError):
+        h[:,:,:,...]
+    with pytest.raises(IndexError):
+        h[:,:,...,:]
+    with pytest.raises(IndexError):
+        h[...,:,:,:]
+    with pytest.raises(IndexError):
+        h[...,...]
+
+    assert h[2:4,...] == h[2:4,:]

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -89,3 +89,15 @@ def test_ellipsis():
         h[..., ...]
 
     assert h[2:4, ...] == h[2:4, :]
+
+
+def test_basic_projection():
+    h2 = bh.histogram(bh.axis.regular(10, 0, 1), bh.axis.regular(10, 0, 1))
+    h1 = bh.histogram(bh.axis.regular(10, 0, 1))
+
+    contents = [[2, 2, 2, 3, 4, 5, 6], [1, 2, 2, 3, 2, 1, 2]]
+
+    h1.fill(contents[0])
+    h2.fill(*contents)
+
+    assert h1 == h2[:, :: bh.project]

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,0 +1,35 @@
+import boost.histogram as bh
+
+import pytest
+
+def test_1D_get_bin():
+
+    h = bh.histogram(bh.axis.regular(10, 0, 1))
+    h.fill([.25, .25, .25, .15])
+
+    assert h[0] == 0
+    assert h[1] == 1
+    assert h[2] == 3
+
+    assert h.view()[2] == h[2]
+
+    with pytest.raises(IndexError):
+        h[1,2]
+
+def test_2D_get_bin():
+
+    h = bh.histogram(bh.axis.regular(10, 0, 1), bh.axis.regular(10, 0, 1))
+    h.fill(.15, [.25, .25, .25, .15])
+
+    assert h[0,0] == 0
+    assert h[0,1] == 0
+    assert h[1,1] == 1
+    assert h[1,2] == 3
+
+    assert h.view()[1,2] == h[1,2]
+
+    with pytest.raises(IndexError):
+        h[1]
+
+
+

--- a/tests/test_make_axis.py
+++ b/tests/test_make_axis.py
@@ -2,43 +2,50 @@ import pytest
 
 import boost.histogram as bh
 
+
 def test_make_regular_normal():
     ax_reg = bh.axis.regular(10, 0, 1)
     assert isinstance(ax_reg, bh.axis._regular_uoflow)
     assert isinstance(ax_reg, bh.axis.regular)
+
 
 def test_make__regular_uoflow():
     ax_reg = bh.axis.regular(10, 0, 1, flow=True)
     assert isinstance(ax_reg, bh.axis._regular_uoflow)
     assert isinstance(ax_reg, bh.axis.regular)
 
+
 def test_make__regular_noflow():
     ax_reg = bh.axis.regular(10, 0, 1, flow=False)
     assert isinstance(ax_reg, bh.axis._regular_noflow)
     assert isinstance(ax_reg, bh.axis.regular)
+
 
 def test_make__regular_growth():
     ax_reg = bh.axis.regular(10, 0, 1, growth=True)
     assert isinstance(ax_reg, bh.axis._regular_growth)
     assert isinstance(ax_reg, bh.axis.regular)
 
+
 def test_make__category_int():
-    ax = bh.axis.category([1,2,3])
+    ax = bh.axis.category([1, 2, 3])
     assert isinstance(ax, bh.axis._category_int)
     assert isinstance(ax, bh.axis.category)
 
+
 def test_make__category_int_growth():
-    ax = bh.axis.category([1,2,3], growth=True)
+    ax = bh.axis.category([1, 2, 3], growth=True)
     assert isinstance(ax, bh.axis._category_int_growth)
     assert isinstance(ax, bh.axis.category)
+
 
 def test_make__category_str():
     ax = bh.axis.category(["one", "two"])
     assert isinstance(ax, bh.axis._category_str)
     assert isinstance(ax, bh.axis.category)
 
+
 def test_make__category_str_growth():
     ax = bh.axis.category(["one", "two"], growth=True)
     assert isinstance(ax, bh.axis._category_str_growth)
     assert isinstance(ax, bh.axis.category)
-

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -4,19 +4,22 @@ import math
 
 import boost.histogram as bh
 
-@pytest.mark.parametrize("axis,extent", ((bh.axis._regular_uoflow, 2),
-                                         (lambda *x: x, 2),
-                                         (bh.axis._regular_noflow, 0)))
+
+@pytest.mark.parametrize(
+    "axis,extent",
+    ((bh.axis._regular_uoflow, 2), (lambda *x: x, 2), (bh.axis._regular_noflow, 0)),
+)
 def test_make_regular_1D(axis, extent):
-    hist = bh._make_histogram(axis(3,2,5))
+    hist = bh._make_histogram(axis(3, 2, 5))
 
     assert hist.rank() == 1
     assert hist.axis(0).size() == 3
     assert hist.axis(0).size(flow=True) == 3 + extent
     assert hist.axis(0).bin(1).center() == approx(3.5)
 
+
 def test_shortcuts():
-    hist = bh.histogram((1,2,3), (10,0,1))
+    hist = bh.histogram((1, 2, 3), (10, 0, 1))
     assert hist.rank() == 2
     for i in range(2):
         assert isinstance(hist.axis(i), bh.axis.regular)
@@ -25,21 +28,20 @@ def test_shortcuts():
 
 
 def test_shortcuts_with_metadata():
-    bh.histogram((1,2,3, "this"))
+    bh.histogram((1, 2, 3, "this"))
     with pytest.raises(TypeError):
-        bh.histogram((1,2,3,4))
+        bh.histogram((1, 2, 3, 4))
     with pytest.raises(TypeError):
-        bh.histogram((1,2))
+        bh.histogram((1, 2))
     with pytest.raises(TypeError):
-        bh.histogram((1,2,3,4,5))
+        bh.histogram((1, 2, 3, 4, 5))
 
 
-
-@pytest.mark.parametrize("axis,extent", ((bh.axis._regular_uoflow, 2),
-                                         (bh.axis._regular_noflow, 0)))
+@pytest.mark.parametrize(
+    "axis,extent", ((bh.axis._regular_uoflow, 2), (bh.axis._regular_noflow, 0))
+)
 def test_make_regular_2D(axis, extent):
-    hist = bh._make_histogram(axis(3,2,5),
-                             axis(5,1,6))
+    hist = bh._make_histogram(axis(3, 2, 5), axis(5, 1, 6))
 
     assert hist.rank() == 2
     assert hist.axis(0).size() == 3
@@ -51,15 +53,22 @@ def test_make_regular_2D(axis, extent):
     assert hist.axis(1).bin(1).center() == approx(2.5)
 
 
-@pytest.mark.parametrize("storage", (bh.storage.int(),
-                                     bh.storage.double(),
-                                     bh.storage.unlimited(),
-                                     bh.storage.weight()))
+@pytest.mark.parametrize(
+    "storage",
+    (
+        bh.storage.int(),
+        bh.storage.double(),
+        bh.storage.unlimited(),
+        bh.storage.weight(),
+    ),
+)
 def test_make_any_hist(storage):
-    hist = bh._make_histogram(bh.axis._regular_uoflow(5,1,2),
-                             bh.axis._regular_noflow(6,2,3),
-                             bh.axis.circular(8,3,4),
-                             storage=storage)
+    hist = bh._make_histogram(
+        bh.axis._regular_uoflow(5, 1, 2),
+        bh.axis._regular_noflow(6, 2, 3),
+        bh.axis.circular(8, 3, 4),
+        storage=storage,
+    )
 
     assert hist.rank() == 3
     assert hist.axis(0).size() == 5
@@ -72,38 +81,51 @@ def test_make_any_hist(storage):
     assert hist.axis(2).size(flow=True) == 9
     assert hist.axis(2).bin(1).center() == approx(3.1875)
 
+
 def test_make_any_hist_storage():
 
-    assert float != type(bh._make_histogram(bh.axis._regular_uoflow(5,1,2), storage=bh.storage.int()).at(0))
-    assert float == type(bh._make_histogram(bh.axis._regular_uoflow(5,1,2), storage=bh.storage.double()).at(0))
+    assert float != type(
+        bh._make_histogram(
+            bh.axis._regular_uoflow(5, 1, 2), storage=bh.storage.int()
+        ).at(0)
+    )
+    assert float == type(
+        bh._make_histogram(
+            bh.axis._regular_uoflow(5, 1, 2), storage=bh.storage.double()
+        ).at(0)
+    )
+
 
 def test_issue_axis_bin_swan():
-    hist = bh._make_histogram(bh.axis.regular_sqrt(10,0,10, metadata='x'),
-                             bh.axis.circular(10,0,1, metadata='y'))
+    hist = bh._make_histogram(
+        bh.axis.regular_sqrt(10, 0, 10, metadata="x"),
+        bh.axis.circular(10, 0, 1, metadata="y"),
+    )
 
     b = hist.axis(1).bin(1)
-    assert repr(b) == '<bin [0.100000, 0.200000]>'
+    assert repr(b) == "<bin [0.100000, 0.200000]>"
     assert b.lower() == approx(0.1)
     assert b.upper() == approx(0.2)
 
     assert hist.axis(0).bin(0).lower() == 0
-    assert hist.axis(0).bin(1).lower() == approx(.1)
-    assert hist.axis(0).bin(2).lower() == approx(.4)
+    assert hist.axis(0).bin(1).lower() == approx(0.1)
+    assert hist.axis(0).bin(2).lower() == approx(0.4)
 
 
 options = (
-        (bh.hist._any_unlimited, bh.axis._regular_uoflow(5,1,2), bh.storage.unlimited),
-        (bh.hist._any_int, bh.axis._regular_uoflow(5,1,2), bh.storage.int),
-        (bh.hist._any_atomic_int, bh.axis._regular_uoflow(5,1,2), bh.storage.atomic_int),
-        (bh.hist._any_int, bh.axis._regular_noflow(5,1,2), bh.storage.int),
-        (bh.hist._any_double, bh.axis._regular_uoflow(5,1,2), bh.storage.double),
-        (bh.hist._any_weight, bh.axis._regular_uoflow(5,1,2), bh.storage.weight),
-        (bh.hist._any_int, bh.axis._integer_uoflow(0,5), bh.storage.int),
-        (bh.hist._any_atomic_int, bh.axis._integer_uoflow(0,5), bh.storage.atomic_int),
-        (bh.hist._any_double, bh.axis._integer_uoflow(0,5), bh.storage.double),
-        (bh.hist._any_unlimited, bh.axis._integer_uoflow(0,5), bh.storage.unlimited),
-        (bh.hist._any_weight, bh.axis._integer_uoflow(0,5), bh.storage.weight),
-        )
+    (bh.hist._any_unlimited, bh.axis._regular_uoflow(5, 1, 2), bh.storage.unlimited),
+    (bh.hist._any_int, bh.axis._regular_uoflow(5, 1, 2), bh.storage.int),
+    (bh.hist._any_atomic_int, bh.axis._regular_uoflow(5, 1, 2), bh.storage.atomic_int),
+    (bh.hist._any_int, bh.axis._regular_noflow(5, 1, 2), bh.storage.int),
+    (bh.hist._any_double, bh.axis._regular_uoflow(5, 1, 2), bh.storage.double),
+    (bh.hist._any_weight, bh.axis._regular_uoflow(5, 1, 2), bh.storage.weight),
+    (bh.hist._any_int, bh.axis._integer_uoflow(0, 5), bh.storage.int),
+    (bh.hist._any_atomic_int, bh.axis._integer_uoflow(0, 5), bh.storage.atomic_int),
+    (bh.hist._any_double, bh.axis._integer_uoflow(0, 5), bh.storage.double),
+    (bh.hist._any_unlimited, bh.axis._integer_uoflow(0, 5), bh.storage.unlimited),
+    (bh.hist._any_weight, bh.axis._integer_uoflow(0, 5), bh.storage.weight),
+)
+
 
 @pytest.mark.parametrize("histclass, ax, storage", options)
 def test_make_selection(histclass, ax, storage):
@@ -115,5 +137,7 @@ def test_make_selection(histclass, ax, storage):
 
 
 def test_make_selection_special():
-    histogram = bh._make_histogram(bh.axis._regular_uoflow(5,1,2), bh.axis._regular_noflow(10,1,2))
+    histogram = bh._make_histogram(
+        bh.axis._regular_uoflow(5, 1, 2), bh.axis._regular_noflow(10, 1, 2)
+    )
     assert isinstance(histogram, bh.hist._any_int)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -11,17 +11,17 @@ import copy
 import boost.histogram as bh
 
 copy_fns = (
-        lambda x: loads(dumps(x, 2)),
-        lambda x: loads(dumps(x, -1)),
-        copy.copy,
-        copy.deepcopy
-        )
+    lambda x: loads(dumps(x, 2)),
+    lambda x: loads(dumps(x, -1)),
+    copy.copy,
+    copy.deepcopy,
+)
 
 accumulators = (
     (bh.accumulators.sum, (12,)),
     (bh.accumulators.weighted_sum, (1.5, 2.5)),
     (bh.accumulators.mean, (5, 1.5, 2.5)),
-    (bh.accumulators.weighted_mean, (1.5, 2.5, 3.5, 4.5))
+    (bh.accumulators.weighted_mean, (1.5, 2.5, 3.5, 4.5)),
 )
 
 copies = (copy.copy, copy.deepcopy)
@@ -30,26 +30,26 @@ copies = (copy.copy, copy.deepcopy)
 @pytest.mark.parametrize("accum,args", accumulators)
 @pytest.mark.parametrize("copy_fn", copies)
 def test_accumulators(accum, args, copy_fn):
-        orig = accum(*args)
-        new = copy_fn(orig)
-        assert new == orig
+    orig = accum(*args)
+    new = copy_fn(orig)
+    assert new == orig
 
 
 axes_creations = (
-        (bh.axis._regular_uoflow,      (4, 2, 4)),
-        (bh.axis._regular_growth,      (4, 2, 4)),
-        (bh.axis._regular_noflow,      (4, 2, 4)),
-        (bh.axis.regular_log,         (4, 2, 4)),
-        (bh.axis.regular_sqrt,        (4, 2, 4)),
-        (bh.axis.regular_pow,         (4, 2, 4, 0.5)),
-        (bh.axis.circular,            (4, 2, 4)),
-        (bh.axis.variable,            ([1, 2, 3, 4],)),
-        (bh.axis._integer_uoflow,      (1, 4)),
-        (bh.axis._category_int,        ([1, 2, 3],)),
-        (bh.axis._category_int_growth, ([1, 2, 3],)),
-        (bh.axis._category_str,        (["1", "2", "3"],)),
-        (bh.axis._category_str_growth, (["1", "2", "3"],)),
-        )
+    (bh.axis._regular_uoflow, (4, 2, 4)),
+    (bh.axis._regular_growth, (4, 2, 4)),
+    (bh.axis._regular_noflow, (4, 2, 4)),
+    (bh.axis.regular_log, (4, 2, 4)),
+    (bh.axis.regular_sqrt, (4, 2, 4)),
+    (bh.axis.regular_pow, (4, 2, 4, 0.5)),
+    (bh.axis.circular, (4, 2, 4)),
+    (bh.axis.variable, ([1, 2, 3, 4],)),
+    (bh.axis._integer_uoflow, (1, 4)),
+    (bh.axis._category_int, ([1, 2, 3],)),
+    (bh.axis._category_int_growth, ([1, 2, 3],)),
+    (bh.axis._category_str, (["1", "2", "3"],)),
+    (bh.axis._category_str_growth, (["1", "2", "3"],)),
+)
 
 
 @pytest.mark.parametrize("axis,args", axes_creations)
@@ -69,10 +69,11 @@ def test_metadata_str(axis, args, copy_fn):
     new.metadata = orig.metadata
     assert new == orig
 
+
 # Special test: Deepcopy should change metadata id, copy should not
-@pytest.mark.parametrize("metadata", ({1:2}, [1,2,3]))
+@pytest.mark.parametrize("metadata", ({1: 2}, [1, 2, 3]))
 def test_compare_copy_axis(metadata):
-    orig = bh.axis._regular_noflow(4,0,2, metadata=metadata)
+    orig = bh.axis._regular_noflow(4, 0, 2, metadata=metadata)
     new = copy.copy(orig)
     dnew = copy.deepcopy(orig)
 
@@ -80,10 +81,11 @@ def test_compare_copy_axis(metadata):
     assert orig.metadata == dnew.metadata
     assert orig.metadata is not dnew.metadata
 
+
 # Special test: Deepcopy should change metadata id, copy should not
-@pytest.mark.parametrize("metadata", ({1:2}, [1,2,3]))
+@pytest.mark.parametrize("metadata", ({1: 2}, [1, 2, 3]))
 def test_compare_copy_hist(metadata):
-    orig = bh._make_histogram(bh.axis._regular_noflow(4,0,2, metadata=metadata))
+    orig = bh._make_histogram(bh.axis._regular_noflow(4, 0, 2, metadata=metadata))
     new = copy.copy(orig)
     dnew = copy.deepcopy(orig)
 
@@ -91,10 +93,11 @@ def test_compare_copy_hist(metadata):
     assert orig.axis(0).metadata == dnew.axis(0).metadata
     assert orig.axis(0).metadata is not dnew.axis(0).metadata
 
+
 @pytest.mark.parametrize("axis,args", axes_creations)
 @pytest.mark.parametrize("copy_fn", copies)
 def test_metadata_any(axis, args, copy_fn):
-    orig = axis(*args, metadata=(1,2,3))
+    orig = axis(*args, metadata=(1, 2, 3))
     new = copy_fn(orig)
     assert new.metadata == orig.metadata
     new.metadata = orig.metadata
@@ -118,7 +121,7 @@ def test_storage_int(copy_fn):
 
 @pytest.mark.parametrize("copy_fn", copies)
 def test_histogram_regular(copy_fn):
-    hist = bh.histogram(bh.axis.regular(4,1,2), bh.axis.regular(8,3,6))
+    hist = bh.histogram(bh.axis.regular(4, 1, 2), bh.axis.regular(8, 3, 6))
 
     new = copy_fn(hist)
     assert hist == new
@@ -126,17 +129,16 @@ def test_histogram_regular(copy_fn):
 
 @pytest.mark.parametrize("copy_fn", copies)
 def test_histogram_fancy(copy_fn):
-    hist = bh.histogram(bh.axis._regular_noflow(4,1,2), bh.axis._integer_uoflow(0, 6))
+    hist = bh.histogram(bh.axis._regular_noflow(4, 1, 2), bh.axis._integer_uoflow(0, 6))
 
     new = copy_fn(hist)
     assert hist == new
 
 
 @pytest.mark.parametrize("copy_fn", copies)
-@pytest.mark.parametrize("metadata", ("This", (1,2,3)))
+@pytest.mark.parametrize("metadata", ("This", (1, 2, 3)))
 def test_histogram_metadata(copy_fn, metadata):
 
-    hist = bh.histogram(bh.axis.regular(4,1,2, metadata=metadata))
+    hist = bh.histogram(bh.axis.regular(4, 1, 2, metadata=metadata))
     new = copy_fn(hist)
     assert hist == new
-

--- a/tests/test_public_axis.py
+++ b/tests/test_public_axis.py
@@ -2,12 +2,16 @@ import pytest
 from pytest import approx
 
 import boost.histogram.axis as bha
-from boost.histogram.axis import (regular, 
-                                  regular_log, regular_sqrt,
-                                  regular_pow, circular,
-                                  variable,
-                                  integer,
-                                  category)
+from boost.histogram.axis import (
+    regular,
+    regular_log,
+    regular_sqrt,
+    regular_pow,
+    circular,
+    variable,
+    integer,
+    category,
+)
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
@@ -15,7 +19,7 @@ from numpy.testing import assert_array_equal, assert_allclose
 import abc
 
 # compatible with Python 2 *and* 3:
-ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
+ABC = abc.ABCMeta("ABC", (object,), {"__slots__": ()})
 
 # histogram -> boost.histogram
 # regular(..., noflow=False) -> regular_ouflow(...)
@@ -27,8 +31,8 @@ ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
 # Circular is very different (Boost::Histogram change)
 # Variable and category take an array/list now
 
-class Axis(ABC):
 
+class Axis(ABC):
     @abc.abstractmethod
     def test_init(self):
         pass
@@ -54,28 +58,30 @@ class Axis(ABC):
         pass
 
 
-
 class TestRegular(Axis):
-
     def test_shortcut(self):
-        assert isinstance(regular(1,2,3), bha._regular_uoflow)
-        assert isinstance(regular(1,2,3), regular)
+        assert isinstance(regular(1, 2, 3), bha._regular_uoflow)
+        assert isinstance(regular(1, 2, 3), regular)
 
-        assert isinstance(regular(1,2,3, overflow=False), bha._regular_uflow)
-        assert isinstance(regular(1,2,3, overflow=False), regular)
+        assert isinstance(regular(1, 2, 3, overflow=False), bha._regular_uflow)
+        assert isinstance(regular(1, 2, 3, overflow=False), regular)
 
-        assert isinstance(regular(1,2,3, underflow=False), bha._regular_oflow)
-        assert isinstance(regular(1,2,3, underflow=False), regular)
+        assert isinstance(regular(1, 2, 3, underflow=False), bha._regular_oflow)
+        assert isinstance(regular(1, 2, 3, underflow=False), regular)
 
-        assert isinstance(regular(1,2,3, flow=False), bha._regular_noflow)
-        assert isinstance(regular(1,2,3, flow=False), regular)
+        assert isinstance(regular(1, 2, 3, flow=False), bha._regular_noflow)
+        assert isinstance(regular(1, 2, 3, flow=False), regular)
 
-        assert isinstance(regular(1,2,3, underflow=False, overflow=False), bha._regular_noflow)
-        assert isinstance(regular(1,2,3, underflow=False, overflow=False, flow=True), bha._regular_uoflow)
+        assert isinstance(
+            regular(1, 2, 3, underflow=False, overflow=False), bha._regular_noflow
+        )
+        assert isinstance(
+            regular(1, 2, 3, underflow=False, overflow=False, flow=True),
+            bha._regular_uoflow,
+        )
 
-        assert isinstance(regular(1,2,3, growth=True), bha._regular_growth)
-        assert isinstance(regular(1,2,3, growth=True), regular)
-
+        assert isinstance(regular(1, 2, 3, growth=True), bha._regular_growth)
+        assert isinstance(regular(1, 2, 3, growth=True), regular)
 
     def test_init(self):
         # Should not throw
@@ -102,7 +108,7 @@ class TestRegular(Axis):
         with pytest.raises(Exception):
             regular(-1, 1.0, 2.0)
         # CLASSIC
-        #with pytest.raises(ValueError):
+        # with pytest.raises(ValueError):
         regular(1, 2.0, 1.0)
 
         with pytest.raises(ValueError):
@@ -110,8 +116,6 @@ class TestRegular(Axis):
 
         with pytest.raises(TypeError):
             regular(1, 1.0, 2.0, metadata=0)
-
-
 
         with pytest.raises(KeyError):
             regular(1, 1.0, 2.0, bad_keyword="ra")
@@ -123,7 +127,6 @@ class TestRegular(Axis):
         assert a != regular(3, 1.0, 2.0)
         assert a != regular(4, 1.1, 2.0)
         assert a != regular(4, 1.0, 2.1)
-
 
     def test_len(self):
         a = regular(4, 1.0, 2.0)
@@ -137,31 +140,36 @@ class TestRegular(Axis):
         ax = regular(4, 1.1, 2.2)
         assert repr(ax) == "regular(4, 1.1, 2.2, options=underflow | overflow)"
 
-        ax = regular(4, 1.1, 2.2, metadata='ra')
-        assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra", options=underflow | overflow)'
+        ax = regular(4, 1.1, 2.2, metadata="ra")
+        assert (
+            repr(ax)
+            == 'regular(4, 1.1, 2.2, metadata="ra", options=underflow | overflow)'
+        )
 
         ax = regular(4, 1.1, 2.2, flow=False)
         assert repr(ax) == "regular(4, 1.1, 2.2, options=none)"
 
-        ax = regular(4, 1.1, 2.2, metadata='ra', flow=False)
+        ax = regular(4, 1.1, 2.2, metadata="ra", flow=False)
         assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra", options=none)'
 
         ax = regular_log(4, 1.1, 2.2)
-        assert repr(ax) == 'regular_log(4, 1.1, 2.2, options=underflow | overflow)'
+        assert repr(ax) == "regular_log(4, 1.1, 2.2, options=underflow | overflow)"
 
         ax = regular_sqrt(3, 1.1, 2.2)
-        assert repr(ax) == 'regular_sqrt(3, 1.1, 2.2, options=underflow | overflow)'
+        assert repr(ax) == "regular_sqrt(3, 1.1, 2.2, options=underflow | overflow)"
 
         ax = regular_pow(4, 1.1, 2.2, 0.5)
-        assert repr(ax) == 'regular_pow(4, 1.1, 2.2, options=underflow | overflow, power=0.5)'
-
+        assert (
+            repr(ax)
+            == "regular_pow(4, 1.1, 2.2, options=underflow | overflow, power=0.5)"
+        )
 
     def test_getitem(self):
         v = [1.0, 1.25, 1.5, 1.75, 2.0]
         a = regular(4, 1.0, 2.0)
         for i in range(4):
             a.bin(i).lower() == approx(v[i])
-            a.bin(i).upper() == approx(v[i+1])
+            a.bin(i).upper() == approx(v[i + 1])
         assert a.bin(-1).lower() == -float("infinity")
         assert a.bin(4).upper() == float("infinity")
 
@@ -181,7 +189,7 @@ class TestRegular(Axis):
         a = regular(4, 1.0, 2.0)
         assert_array_equal(a.edges(), v)
 
-        c = (v[:-1] + v[1:])/2
+        c = (v[:-1] + v[1:]) / 2
         assert_allclose(a.centers(), c)
 
     def test_index(self):
@@ -216,7 +224,6 @@ class TestRegular(Axis):
         assert a.index(2.000) == 0
         assert a.index(20) == -1
 
-
     def test_log_transform(self):
         a = regular_log(2, 1e0, 1e2)
 
@@ -250,10 +257,7 @@ class TestRegular(Axis):
         assert a.bin(1).upper(), approx(9.0)
 
 
-
-
 class TestCircular(Axis):
-
     def test_init(self):
         # Should not throw
 
@@ -295,25 +299,25 @@ class TestCircular(Axis):
         ax = circular(4, 1.1, 2.2)
         assert repr(ax) == "regular(4, 1.1, 2.2, options=overflow | circular)"
 
-        ax = circular(4, 1.1, 2.2, metadata='hi')
-        assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="hi", options=overflow | circular)'
+        ax = circular(4, 1.1, 2.2, metadata="hi")
+        assert (
+            repr(ax)
+            == 'regular(4, 1.1, 2.2, metadata="hi", options=overflow | circular)'
+        )
 
         ax = circular(4, 2.0)
         assert repr(ax) == "regular(4, 0, 2, options=overflow | circular)"
 
-        ax = circular(4, 2.0, metadata='hi')
-        assert repr(ax) == 'regular(4, 0, 2, metadata="hi", options=overflow | circular)'
-
+        ax = circular(4, 2.0, metadata="hi")
+        assert (
+            repr(ax) == 'regular(4, 0, 2, metadata="hi", options=overflow | circular)'
+        )
 
     def test_getitem(self):
-        v = [1.0,
-             1.0 + 0.5 * np.pi,
-             1.0 + np.pi,
-             1.0 + 1.5 * np.pi,
-             1.0 + 2.0 * np.pi]
+        v = [1.0, 1.0 + 0.5 * np.pi, 1.0 + np.pi, 1.0 + 1.5 * np.pi, 1.0 + 2.0 * np.pi]
 
         # CLASSIC: Used to be 1 (phase 2pi automatic?)
-        a = circular(4, 1, 1+np.pi*2)
+        a = circular(4, 1, 1 + np.pi * 2)
 
         for i in range(4):
             assert a.bin(i).lower() == v[i]
@@ -322,22 +326,19 @@ class TestCircular(Axis):
         # CLASSIC: Out of range used to raise
         # TODO: test out of range
 
-
     def test_iter(self):
-        v = np.array([1.0,
-             1.0 + 0.5 * np.pi,
-             1.0 + np.pi,
-             1.0 + 1.5 * np.pi,
-             1.0 + 2.0 * np.pi])
+        v = np.array(
+            [1.0, 1.0 + 0.5 * np.pi, 1.0 + np.pi, 1.0 + 1.5 * np.pi, 1.0 + 2.0 * np.pi]
+        )
 
-        a = circular(4, 1, 1+np.pi*2)
+        a = circular(4, 1, 1 + np.pi * 2)
         assert_array_equal(a.edges(), v)
 
-        c = (v[:-1] + v[1:])/2
+        c = (v[:-1] + v[1:]) / 2
         assert_allclose(a.centers(), c)
 
     def test_index(self):
-        a = circular(4, 1, 1+np.pi*2)
+        a = circular(4, 1, 1 + np.pi * 2)
         d = 0.5 * np.pi
         assert a.index(0.99 - 4 * d) == 3
         assert a.index(0.99 - 3 * d) == 0
@@ -356,20 +357,25 @@ class TestCircular(Axis):
 
 class TestVariable(Axis):
     def test_shortcut(self):
-        assert isinstance(variable([1,2,3]), bha._variable_uoflow)
-        assert isinstance(variable([1,2,3]), variable)
+        assert isinstance(variable([1, 2, 3]), bha._variable_uoflow)
+        assert isinstance(variable([1, 2, 3]), variable)
 
-        assert isinstance(variable([1,2,3], overflow=False), bha._variable_uflow)
-        assert isinstance(variable([1,2,3], overflow=False), variable)
+        assert isinstance(variable([1, 2, 3], overflow=False), bha._variable_uflow)
+        assert isinstance(variable([1, 2, 3], overflow=False), variable)
 
-        assert isinstance(variable([1,2,3], underflow=False), bha._variable_oflow)
-        assert isinstance(variable([1,2,3], underflow=False), variable)
+        assert isinstance(variable([1, 2, 3], underflow=False), bha._variable_oflow)
+        assert isinstance(variable([1, 2, 3], underflow=False), variable)
 
-        assert isinstance(variable([1,2,3], flow=False), bha._variable_noflow)
-        assert isinstance(variable([1,2,3], flow=False), variable)
+        assert isinstance(variable([1, 2, 3], flow=False), bha._variable_noflow)
+        assert isinstance(variable([1, 2, 3], flow=False), variable)
 
-        assert isinstance(variable([1,2,3], underflow=False, overflow=False), bha._variable_noflow)
-        assert isinstance(variable([1,2,3], underflow=False, overflow=False, flow=True), bha._variable_uoflow)
+        assert isinstance(
+            variable([1, 2, 3], underflow=False, overflow=False), bha._variable_noflow
+        )
+        assert isinstance(
+            variable([1, 2, 3], underflow=False, overflow=False, flow=True),
+            bha._variable_uoflow,
+        )
 
     def test_init(self):
         variable([0, 1])
@@ -404,9 +410,11 @@ class TestVariable(Axis):
         ax = variable([-0.1, 0.2])
         assert repr(ax) == "variable(-0.1, 0.2, options=underflow | overflow)"
 
-        ax = variable([-0.1, 0.2], metadata='hi')
-        assert repr(ax) == 'variable(-0.1, 0.2, metadata="hi", options=underflow | overflow)'
-
+        ax = variable([-0.1, 0.2], metadata="hi")
+        assert (
+            repr(ax)
+            == 'variable(-0.1, 0.2, metadata="hi", options=underflow | overflow)'
+        )
 
     def test_getitem(self):
         v = [-0.1, 0.2, 0.3]
@@ -426,14 +434,13 @@ class TestVariable(Axis):
         assert a.bin(-2).upper() == -float("infinity")
         assert a.bin(3).lower() == float("infinity")
 
-
     def test_iter(self):
         v = np.array([-0.1, 0.2, 0.3])
         a = variable(v)
 
         assert_array_equal(a.edges(), v)
 
-        c = (v[:-1] + v[1:])/2
+        c = (v[:-1] + v[1:]) / 2
         assert_allclose(a.centers(), c)
 
     def test_index(self):
@@ -450,6 +457,7 @@ class TestVariable(Axis):
         assert a.index(0.31) == 2
         assert a.index(10) == 2
 
+
 class TestInteger:
     def test_shortcut(self):
         assert isinstance(integer(1, 3), bha._integer_uoflow)
@@ -464,8 +472,13 @@ class TestInteger:
         assert isinstance(integer(1, 3, flow=False), bha._integer_noflow)
         assert isinstance(integer(1, 3, flow=False), integer)
 
-        assert isinstance(integer(1, 3, underflow=False, overflow=False), bha._integer_noflow)
-        assert isinstance(integer(1, 3, underflow=False, overflow=False, flow=True), bha._integer_uoflow)
+        assert isinstance(
+            integer(1, 3, underflow=False, overflow=False), bha._integer_noflow
+        )
+        assert isinstance(
+            integer(1, 3, underflow=False, overflow=False, flow=True),
+            bha._integer_uoflow,
+        )
 
         assert isinstance(integer(1, 3, growth=True), bha._integer_growth)
         assert isinstance(integer(1, 3, growth=True), integer)
@@ -473,8 +486,8 @@ class TestInteger:
     def test_init(self):
         integer(-1, 2, flow=True)
         integer(-1, 2, flow=False)
-        integer(-1, 2 , growth=True)
-        
+        integer(-1, 2, growth=True)
+
         with pytest.raises(TypeError):
             integer()
         with pytest.raises(TypeError):
@@ -501,16 +514,16 @@ class TestInteger:
 
     def test_repr(self):
         a = integer(-1, 1)
-        assert repr(a) == 'integer(-1, 1, options=underflow | overflow)'
+        assert repr(a) == "integer(-1, 1, options=underflow | overflow)"
 
         a = integer(-1, 1, metadata="hi")
         assert repr(a) == 'integer(-1, 1, metadata="hi", options=underflow | overflow)'
 
         a = integer(-1, 1, flow=False)
-        assert repr(a) == 'integer(-1, 1, options=none)'
+        assert repr(a) == "integer(-1, 1, options=none)"
 
         a = integer(-1, 1, growth=True)
-        assert repr(a) == 'integer(-1, 1, options=growth)'
+        assert repr(a) == "integer(-1, 1, options=growth)"
 
     def test_label(self):
         a = integer(-1, 2, metadata="foo")
@@ -544,11 +557,10 @@ class TestInteger:
 
 
 class TestCategory(Axis):
-
     def test_init(self):
         category([1, 2, 3])
         category([1, 2, 3], metadata="ca")
-        
+
         # Basic string support
         category(["1"])
 
@@ -565,16 +577,15 @@ class TestCategory(Axis):
         assert category([1, 2, 3]) != category([1, 3, 2])
 
     def test_len(self):
-        assert category([1,2,3]).size() == 3
-        assert category([1,2,3]).size(flow=True) == 4
+        assert category([1, 2, 3]).size() == 3
+        assert category([1, 2, 3]).size(flow=True) == 4
 
     def test_repr(self):
-        ax = category([1,2,3])
+        ax = category([1, 2, 3])
         assert repr(ax) == "category(1, 2, 3, options=overflow)"
 
-        ax = category([1,2,3], metadata='hi')
+        ax = category([1, 2, 3], metadata="hi")
         assert repr(ax) == 'category(1, 2, 3, metadata="hi", options=overflow)'
-
 
     def test_getitem(self):
         c = [1, 2, 3]
@@ -585,7 +596,6 @@ class TestCategory(Axis):
 
         # CLASSIC: out of range used to throw
         # TODO: Check out of range bin values
-
 
     def test_iter(self):
         c = [1, 2, 3]
@@ -604,4 +614,3 @@ class TestCategory(Axis):
         assert a.index(1) == 0
         assert a.index(2) == 1
         assert a.index(3) == 2
-

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -85,7 +85,7 @@ def test_fill_int_1d():
         h.at(0, foo=None)
     with pytest.raises(ValueError):
         h.at(0, 1)
-    with pytest.raises(TypeError):
+    with pytest.raises(IndexError):
         h[0, 1]
 
     for get in (lambda h, arg: h.at(arg),):
@@ -119,7 +119,7 @@ def test_fill_1d(flow):
         h.at(0, foo=None)
     with pytest.raises(ValueError):
         h.at(0, 1)
-    with pytest.raises(TypeError):
+    with pytest.raises(IndexError):
         h[0, 1]
 
     for get in (lambda h, arg: h.at(arg),):

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -3,11 +3,16 @@ from pytest import approx
 
 
 from boost.histogram import histogram
-from boost.histogram.axis import (regular, integer,
-                                  regular_log, regular_sqrt,
-                                  regular_pow, circular,
-                                  variable,
-                                  category)
+from boost.histogram.axis import (
+    regular,
+    integer,
+    regular_log,
+    regular_sqrt,
+    regular_pow,
+    circular,
+    variable,
+    category,
+)
 
 import boost.histogram as bh
 
@@ -23,6 +28,7 @@ except ImportError:
 # histogram -> boost.histogram
 # histogram -> _make_histogram
 # .dim -> .rank()
+
 
 def test_init():
     histogram()
@@ -56,6 +62,7 @@ def test_init():
 def test_copy():
     a = histogram(integer(-1, 1))
     import copy
+
     b = copy.copy(a)
     assert a == b
     assert id(a) != id(b)
@@ -89,13 +96,13 @@ def test_fill_int_1d():
         h[0, 1]
 
     for get in (lambda h, arg: h.at(arg),):
-               # lambda h, arg: h[arg]):
+        # lambda h, arg: h[arg]):
         assert get(h, 0) == 2
         assert get(h, 1) == 1
         assert get(h, 2) == 3
-        #assert get(h, 0).variance == 2
-        #assert get(h, 1).variance == 1
-        #assert get(h, 2).variance == 3
+        # assert get(h, 0).variance == 2
+        # assert get(h, 1).variance == 1
+        # assert get(h, 2).variance == 3
 
         assert get(h, -1) == 1
         assert get(h, 3) == 1
@@ -112,8 +119,8 @@ def test_fill_1d(flow):
         h.fill(x)
 
     assert h.sum() == 6
-    assert h.sum(flow=True) == 6 + 2*flow
-    assert h.axis(0).size(flow=True) == 3 + 2*flow
+    assert h.sum(flow=True) == 6 + 2 * flow
+    assert h.axis(0).size(flow=True) == 3 + 2 * flow
 
     with pytest.raises(TypeError):
         h.at(0, foo=None)
@@ -123,17 +130,18 @@ def test_fill_1d(flow):
         h[0, 1]
 
     for get in (lambda h, arg: h.at(arg),):
-               # lambda h, arg: h[arg]):
+        # lambda h, arg: h[arg]):
         assert get(h, 0) == 2
         assert get(h, 1) == 1
         assert get(h, 2) == 3
-        #assert get(h, 0).variance == 2
-        #assert get(h, 1).variance == 1
-        #assert get(h, 2).variance == 3
+        # assert get(h, 0).variance == 2
+        # assert get(h, 1).variance == 1
+        # assert get(h, 2).variance == 3
 
     if flow is True:
         assert get(h, -1) == 1
         assert get(h, 3) == 1
+
 
 def test_growth():
     h = histogram(integer(-1, 2))
@@ -154,8 +162,7 @@ def test_growth():
 
 @pytest.mark.parametrize("flow", [True, False])
 def test_fill_2d(flow):
-    h = histogram(integer(-1, 2, flow=flow),
-                  regular(4, -2, 2, flow=flow))
+    h = histogram(integer(-1, 2, flow=flow), regular(4, -2, 2, flow=flow))
     h.fill(-1, -2)
     h.fill(-1, -1)
     h.fill(0, 0)
@@ -169,14 +176,16 @@ def test_fill_2d(flow):
     with pytest.raises(Exception):
         h.fill(1, 2, 3)
 
-    m = [[1, 1, 0, 0, 0, 0],
-         [0, 0, 1, 1, 0, 1],
-         [0, 0, 1, 0, 0, 0],
-         [0, 1, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0, 0]]
+    m = [
+        [1, 1, 0, 0, 0, 0],
+        [0, 0, 1, 1, 0, 1],
+        [0, 0, 1, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0],
+    ]
 
     for get in (lambda h, x, y: h.at(x, y),):
-                # lambda h, x, y: h[x, y]):
+        # lambda h, x, y: h[x, y]):
         for i in range(-flow, h.axis(0).size() + flow):
             for j in range(-flow, h.axis(1).size() + flow):
                 assert get(h, i, j) == m[i][j]
@@ -184,8 +193,7 @@ def test_fill_2d(flow):
 
 @pytest.mark.parametrize("flow", [True, False])
 def test_add_2d(flow):
-    h = histogram(integer(-1, 2, flow=flow),
-                  regular(4, -2, 2, flow=flow))
+    h = histogram(integer(-1, 2, flow=flow), regular(4, -2, 2, flow=flow))
     assert isinstance(h, histogram)
 
     h.fill(-1, -2)
@@ -196,17 +204,20 @@ def test_add_2d(flow):
     h.fill(3, -1)
     h.fill(0, -3)
 
-    m = [[1, 1, 0, 0, 0, 0],
-         [0, 0, 1, 1, 0, 1],
-         [0, 0, 1, 0, 0, 0],
-         [0, 1, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0, 0]]
+    m = [
+        [1, 1, 0, 0, 0, 0],
+        [0, 0, 1, 1, 0, 1],
+        [0, 0, 1, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0],
+    ]
 
     h += h
 
     for i in range(-flow, h.axis(0).size() + flow):
         for j in range(-flow, h.axis(1).size() + flow):
             assert h.at(i, j) == 2 * m[i][j]
+
 
 def test_add_2d_bad():
     a = histogram(integer(-1, 1))
@@ -215,10 +226,10 @@ def test_add_2d_bad():
     with pytest.raises(ValueError):
         a += b
 
+
 @pytest.mark.parametrize("flow", [True, False])
 def test_add_2d_w(flow):
-    h = histogram(integer(-1, 2, flow=flow),
-                  regular(4, -2, 2, flow=flow))
+    h = histogram(integer(-1, 2, flow=flow), regular(4, -2, 2, flow=flow))
     h.fill(-1, -2)
     h.fill(-1, -1)
     h.fill(0, 0)
@@ -227,14 +238,15 @@ def test_add_2d_w(flow):
     h.fill(3, -1)
     h.fill(0, -3)
 
-    m = [[1, 1, 0, 0, 0, 0],
-         [0, 0, 1, 1, 0, 1],
-         [0, 0, 1, 0, 0, 0],
-         [0, 1, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0, 0]]
+    m = [
+        [1, 1, 0, 0, 0, 0],
+        [0, 0, 1, 1, 0, 1],
+        [0, 0, 1, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0],
+    ]
 
-    h2 = histogram(integer(-1, 2, flow=flow),
-                   regular(4, -2, 2, flow=flow))
+    h2 = histogram(integer(-1, 2, flow=flow), regular(4, -2, 2, flow=flow))
     h2.fill(0, 0, weight=0)
 
     h2 += h
@@ -246,10 +258,13 @@ def test_add_2d_w(flow):
         for j in range(-flow, h.axis(1).size() + flow):
             assert h.at(i, j) == 2 * m[i][j]
 
+
 def test_repr():
     h = histogram(regular(3, 0, 1), integer(0, 1))
     hr = repr(h)
-    assert hr == '''histogram(
+    assert (
+        hr
+        == """histogram(
   regular(3, 0, 1, options=underflow | overflow),
   integer(0, 1, options=underflow | overflow),
   0: 0
@@ -267,7 +282,9 @@ def test_repr():
   12: 0
   13: 0
   14: 0
-)'''
+)"""
+    )
+
 
 def test_axis():
     axes = (regular(10, 0, 1), integer(0, 1))
@@ -279,7 +296,8 @@ def test_axis():
     assert h.axis(-1) == axes[-1]
     assert h.axis(-2) == axes[-2]
     with pytest.raises(IndexError):
-            h.axis(-3)
+        h.axis(-3)
+
 
 # CLASSIC: This used to only fail when accessing, now fails in creation
 def test_overflow():
@@ -297,10 +315,11 @@ def test_out_of_range():
         h.at(-2)
     with pytest.raises(IndexError):
         h.at(4)
-    #with pytest.raises(IndexError):
+    # with pytest.raises(IndexError):
     #    h.at(-2).variance
-    #with pytest.raises(IndexError):
+    # with pytest.raises(IndexError):
     #    h.at(4).variance
+
 
 # CLASSIC: This used to have variance
 def test_operators():
@@ -317,6 +336,7 @@ def test_operators():
     h2 = histogram(regular(2, 0, 2))
     with pytest.raises(ValueError):
         h + h2
+
 
 # CLASSIC: reduce_to -> project,
 def test_project():
@@ -341,32 +361,37 @@ def test_project():
     with pytest.raises(ValueError):
         h.project(2, 1)
 
+
 def test_shrink_1d():
     h = histogram(regular(20, 1, 5))
     h.fill(1.1)
     hs = h.reduce(bh.algorithm.shrink(0, 1, 2))
-    assert_array_equal(hs.view(), [1,0,0,0,0])
+    assert_array_equal(hs.view(), [1, 0, 0, 0, 0])
+
 
 def test_rebin_1d():
     h = histogram(regular(20, 1, 5))
     h.fill(1.1)
     hs = h.reduce(bh.algorithm.rebin(0, 4))
-    assert_array_equal(hs.view(), [1,0,0,0,0])
+    assert_array_equal(hs.view(), [1, 0, 0, 0, 0])
+
 
 def test_shrink_rebin_1d():
     h = histogram(regular(20, 0, 4))
     h.fill(1.1)
     hs = h.reduce(bh.algorithm.shrink_and_rebin(0, 1, 3, 2))
-    assert_array_equal(hs.view(), [1,0,0,0,0])
+    assert_array_equal(hs.view(), [1, 0, 0, 0, 0])
 
 
 # CLASSIC: This used to have metadata too, but that does not compare equal
 def test_pickle_0():
-    a = histogram(category([0, 1, 2]),
-                  integer(0, 20),
-                  regular(20, 0.0, 20.0, flow=False),
-                  variable([0.0, 1.0, 2.0]),
-                  circular(4, 2*np.pi))
+    a = histogram(
+        category([0, 1, 2]),
+        integer(0, 20),
+        regular(20, 0.0, 20.0, flow=False),
+        variable([0.0, 1.0, 2.0]),
+        circular(4, 2 * np.pi),
+    )
     for i in range(a.axis(0).size(flow=True)):
         a.fill(i, 0, 0, 0, 0)
         for j in range(a.axis(1).size(flow=True)):
@@ -378,7 +403,7 @@ def test_pickle_0():
                     for m in range(a.axis(4).size(flow=True)):
                         a.fill(i, j, k, l, m * 0.5 * np.pi)
 
-    io = pickle.dumps(a,-1)
+    io = pickle.dumps(a, -1)
     b = pickle.loads(io)
 
     assert id(a) != id(b)
@@ -391,11 +416,14 @@ def test_pickle_0():
     assert a.sum() == b.sum()
     assert a == b
 
+
 def test_pickle_1():
-    a = histogram(category([0, 1, 2]),
-                  integer(0, 3, metadata='ia'),
-                  regular(4, 0.0, 4.0, flow=False),
-                  variable([0.0, 1.0, 2.0]))
+    a = histogram(
+        category([0, 1, 2]),
+        integer(0, 3, metadata="ia"),
+        regular(4, 0.0, 4.0, flow=False),
+        variable([0.0, 1.0, 2.0]),
+    )
     assert isinstance(a, bh.hist._any_int)
     assert isinstance(a, histogram)
 
@@ -422,7 +450,9 @@ def test_pickle_1():
     assert a.sum() == b.sum()
     assert a == b
 
+
 # Numpy tests
+
 
 def test_numpy_conversion_0():
     a = histogram(integer(0, 3, flow=False))
@@ -433,7 +463,7 @@ def test_numpy_conversion_0():
     v = np.asarray(a)  # a view
 
     for t in (c, v):
-        assert t.dtype == np.uint64 # CLASSIC: np.uint8
+        assert t.dtype == np.uint64  # CLASSIC: np.uint8
         assert_array_equal(t, (1, 5, 0))
 
     for i in range(10):
@@ -446,10 +476,11 @@ def test_numpy_conversion_0():
         a.fill(1)
     c = np.array(a)
 
-    assert c.dtype == np.uint64 # CLASSIC: np.uint16
+    assert c.dtype == np.uint64  # CLASSIC: np.uint16
     assert_array_equal(c, (1, 260, 10))
     # view does not follow underlying switch in word size
     # assert not np.all(c, v)
+
 
 def test_numpy_conversion_1():
     # CLASSIC: was weight array
@@ -458,14 +489,15 @@ def test_numpy_conversion_1():
         a.fill(1, weight=3)
     c = np.array(a)  # a copy
     v = np.asarray(a)  # a view
-    assert c.dtype == np.uint64 # CLASSIC: np.float64
+    assert c.dtype == np.uint64  # CLASSIC: np.float64
     assert_array_equal(c, np.array((0, 30, 0)))
     assert_array_equal(v, c)
 
+
 def test_numpy_conversion_2():
-    a = histogram(integer(0, 2, flow=False),
-                  integer(0, 3, flow=False),
-                  integer(0, 4, flow=False))
+    a = histogram(
+        integer(0, 2, flow=False), integer(0, 3, flow=False), integer(0, 4, flow=False)
+    )
     r = np.zeros((2, 3, 4), dtype=np.int8)
     for i in range(a.axis(0).size(flow=True)):
         for j in range(a.axis(1).size(flow=True)):
@@ -488,17 +520,17 @@ def test_numpy_conversion_2():
     assert_array_equal(c, r)
     assert_array_equal(v, r)
 
+
 def test_numpy_conversion_3():
-    a = histogram(integer(0, 2),
-                  integer(0, 3),
-                  integer(0, 4),
-                  storage=bh.storage.double())
+    a = histogram(
+        integer(0, 2), integer(0, 3), integer(0, 4), storage=bh.storage.double()
+    )
 
     r = np.zeros((4, 5, 6))
     for i in range(a.axis(0).size(flow=True)):
         for j in range(a.axis(1).size(flow=True)):
             for k in range(a.axis(2).size(flow=True)):
-                a.fill(i-1, j-1, k-1, weight=i + j + k)
+                a.fill(i - 1, j - 1, k - 1, weight=i + j + k)
                 r[i, j, k] = i + j + k
     c = a.view(flow=True)
 
@@ -506,7 +538,7 @@ def test_numpy_conversion_3():
     for i in range(a.axis(0).size(flow=True)):
         for j in range(a.axis(1).size(flow=True)):
             for k in range(a.axis(2).size(flow=True)):
-                c2[i, j, k] = a.at(i-1, j-1, k-1)
+                c2[i, j, k] = a.at(i - 1, j - 1, k - 1)
 
     assert_array_equal(c, c2)
     assert_array_equal(c, r)
@@ -515,11 +547,11 @@ def test_numpy_conversion_3():
     assert a.sum(flow=True) == approx(720)
     assert c.sum() == approx(720)
 
+
 def test_numpy_conversion_4():
-    a = histogram(integer(0, 2, flow=False),
-                  integer(0, 4, flow=False))
+    a = histogram(integer(0, 2, flow=False), integer(0, 4, flow=False))
     a1 = np.asarray(a)
-    assert a1.dtype == np.uint64 # CLASSIC: np.uint8
+    assert a1.dtype == np.uint64  # CLASSIC: np.uint8
     assert a1.shape == (2, 4)
 
     b = histogram()
@@ -530,10 +562,13 @@ def test_numpy_conversion_4():
     # Compare sum methods
     assert b.sum() == np.asarray(b).sum()
 
+
 def test_numpy_conversion_5():
-    a = histogram(integer(0, 3, flow=False),
-                  integer(0, 2, flow=False),
-                  storage=bh.storage.unlimited())
+    a = histogram(
+        integer(0, 3, flow=False),
+        integer(0, 2, flow=False),
+        storage=bh.storage.unlimited(),
+    )
     a.fill(0, 0)
     for i in range(80):
         a = a + a
@@ -556,17 +591,18 @@ def test_numpy_conversion_5():
     assert a1[1, 1] == 4
     assert a1[2, 1] == 5
 
+
 def test_numpy_conversion_6():
     a = integer(0, 2)
     b = regular(2, 0, 2)
     c = variable([0, 1, 2])
-    ref = np.array((0., 1., 2.))
+    ref = np.array((0.0, 1.0, 2.0))
     assert_array_equal(a.bins(), [0, 1])
     assert_array_equal(b.edges(), ref)
     assert_array_equal(c.edges(), ref)
 
-    d = circular(4, 0, 2*np.pi)
-    ref = np.array((0., 0.5 * np.pi, np.pi, 1.5 * np.pi, 2.0 * np.pi))
+    d = circular(4, 0, 2 * np.pi)
+    ref = np.array((0.0, 0.5 * np.pi, np.pi, 1.5 * np.pi, 2.0 * np.pi))
     assert_array_equal(d.edges(), ref)
     e = category([1, 2])
     ref = np.array((1, 2))
@@ -576,6 +612,7 @@ def test_numpy_conversion_6():
 def test_fill_with_numpy_array_0():
     def ar(*args):
         return np.array(args, dtype=float)
+
     a = histogram(integer(0, 3, flow=False))
     a.fill(ar(-1, 0, 1, 2, 1))
     a.fill((4, -1, 0, 1, 2))
@@ -595,9 +632,8 @@ def test_fill_with_numpy_array_0():
     with pytest.raises(ValueError):
         a.at(1, 2)
 
-    a = histogram(integer(0, 2, flow=False),
-                  regular(2, 0, 2, flow=False))
-    a.fill(ar(-1, 0, 1), ar(-1., 1., 0.1))
+    a = histogram(integer(0, 2, flow=False), regular(2, 0, 2, flow=False))
+    a.fill(ar(-1, 0, 1), ar(-1.0, 1.0, 0.1))
     assert a.at(0, 0) == 0
     assert a.at(0, 1) == 1
     assert a.at(1, 0) == 1
@@ -608,7 +644,7 @@ def test_fill_with_numpy_array_0():
         a.fill(1)
     with pytest.raises(ValueError):
         a.fill([1, 0, 2], [1, 1])
-    
+
     # This actually broadcasts
     a.fill([1, 0], [1])
 
@@ -623,17 +659,18 @@ def test_fill_with_numpy_array_0():
     assert a.at(1) == 2
     assert a.at(2) == 3
 
+
 def test_fill_with_numpy_array_1():
     def ar(*args):
         return np.array(args, dtype=float)
 
     a = histogram(integer(0, 3), storage=bh.storage.weight())
     v = ar(-1, 0, 1, 2, 3, 4)
-    w = ar( 2, 3, 4, 5, 6, 7)  # noqa
+    w = ar(2, 3, 4, 5, 6, 7)  # noqa
     a.fill(v, weight=w)
     a.fill((0, 1), weight=(2, 3))
 
-    assert a.at(-1) == bh.accumulators.weighted_sum(2,4)
+    assert a.at(-1) == bh.accumulators.weighted_sum(2, 4)
     assert a.at(0) == bh.accumulators.weighted_sum(5, 13)
     assert a.at(1) == bh.accumulators.weighted_sum(7, 25)
     assert a.at(2) == bh.accumulators.weighted_sum(5, 25)
@@ -642,12 +679,11 @@ def test_fill_with_numpy_array_1():
     assert a.at(0).value == 5
     assert a.at(1).value == 7
     assert a.at(2).value == 5
-    
+
     assert a.at(-1).variance == 4
     assert a.at(0).variance == 13
     assert a.at(1).variance == 25
     assert a.at(2).variance == 25
-
 
     a.fill((1, 2), weight=1)
     a.fill(0, weight=1)
@@ -667,8 +703,7 @@ def test_fill_with_numpy_array_1():
     with pytest.raises(ValueError):
         a.fill((1, 2), weight=([1, 1], [2, 2]))
 
-    a = histogram(integer(0, 2, flow=False),
-                  regular(2, 0, 2, flow=False))
+    a = histogram(integer(0, 2, flow=False), regular(2, 0, 2, flow=False))
     a.fill((-1, 0, 1), (-1, 1, 0.1))
     assert a.at(0, 0) == 0
     assert a.at(0, 1) == 1

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -344,19 +344,19 @@ def test_project():
 def test_shrink_1d():
     h = histogram(regular(20, 1, 5))
     h.fill(1.1)
-    hs = h.shrink(0, 1, 2)
+    hs = h.reduce(bh.algorithm.shrink(0, 1, 2))
     assert_array_equal(hs.view(), [1,0,0,0,0])
 
 def test_rebin_1d():
     h = histogram(regular(20, 1, 5))
     h.fill(1.1)
-    hs = h.rebin(0, 4)
+    hs = h.reduce(bh.algorithm.rebin(0, 4))
     assert_array_equal(hs.view(), [1,0,0,0,0])
 
 def test_shrink_rebin_1d():
     h = histogram(regular(20, 0, 4))
     h.fill(1.1)
-    hs = h.shrink_and_rebin(0, 1, 3, 2)
+    hs = h.reduce(bh.algorithm.shrink_and_rebin(0, 1, 3, 2))
     assert_array_equal(hs.view(), [1,0,0,0,0])
 
 

--- a/tests/test_threaded_fill.py
+++ b/tests/test_threaded_fill.py
@@ -11,7 +11,7 @@ from functools import partial
 @pytest.mark.benchmark(group="threaded-fill-1d")
 @pytest.mark.parametrize("method", [thread_fill, classic_fill, atomic_fill])
 def test_threads(benchmark, method):
-    axes = [bh.axis.regular(1000,0,1)]
+    axes = [bh.axis.regular(1000, 0, 1)]
     hist_linear = bh._make_histogram(*axes)
 
     vals = np.random.rand(100000)
@@ -23,9 +23,9 @@ def test_threads(benchmark, method):
     assert_array_equal(hist_linear, hist_atomic)
 
 
-@pytest.mark.parametrize("threads", [1,2,4,7])
+@pytest.mark.parametrize("threads", [1, 2, 4, 7])
 def test_threaded_builtin(threads):
-    axes = [bh.axis.regular(1000,0,1)]
+    axes = [bh.axis.regular(1000, 0, 1)]
     hist_atomic1 = bh._make_histogram(*axes, storage=bh.storage.atomic_int())
 
     vals = np.random.rand(10000)
@@ -34,5 +34,3 @@ def test_threaded_builtin(threads):
     hist_atomic2 = atomic_fill(axes, 4, vals)
 
     assert_array_equal(hist_atomic1, hist_atomic2)
-
-


### PR DESCRIPTION
This reworks the reduce support to match Boost::Histogram (I realized the old version was inspired by the original Python bindings). Most users should use #35, which is included now (at least in part). The Boost::Histogram based methods do less Python magic, so will be faster if a user indexes a *lot* (thousands to millions of times in a loop). I have left off the "shortcut" 1D methods because of this, but I could add them for constancy.

* [x] Ellipsis is now supported
* [x] Basic projection is supported
* [x] Using `bh::loc` in simple indexing is now supported
* Setting is not supported (deferred for a later PR)
* Slice/shrink + projection is not supported (deferred for a later PR)

Other features of this PR:

* Black formatting for Python now tested
* Docs updates.