### PR TITLE
Sampled fills and profile histograms

### DIFF
--- a/include/boost/histogram/python/indexed.hpp
+++ b/include/boost/histogram/python/indexed.hpp
@@ -146,6 +146,8 @@ void register_indexed(py::module &m, std::string name) {
         "content",
         [](const indexed_t &self) { return self.get_content(); },
         [](indexed_t &self, typename histogram_t::value_type value) { self.get_content() = value; });
+
+    indexed.def("__getattr__", [](indexed_t &self, py::str name) { return py::cast(self).attr("content").attr(name); });
 }
 
 template <class histogram_t>

--- a/include/boost/histogram/python/indexed.hpp
+++ b/include/boost/histogram/python/indexed.hpp
@@ -146,8 +146,6 @@ void register_indexed(py::module &m, std::string name) {
         "content",
         [](const indexed_t &self) { return self.get_content(); },
         [](indexed_t &self, typename histogram_t::value_type value) { self.get_content() = value; });
-
-    indexed.def("__getattr__", [](indexed_t &self, py::str name) { return py::cast(self).attr("content").attr(name); });
 }
 
 template <class histogram_t>

--- a/src/histogram/algorithm.cpp
+++ b/src/histogram/algorithm.cpp
@@ -21,13 +21,6 @@ void register_algorithms(py::module &algorithm) {
         "Reduce a histogram with one or more reduce_options",
         "histogram"_a);
 
-    algorithm.def(
-        "indexed",
-        [](py::object item, bool flow) { return item.attr("indexed")("flow"_a = flow); },
-        "histogram"_a,
-        "flow"_a = false,
-        "Set up an iterator, returns a special accessor for bin info and content");
-
     py::class_<bh::algorithm::reduce_option>(algorithm, "reduce_option")
         .def(py::init<unsigned, bool, bh::axis::index_type, bh::axis::index_type, bool, double, double, unsigned>(),
              "iaxis"_a,

--- a/src/histogram/general_histograms.cpp
+++ b/src/histogram/general_histograms.cpp
@@ -27,7 +27,6 @@ void register_general_histograms(py::module &hist) {
     register_histogram<axes::any, storage::weight>(
         hist, "_any_weight", "N-dimensional histogram for weighted data with any axis types.");
 
-    // Requires sampled fills
     register_histogram<axes::any, bh::profile_storage>(
         hist, "_any_profile", "N-dimensional histogram for sampled data with any axis types.");
 

--- a/src/histogram/make_histogram.cpp
+++ b/src/histogram/make_histogram.cpp
@@ -5,6 +5,7 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
+#include <boost/histogram/accumulators.hpp>
 #include <boost/histogram/histogram.hpp>
 #include <boost/histogram/make_histogram.hpp>
 #include <boost/histogram/python/axis.hpp>
@@ -22,6 +23,13 @@ void register_make_histogram(py::module &m, py::module &hist) {
         [](py::args t_args, py::kwargs kwargs) -> py::object {
             py::list args      = py::cast<py::list>(t_args);
             py::object storage = optional_arg(kwargs, "storage", py::cast(storage::int_{}));
+
+            // Allow a user to forget to add () when calling bh.storage.item
+            try {
+                storage = storage();
+            } catch(const py::error_already_set &) {
+            }
+
             // TODO: change this to be unlimited by default
             std::unique_ptr<py::object> dtype = optional_arg(kwargs, "dtype");
             finalize_args(kwargs);

--- a/src/histogram/make_histogram.cpp
+++ b/src/histogram/make_histogram.cpp
@@ -69,10 +69,15 @@ void register_make_histogram(py::module &m, py::module &hist) {
 
             auto axes = py::cast<axes::any>(args);
 
-            return try_cast<storage::unlimited, storage::double_, storage::int_, storage::atomic_int, storage::weight>(
-                storage, [&axes](auto &&storage) {
-                    return py::cast(bh::make_histogram_with(storage, axes), py::return_value_policy::move);
-                });
+            return try_cast<storage::unlimited,
+                            storage::double_,
+                            storage::int_,
+                            storage::atomic_int,
+                            storage::weight,
+                            storage::profile,
+                            storage::weighted_profile>(storage, [&axes](auto &&storage) {
+                return py::cast(bh::make_histogram_with(storage, axes), py::return_value_policy::move);
+            });
         },
         "Make any histogram");
 

--- a/src/histogram/utils.cpp
+++ b/src/histogram/utils.cpp
@@ -28,4 +28,11 @@ void register_utils(py::module &m) {
         .def_property_readonly_static("projection", [](py::object /* self */) { return true; });
 
     m.attr("project") = project{};
+
+    m.def(
+        "indexed",
+        [](py::object item, bool flow) { return item.attr("indexed")("flow"_a = flow); },
+        "histogram"_a,
+        "flow"_a = false,
+        "Set up an iterator, returns a special accessor for bin info and content");
 }

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -23,6 +23,6 @@ def test_profile_hist():
         ind, = x.indices()
 
         assert res["bin"] == ind
-        assert res["count"] == x.count
-        assert approx(res["value"]) == x.value
-        assert approx(res["variance"]) == x.variance
+        assert res["count"] == x.content.count
+        assert approx(res["value"]) == x.content.value
+        assert approx(res["variance"]) == x.content.variance

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,28 @@
+from pytest import approx
+import boost.histogram as bh
+
+
+def test_profile_hist():
+
+    h = bh.histogram(bh.axis.regular(3, 0, 1), storage=bh.storage.profile)
+
+    h.fill(0.10, sample=[2.5])
+    h.fill(0.25, sample=[3.5])
+    h.fill(0.45, sample=[1.2])
+    h.fill(0.51, sample=[3.4])
+    h.fill(0.81, sample=[1.3])
+    h.fill(0.86, sample=[1.9])
+
+    results = (
+        dict(bin=0, count=2, value=3.0, variance=0.5),
+        dict(bin=1, count=2, value=2.3, variance=2.42),
+        dict(bin=2, count=2, value=1.6, variance=0.18),
+    )
+
+    for res, x in zip(results, bh.indexed(h)):
+        ind, = x.indices()
+
+        assert res["bin"] == ind
+        assert res["count"] == x.count
+        assert approx(res["value"]) == x.value
+        assert approx(res["variance"]) == x.variance

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -522,8 +522,9 @@ def test_numpy_conversion_2():
 
 
 def test_numpy_conversion_3():
+    # It's okay to forget the () on a storage
     a = histogram(
-        integer(0, 2), integer(0, 3), integer(0, 4), storage=bh.storage.double()
+        integer(0, 2), integer(0, 3), integer(0, 4), storage=bh.storage.double
     )
 
     r = np.zeros((4, 5, 6))


### PR DESCRIPTION
This enables profile histograms and sampled fills.

It also drops the required `()` after a storage (`storage=bh.storage.profile` is now valid, for example, instead of only `storage=bh.storage.profile()`).
