### PR TITLE
Python-ready repr

### DIFF
--- a/include/boost/histogram/python/axis_ostream.hpp
+++ b/include/boost/histogram/python/axis_ostream.hpp
@@ -1,0 +1,191 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+//
+// Based on boost/histogram/axis/ostream.hpp
+// String representations here evaluate correctly in Python.
+
+#pragma once
+
+#include <boost/assert.hpp>
+#include <boost/histogram/axis/regular.hpp>
+#include <boost/histogram/detail/cat.hpp>
+#include <boost/histogram/detail/static_if.hpp>
+#include <boost/histogram/detail/type_name.hpp>
+#include <boost/histogram/fwd.hpp>
+#include <boost/throw_exception.hpp>
+#include <iomanip>
+#include <iosfwd>
+#include <stdexcept>
+#include <type_traits>
+
+/**
+  \file boost/histogram/axis/ostream.hpp
+  Simple streaming operators for the builtin axis types.
+
+  The text representation is not guaranteed to be stable between versions of
+  Boost.Histogram. This header is only included by
+  [boost/histogram/ostream.hpp](histogram/reference.html#header.boost.histogram.ostream_hpp).
+  To you use your own, include your own implementation instead of this header and do not
+  include
+  [boost/histogram/ostream.hpp](histogram/reference.html#header.boost.histogram.ostream_hpp).
+ */
+
+namespace boost {
+namespace histogram {
+
+namespace detail {
+inline const char *axis_suffix(const axis::transform::id &) { return ""; }
+inline const char *axis_suffix(const axis::transform::log &) { return "_log"; }
+inline const char *axis_suffix(const axis::transform::sqrt &) { return "_sqrt"; }
+inline const char *axis_suffix(const axis::transform::pow &) { return "_pow"; }
+
+template <class OStream, class T>
+void stream_metadata(OStream &os, const T &t) {
+    detail::static_if<detail::is_streamable<T>>(
+        [&os](const auto &t) {
+            std::ostringstream oss;
+            oss << t;
+            if(!oss.str().empty()) {
+                os << ", metadata=" << std::quoted(oss.str());
+            }
+        },
+        [&os](const auto &) { os << ", metadata=" << detail::type_name<T>(); },
+        t);
+}
+
+template <class OStream>
+void stream_options(OStream &os, const unsigned bits) {
+    bool circular  = bits & axis::option::circular;
+    bool underflow = bits & axis::option::underflow;
+    bool overflow  = bits & axis::option::overflow;
+    bool growth    = bits & axis::option::growth;
+
+    // Axes types (circular) that have a single flow bin should report flow=False if turned off
+    // But currently, flow=False is the only supported circular axis type
+    // if circular, then underflow = overflow = underflow && overflow;
+
+    if(circular)
+        return;
+    else if(growth)
+        os << ", growth=True";
+    else if(!underflow && !overflow)
+        os << ", flow=False";
+    else if(underflow && !overflow)
+        os << ", overflow=False";
+    else if(!underflow && overflow)
+        os << ", underflow=False";
+}
+
+template <class OStream, class T>
+void stream_transform(OStream &, const T &) {}
+
+template <class OStream>
+void stream_transform(OStream &os, const axis::transform::pow &t) {
+    os << ", power=" << t.power;
+}
+
+template <class OStream, class T>
+void stream_value(OStream &os, const T &t) {
+    os << t;
+}
+
+template <class OStream, class... Ts>
+void stream_value(OStream &os, const std::basic_string<Ts...> &t) {
+    os << std::quoted(t);
+}
+
+} // namespace detail
+
+namespace axis {
+
+template <class T>
+class polymorphic_bin;
+
+template <class... Ts>
+std::basic_ostream<Ts...> &operator<<(std::basic_ostream<Ts...> &os, const null_type &) {
+    return os; // do nothing
+}
+
+template <class... Ts, class U>
+std::basic_ostream<Ts...> &operator<<(std::basic_ostream<Ts...> &os, const interval_view<U> &i) {
+    os << "[" << i.lower() << ", " << i.upper() << ")";
+    return os;
+}
+
+template <class... Ts, class U>
+std::basic_ostream<Ts...> &operator<<(std::basic_ostream<Ts...> &os, const polymorphic_bin<U> &i) {
+    if(i.is_discrete())
+        os << static_cast<double>(i);
+    else
+        os << "[" << i.lower() << ", " << i.upper() << ")";
+    return os;
+}
+
+template <class... Ts, class... Us>
+std::basic_ostream<Ts...> &operator<<(std::basic_ostream<Ts...> &os, const regular<Us...> &a) {
+    bool circular = a.options() & axis::option::circular;
+    os << (circular ? "circular" : "regular") << detail::axis_suffix(a.transform()) << "(" << a.size() << ", "
+       << a.value(0) << ", " << a.value(a.size());
+    detail::stream_metadata(os, a.metadata());
+    detail::stream_options(os, a.options());
+    detail::stream_transform(os, a.transform());
+    os << ")";
+    return os;
+}
+
+template <class... Ts, class... Us>
+std::basic_ostream<Ts...> &operator<<(std::basic_ostream<Ts...> &os, const integer<Us...> &a) {
+    os << "integer(" << a.value(0) << ", " << a.value(a.size());
+    detail::stream_metadata(os, a.metadata());
+    detail::stream_options(os, a.options());
+    os << ")";
+    return os;
+}
+
+template <class... Ts, class... Us>
+std::basic_ostream<Ts...> &operator<<(std::basic_ostream<Ts...> &os, const variable<Us...> &a) {
+    os << "variable([" << a.value(0);
+    for(index_type i = 1, n = a.size(); i <= n; ++i) {
+        os << ", " << a.value(i);
+    }
+    os << "]";
+    detail::stream_metadata(os, a.metadata());
+    detail::stream_options(os, a.options());
+    os << ")";
+    return os;
+}
+
+template <class... Ts, class... Us>
+std::basic_ostream<Ts...> &operator<<(std::basic_ostream<Ts...> &os, const category<Us...> &a) {
+    os << "category([";
+    for(index_type i = 0, n = a.size(); i < n; ++i) {
+        detail::stream_value(os, a.value(i));
+        os << (i == (a.size() - 1) ? "" : ", ");
+    }
+    os << "]";
+    detail::stream_metadata(os, a.metadata());
+    os << ")";
+    return os;
+}
+
+template <class... Ts, class... Us>
+std::basic_ostream<Ts...> &operator<<(std::basic_ostream<Ts...> &os, const variant<Us...> &v) {
+    visit(
+        [&os](const auto &x) {
+            using A = std::decay_t<decltype(x)>;
+            detail::static_if<detail::is_streamable<A>>([&os](const auto &x) { os << x; },
+                                                        [](const auto &) {
+                                                            BOOST_THROW_EXCEPTION(std::runtime_error(detail::cat(
+                                                                detail::type_name<A>(), " is not streamable")));
+                                                        },
+                                                        x);
+        },
+        v);
+    return os;
+}
+
+} // namespace axis
+} // namespace histogram
+} // namespace boost

--- a/include/boost/histogram/python/histogram_ostream.hpp
+++ b/include/boost/histogram/python/histogram_ostream.hpp
@@ -1,0 +1,27 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/accumulators/ostream.hpp>
+#include <boost/histogram/fwd.hpp>
+#include <boost/histogram/python/axis_ostream.hpp>
+#include <boost/histogram/python/storage.hpp>
+#include <iosfwd>
+
+namespace boost {
+namespace histogram {
+
+template <typename CharT, typename Traits, typename A, typename S>
+std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> &os, const histogram<A, S> &h) {
+    os << "histogram(";
+    h.for_each_axis([&](const auto &a) { os << "\n  " << a << ","; });
+    os << (h.rank() ? "\n  " : " ") << "storage=" << storage::name<S>();
+    os << (h.rank() ? "\n)" : ")");
+    return os;
+}
+
+} // namespace histogram
+} // namespace boost

--- a/include/boost/histogram/python/register_axis.hpp
+++ b/include/boost/histogram/python/register_axis.hpp
@@ -7,9 +7,9 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
-#include <boost/histogram/axis/ostream.hpp>
 #include <boost/histogram/axis/traits.hpp>
 #include <boost/histogram/python/axis.hpp>
+#include <boost/histogram/python/axis_ostream.hpp>
 #include <boost/histogram/python/bin_setup.hpp>
 #include <boost/histogram/python/serializion.hpp>
 

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -11,11 +11,10 @@
 #include <boost/histogram/algorithm/project.hpp>
 #include <boost/histogram/algorithm/reduce.hpp>
 #include <boost/histogram/algorithm/sum.hpp>
-#include <boost/histogram/axis/ostream.hpp>
 #include <boost/histogram/histogram.hpp>
-#include <boost/histogram/ostream.hpp>
 #include <boost/histogram/python/axis.hpp>
 #include <boost/histogram/python/histogram.hpp>
+#include <boost/histogram/python/histogram_ostream.hpp>
 #include <boost/histogram/python/indexed.hpp>
 #include <boost/histogram/python/kwargs.hpp>
 #include <boost/histogram/python/serializion.hpp>

--- a/include/boost/histogram/python/storage.hpp
+++ b/include/boost/histogram/python/storage.hpp
@@ -24,4 +24,45 @@ using weight           = bh::weight_storage;
 using profile          = bh::profile_storage;
 using weighted_profile = bh::weighted_profile_storage;
 
+// Allow repr to show python name
+template <class S>
+inline const char *name() {
+    return "unknown";
+}
+
+template <>
+inline const char *name<int_>() {
+    return "int";
+}
+
+template <>
+inline const char *name<atomic_int>() {
+    return "atomic_int";
+}
+
+template <>
+inline const char *name<double_>() {
+    return "double";
+}
+
+template <>
+inline const char *name<unlimited>() {
+    return "unlimited";
+}
+
+template <>
+inline const char *name<weight>() {
+    return "weight";
+}
+
+template <>
+inline const char *name<profile>() {
+    return "profile";
+}
+
+template <>
+inline const char *name<weighted_profile>() {
+    return "weighted_profile";
+}
+
 } // namespace storage

--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -2,19 +2,8 @@
 
 set -evx
 
-CLANG_FORMAT=unibeautify/clang-format
-
-if [ -x "$(command -v clang-format)" ] ; then
-
-    clang-format --version
-    git ls-files -- '*.cpp' '*.hpp' '*.cu' '*.h' | xargs clang-format -style=file -sort-includes -i
-
-elif [ -x "$(command -v docker)" ] ; then
-
-    docker run -it --rm ${CLANG_FORMAT} --version
-    docker run -it --rm -v "$(pwd)":/workdir -w /workdir  ${CLANG_FORMAT} -style=file -sort-includes -i $(git ls-files -- '*.cpp' '*.hpp' '*.cu' '*.h')
-
-fi
+clang-format --version
+git ls-files -- '*.cpp' '*.hpp' '*.cu' '*.h' | xargs clang-format -style=file -sort-includes -i
 
 git diff --exit-code --color
 

--- a/tests/test_public_axis.py
+++ b/tests/test_public_axis.py
@@ -138,31 +138,25 @@ class TestRegular(Axis):
 
     def test_repr(self):
         ax = regular(4, 1.1, 2.2)
-        assert repr(ax) == "regular(4, 1.1, 2.2, options=underflow | overflow)"
+        assert repr(ax) == "regular(4, 1.1, 2.2)"
 
         ax = regular(4, 1.1, 2.2, metadata="ra")
-        assert (
-            repr(ax)
-            == 'regular(4, 1.1, 2.2, metadata="ra", options=underflow | overflow)'
-        )
+        assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra")'
 
         ax = regular(4, 1.1, 2.2, flow=False)
-        assert repr(ax) == "regular(4, 1.1, 2.2, options=none)"
+        assert repr(ax) == "regular(4, 1.1, 2.2, flow=False)"
 
         ax = regular(4, 1.1, 2.2, metadata="ra", flow=False)
-        assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra", options=none)'
+        assert repr(ax) == 'regular(4, 1.1, 2.2, metadata="ra", flow=False)'
 
         ax = regular_log(4, 1.1, 2.2)
-        assert repr(ax) == "regular_log(4, 1.1, 2.2, options=underflow | overflow)"
+        assert repr(ax) == "regular_log(4, 1.1, 2.2)"
 
         ax = regular_sqrt(3, 1.1, 2.2)
-        assert repr(ax) == "regular_sqrt(3, 1.1, 2.2, options=underflow | overflow)"
+        assert repr(ax) == "regular_sqrt(3, 1.1, 2.2)"
 
         ax = regular_pow(4, 1.1, 2.2, 0.5)
-        assert (
-            repr(ax)
-            == "regular_pow(4, 1.1, 2.2, options=underflow | overflow, power=0.5)"
-        )
+        assert repr(ax) == "regular_pow(4, 1.1, 2.2, power=0.5)"
 
     def test_getitem(self):
         v = [1.0, 1.25, 1.5, 1.75, 2.0]
@@ -297,21 +291,16 @@ class TestCircular(Axis):
 
     def test_repr(self):
         ax = circular(4, 1.1, 2.2)
-        assert repr(ax) == "regular(4, 1.1, 2.2, options=overflow | circular)"
+        assert repr(ax) == "circular(4, 1.1, 2.2)"
 
         ax = circular(4, 1.1, 2.2, metadata="hi")
-        assert (
-            repr(ax)
-            == 'regular(4, 1.1, 2.2, metadata="hi", options=overflow | circular)'
-        )
+        assert repr(ax) == 'circular(4, 1.1, 2.2, metadata="hi")'
 
         ax = circular(4, 2.0)
-        assert repr(ax) == "regular(4, 0, 2, options=overflow | circular)"
+        assert repr(ax) == "circular(4, 0, 2)"
 
         ax = circular(4, 2.0, metadata="hi")
-        assert (
-            repr(ax) == 'regular(4, 0, 2, metadata="hi", options=overflow | circular)'
-        )
+        assert repr(ax) == 'circular(4, 0, 2, metadata="hi")'
 
     def test_getitem(self):
         v = [1.0, 1.0 + 0.5 * np.pi, 1.0 + np.pi, 1.0 + 1.5 * np.pi, 1.0 + 2.0 * np.pi]
@@ -408,13 +397,10 @@ class TestVariable(Axis):
 
     def test_repr(self):
         ax = variable([-0.1, 0.2])
-        assert repr(ax) == "variable(-0.1, 0.2, options=underflow | overflow)"
+        assert repr(ax) == "variable([-0.1, 0.2])"
 
         ax = variable([-0.1, 0.2], metadata="hi")
-        assert (
-            repr(ax)
-            == 'variable(-0.1, 0.2, metadata="hi", options=underflow | overflow)'
-        )
+        assert repr(ax) == 'variable([-0.1, 0.2], metadata="hi")'
 
     def test_getitem(self):
         v = [-0.1, 0.2, 0.3]
@@ -514,16 +500,16 @@ class TestInteger:
 
     def test_repr(self):
         a = integer(-1, 1)
-        assert repr(a) == "integer(-1, 1, options=underflow | overflow)"
+        assert repr(a) == "integer(-1, 1)"
 
         a = integer(-1, 1, metadata="hi")
-        assert repr(a) == 'integer(-1, 1, metadata="hi", options=underflow | overflow)'
+        assert repr(a) == 'integer(-1, 1, metadata="hi")'
 
         a = integer(-1, 1, flow=False)
-        assert repr(a) == "integer(-1, 1, options=none)"
+        assert repr(a) == "integer(-1, 1, flow=False)"
 
         a = integer(-1, 1, growth=True)
-        assert repr(a) == "integer(-1, 1, options=growth)"
+        assert repr(a) == "integer(-1, 1, growth=True)"
 
     def test_label(self):
         a = integer(-1, 2, metadata="foo")
@@ -582,10 +568,13 @@ class TestCategory(Axis):
 
     def test_repr(self):
         ax = category([1, 2, 3])
-        assert repr(ax) == "category(1, 2, 3, options=overflow)"
+        assert repr(ax) == "category([1, 2, 3])"
 
         ax = category([1, 2, 3], metadata="hi")
-        assert repr(ax) == 'category(1, 2, 3, metadata="hi", options=overflow)'
+        assert repr(ax) == 'category([1, 2, 3], metadata="hi")'
+
+        ax = category(["1", "2", "3"], metadata="hi")
+        assert repr(ax) == 'category(["1", "2", "3"], metadata="hi")'
 
     def test_getitem(self):
         c = [1, 2, 3]

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -264,23 +264,9 @@ def test_repr():
     assert (
         hr
         == """histogram(
-  regular(3, 0, 1, options=underflow | overflow),
-  integer(0, 1, options=underflow | overflow),
-  0: 0
-  1: 0
-  2: 0
-  3: 0
-  4: 0
-  5: 0
-  6: 0
-  7: 0
-  8: 0
-  9: 0
-  10: 0
-  11: 0
-  12: 0
-  13: 0
-  14: 0
+  regular(3, 0, 1),
+  integer(0, 1),
+  storage=double
 )"""
     )
 


### PR DESCRIPTION
Fixes part of #90; the repr's are now stable and provide Python-ready syntax. This does not add a quick way to preview the contents of histograms or the bin edges, might be in a later PR.