### PR TITLE
Starting axis options

### DIFF
--- a/.ci/azure-setup.yml
+++ b/.ci/azure-setup.yml
@@ -5,13 +5,13 @@ steps:
 
 - script: .ci/macos-install-python.sh '$(python.version)'
   displayName: Install Python.org Python
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin')) 
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
 - task: UsePythonVersion@0
   inputs:
     versionSpec: '$(python.version)'
     architecture: '$(python.architecture)'
-  condition: and(succeeded(), ne(variables['Agent.OS'], 'Darwin')) 
+  condition: and(succeeded(), ne(variables['Agent.OS'], 'Darwin'))
 
 - script: |
     mkdir -p dist

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -6,7 +6,7 @@ steps:
     set DISTUTILS_USE_SDK=1
     python -m pip wheel . -w wheelhouse/
   displayName: 'Build wheel (Windows Python 2.7)'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['python.version'], '2.7')) 
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['python.version'], '2.7'))
 
 - script: |
     python -m pip wheel . -w wheelhouse/
@@ -38,4 +38,4 @@ steps:
     python -m pip install delocate
     /Library/Frameworks/Python.framework/Versions/$(python.version)/bin/delocate-wheel dist/$(package_name)*.whl
   displayName: 'Delocate wheels'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin')) 
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))

--- a/.ci/azure-test-pipeline.yml
+++ b/.ci/azure-test-pipeline.yml
@@ -13,18 +13,16 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-    - script: scripts/check_style_docker.sh
-      displayName: Check format
     - task: UsePythonVersion@0
       inputs:
         versionSpec: '3.7'
         architecture: 'x64'
-    - script: python -m pip install black
-      displayName: Install Python formatter
-    - script: python -m black .
-      displayName: Run Python formatter
+    - script: python -m pip install pre-commit
+      displayName: Install pre-commit
+    - script: pre-commit run --all
+      displayName: Run pre-commit
     - script: git diff --exit-code --color
-      displayName: Python format changes
+      displayName: Display format changes
 
 - job: LinuxSDist
   pool:

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@
 .ipynb_checkpoints
 /wheelhouse/*
 /dist/*
+*.mypy_cache
 
 # Other editor files
 *.swp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,17 @@
+
 repos:
 - repo: https://github.com/psf/black
   rev: stable
   hooks:
   - id: black
+- repo: local
+  hooks:
+  - id: docker-clang-format
+    name: Docker Clang Format
+    language: docker_image
+    types:
+    - c++
+    entry: unibeautify/clang-format:latest
+    args:
+    - -style=file
+    - -i

--- a/.pre-commit-nodocker.yaml
+++ b/.pre-commit-nodocker.yaml
@@ -16,12 +16,12 @@ repos:
   - id: check-yaml
 - repo: local
   hooks:
-  - id: docker-clang-format
-    name: Docker Clang Format
-    language: docker_image
+  - id: clang-format
+    name: Clang Format
+    language: system
     types:
     - c++
-    entry: unibeautify/clang-format:latest
+    entry: clang-format
     args:
     - -style=file
     - -i

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,7 @@ python:
   version: 3
   install:
     - requirements: docs/requirements.txt
-      
+
 
 # Currently, we do not build the package, so submodules are not needed.
 submodules:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ counts = hist.view()
     * `.view(flow=False)`: Get a view on the bin contents (with or without under/overflow bins)
     * `np.asarray(...)`: Get a view on the bin contents with under/overflow bins
     * `.axis(i)`: Get the `i`th axis
-    * `.at(i, j, ...)`: Get the bin contents as a location 
+    * `.at(i, j, ...)`: Get the bin contents as a location
     * `.sum()`: The total count of all bins
     * `.project(ax1, ax2, ...)`: Project down to listed axis (numbers)
     * `.reduce(ax, reduce_option, ...)`: shrink, rebin, or slice, or any combination
@@ -104,7 +104,7 @@ counts = hist.view()
         * `ind.centers()`: The centers of each bin
         * `ind.indices()`: A list of indices
 * Details
-    * Use `bh.histogram(..., storage=...)` to make a histogram (there are several different types) 
+    * Use `bh.histogram(..., storage=...)` to make a histogram (there are several different types)
     * Several common combinations are optimized, such as regular axes + int storage
 
 
@@ -136,7 +136,7 @@ Conda support is planned.
 
 #### Source builds
 
-For a source build, for example from an "sdist" package, the only requirements are a C++14 compatible compiler. If you are using Python 2.7 on Windows, you will need to use a recent version of Visual studio and force distutils to use it, or just upgrade to Python 3.6 or newer. Check the PyBind11 documentation for [more help](https://pybind11.readthedocs.io/en/stable/faq.html#working-with-ancient-visual-studio-2009-builds-on-windows). On some Linux systems, you may need to use a newer compiler than the one your distribution ships with. 
+For a source build, for example from an "sdist" package, the only requirements are a C++14 compatible compiler. If you are using Python 2.7 on Windows, you will need to use a recent version of Visual studio and force distutils to use it, or just upgrade to Python 3.6 or newer. Check the PyBind11 documentation for [more help](https://pybind11.readthedocs.io/en/stable/faq.html#working-with-ancient-visual-studio-2009-builds-on-windows). On some Linux systems, you may need to use a newer compiler than the one your distribution ships with.
 
 ## Developing
 

--- a/boost_histogram/axis.py
+++ b/boost_histogram/axis.py
@@ -1,19 +1,8 @@
-from ..core.axis import (
-    _make_regular,
-    regular_log,
-    regular_sqrt,
-    regular_pow,
-    circular,
-    _make_variable,
-    _make_integer,
-    _make_category,
-)
+from .core.axis import regular_log, regular_sqrt, regular_pow, circular
 
-from ..core import axis as ca
+from .core import axis as ca
 
-from . import options
-
-from ..utils import FactoryMeta
+from .utils import FactoryMeta
 
 regular = FactoryMeta(
     ca._make_regular,

--- a/boost_histogram/axis.py
+++ b/boost_histogram/axis.py
@@ -1,4 +1,4 @@
-from .core.axis import regular_log, regular_sqrt, regular_pow, circular
+from .core.axis import regular_log, regular_sqrt, regular_pow, circular, options
 
 from .core import axis as ca
 

--- a/boost_histogram/axis/options.py
+++ b/boost_histogram/axis/options.py
@@ -1,1 +1,0 @@
-from ..core.axis.options import none, underflow, overflow, circular, growth

--- a/docs/_src/images/axis_circular.tex
+++ b/docs/_src/images/axis_circular.tex
@@ -27,10 +27,10 @@
 \foreach \i in {0, 45, ..., 360} {
     \draw (\i:.75) -- (\i:.95);
 }
-\node at (0:.95) [right]  {$\pi/2$}; 
+\node at (0:.95) [right]  {$\pi/2$};
 \node at (90:.95) [above] {0, $2\pi$};
-\node at (180:.95) [left] {$\pi$}; 
-\node at (270:.95) [below] {$3\pi/3$}; 
+\node at (180:.95) [left] {$\pi$};
+\node at (270:.95) [below] {$3\pi/3$};
 \node at (0,-1.3) [below] {\verb|bh.axis.circular(8,0,2*np.pi)|};
 \end{tikzpicture}
 

--- a/docs/_src/images/axis_regular.tex
+++ b/docs/_src/images/axis_regular.tex
@@ -28,8 +28,8 @@
 \foreach \i in {0, .1, ..., 1.1} {
     \draw (\i,0) -- (\i,.2);
 }
-\node at (0,.2) [above] {0}; 
-\node at (.5,.2) [above] {0.5}; 
+\node at (0,.2) [above] {0};
+\node at (.5,.2) [above] {0.5};
 \node at (1,.2) [above] {1};
 \node at (.5,0) [below] {\verb|bh.axis.regular(10,0,1)|};
 \end{tikzpicture}

--- a/docs/_src/images/axis_variable.tex
+++ b/docs/_src/images/axis_variable.tex
@@ -28,9 +28,9 @@
 \foreach \i in {0, .3, .5, 1} {
     \draw (\i,0) -- (\i,.2);
 }
-\node at (0,.2) [above] {0}; 
-\node at (.3,.2) [above] {0.3}; 
-\node at (.5,.2) [above] {0.5}; 
+\node at (0,.2) [above] {0};
+\node at (.3,.2) [above] {0.3};
+\node at (.5,.2) [above] {0.5};
 \node at (1,.2) [above] {1};
 \node at (.5,0) [below] {\verb|bh.axis.variable([0,.3,.5,1])|};
 \end{tikzpicture}

--- a/docs/usage/comparison.rst
+++ b/docs/usage/comparison.rst
@@ -12,7 +12,7 @@ There are a few parts of the Boost.Histogram interface that are not bound. They 
 
 The call operator
    This is provided in C++ to allow single item filling, and was designed to mimic the
-   accumulator syntax used elsewhere in Boost. It also works nicely with some STL 
+   accumulator syntax used elsewhere in Boost. It also works nicely with some STL
    algorithms. It was not provided in Python because using call to modify an object
    is not common in Python, using call makes duck-typing more dangerous, and single-item
    fills are not encouraged in Python due to poor performance. The ``.fill`` method from
@@ -41,7 +41,7 @@ Additions
 
 Unified Histogram Indexing
    The Python bindings support UHI, a proposal to unify and simplify histogram indexing in Python.
-   
+
 Numpy compatibility
    The Python bindings do several things to simplify Numpy compatibility.
 

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -79,7 +79,7 @@ if you want to initialize the contents of every bin to a function, you could do:
    hist = bh.histogram(bh.axis.regular(10, 0.0, 1.0),
                        bh.axis.regular(10, 0, 10),
                        storage=bh.storage.double())
-   
+
    for ind in hist.indexed():
        ind.content = f(*ind.centers())
 

--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -85,7 +85,7 @@ py::array to_values_impl(const A &ax,
     for(auto i = -underflow; i < ax.size() + overflow; i++)
         result.mutable_at(static_cast<std::size_t>(i + underflow)) = ax.value(i);
 
-    return result;
+    return std::move(result);
 }
 
 template <class... Ts>
@@ -141,7 +141,7 @@ py::array to_centers(const A &ax) {
         return b.center();
     });
 
-    return result;
+    return std::move(result);
 }
 
 template <class A>

--- a/include/boost/histogram/python/register_axis.hpp
+++ b/include/boost/histogram/python/register_axis.hpp
@@ -31,7 +31,17 @@ using namespace std::literals;
 
 struct options {
     unsigned option;
-    bool none() const { return option == bh::axis::option::none; }
+
+    options(unsigned value)
+        : option(value) {}
+    options(bool uflow, bool oflow, bool circ, bool grow)
+        : option(
+            uflow * bh::axis::option::underflow | oflow * bh::axis::option::overflow
+            | circ * bh::axis::option::circular | grow * bh::axis::option::growth) {}
+
+    bool operator==(const options &other) const { return option == other.option; }
+    bool operator!=(const options &other) const { return option != other.option; }
+
     bool underflow() const {
         return static_cast<bool>(option & bh::axis::option::underflow);
     }

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -9,7 +9,6 @@ void register_version(py::module &);
 void register_algorithms(py::module &);
 void register_storages(py::module &);
 void register_axes(py::module &);
-void register_axes_options(py::module &);
 void register_polymorphic_bin(py::module &);
 void register_general_histograms(py::module &);
 void register_make_histogram(py::module &, py::module &);
@@ -21,9 +20,7 @@ PYBIND11_MODULE(core, m) {
     py::module storage = m.def_submodule("storage");
     register_storages(storage);
 
-    py::module ax  = m.def_submodule("axis");
-    py::module opt = ax.def_submodule("options");
-    register_axes_options(opt);
+    py::module ax = m.def_submodule("axis");
     register_axes(ax);
     register_polymorphic_bin(ax);
 

--- a/src/register_axis.cpp
+++ b/src/register_axis.cpp
@@ -26,6 +26,10 @@ void register_axes(py::module &ax) {
                             return options{py::cast<unsigned>(t[0])};
                         }))
 
+        .def("__copy__", [](const options &self) { return options(self); })
+        .def("__deepcopy__",
+             [](const options &self, py::object) { return options{self}; })
+
         .def_property_readonly("underflow", &options::underflow)
         .def_property_readonly("overflow", &options::overflow)
         .def_property_readonly("circular", &options::circular)

--- a/src/register_axis.cpp
+++ b/src/register_axis.cpp
@@ -10,19 +10,22 @@
 #include <boost/histogram/python/register_axis.hpp>
 #include <vector>
 
-void register_axes_options(py::module &opt) {
-    opt.attr("none")      = (unsigned)bh::axis::option::none;
-    opt.attr("underflow") = (unsigned)bh::axis::option::underflow;
-    opt.attr("overflow")  = (unsigned)bh::axis::option::overflow;
-    opt.attr("circular")  = (unsigned)bh::axis::option::circular;
-    opt.attr("growth")    = (unsigned)bh::axis::option::growth;
-}
-
 void register_axes(py::module &ax) {
-    // This factory makes a class that can be used to create axes and also be used in
-    // is_instance
-    py::object factory_meta_py
-        = py::module::import("boost_histogram.utils").attr("FactoryMeta");
+    py::class_<options>(ax, "options")
+        .def_property_readonly("none", &options::none)
+        .def_property_readonly("underflow", &options::underflow)
+        .def_property_readonly("overflow", &options::overflow)
+        .def_property_readonly("circular", &options::circular)
+        .def_property_readonly("growth", &options::growth)
+        .def("__repr__", [](const options &self) {
+            return py::str("options(none={}, underflow={}, overflow={}, circular={}, "
+                           "growth={})")
+                .format(self.none(),
+                        self.underflow(),
+                        self.overflow(),
+                        self.circular(),
+                        self.growth());
+        });
 
     register_axis<axis::_regular_uoflow>(ax, "_regular_uoflow", "Evenly spaced bins")
         .def(construct_axes<axis::_regular_uoflow, unsigned, double, double>(),

--- a/src/register_axis.cpp
+++ b/src/register_axis.cpp
@@ -12,19 +12,29 @@
 
 void register_axes(py::module &ax) {
     py::class_<options>(ax, "options")
-        .def_property_readonly("none", &options::none)
+        .def(py::init<bool, bool, bool, bool>(),
+             "underflow"_a = false,
+             "overflow"_a  = false,
+             "circular"_a  = false,
+             "growth"_a    = false)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def(py::pickle([](const options &op) { return py::make_tuple(op.option); },
+                        [](py::tuple t) {
+                            if(t.size() != 1)
+                                throw std::runtime_error("Invalid state");
+                            return options{py::cast<unsigned>(t[0])};
+                        }))
+
         .def_property_readonly("underflow", &options::underflow)
         .def_property_readonly("overflow", &options::overflow)
         .def_property_readonly("circular", &options::circular)
         .def_property_readonly("growth", &options::growth)
+
         .def("__repr__", [](const options &self) {
-            return py::str("options(none={}, underflow={}, overflow={}, circular={}, "
-                           "growth={})")
-                .format(self.none(),
-                        self.underflow(),
-                        self.overflow(),
-                        self.circular(),
-                        self.growth());
+            return py::str("options(underflow={}, overflow={}, circular={}, growth={})")
+                .format(
+                    self.underflow(), self.overflow(), self.circular(), self.growth());
         });
 
     register_axis<axis::_regular_uoflow>(ax, "_regular_uoflow", "Evenly spaced bins")

--- a/tests/test_axis_internal.py
+++ b/tests/test_axis_internal.py
@@ -42,28 +42,28 @@ def test_axis_regular_extents():
     assert 11 == len(ax.edges())
     assert 13 == len(ax.edges(True))
     assert 10 == len(ax.centers())
-    assert ax.options() == bh.axis.options.underflow | bh.axis.options.overflow
+    assert ax.options == bh.axis.options(underflow=True, overflow=True)
 
     ax = bh.axis.regular(10, 0, 1, overflow=False)
     assert 11 == ax.extent
     assert 11 == len(ax.edges())
     assert 12 == len(ax.edges(True))
     assert 10 == len(ax.centers())
-    assert ax.options() == bh.axis.options.underflow
+    assert ax.options == bh.axis.options(underflow=True)
 
     ax = bh.axis.regular(10, 0, 1, underflow=False)
     assert 11 == ax.extent
     assert 11 == len(ax.edges())
     assert 12 == len(ax.edges(True))
     assert 10 == len(ax.centers())
-    assert ax.options() == bh.axis.options.overflow
+    assert ax.options == bh.axis.options(overflow=True)
 
     ax = bh.axis.regular(10, 0, 1, flow=False)
     assert 10 == ax.extent
     assert 11 == len(ax.edges())
     assert 11 == len(ax.edges(True))
     assert 10 == len(ax.centers())
-    assert ax.options() == bh.axis.options.none
+    assert ax.options == bh.axis.options()
 
 
 def test_axis_growth():
@@ -103,7 +103,7 @@ def test_axis_circular():
     ax = bh.axis.circular(10, 0, 1)
 
     assert 0.1 == ax.value(1)
-    assert ax.options() == bh.axis.options.circular | bh.axis.options.overflow
+    assert ax.options == bh.axis.options(circular=True, overflow=True)
 
 
 normal_axs = [

--- a/tests/test_axis_options.py
+++ b/tests/test_axis_options.py
@@ -1,0 +1,28 @@
+from boost_histogram.axis import options
+
+
+def test_compare():
+    assert options() == options()
+    assert options(underflow=True) == options(underflow=True)
+    assert options(overflow=True) == options(overflow=True)
+    assert options(circular=True) == options(circular=True)
+    assert options(growth=True) == options(growth=True)
+    assert options(underflow=True, overflow=True) == options(
+        underflow=True, overflow=True
+    )
+
+
+def test_each():
+    o = options()
+
+    assert not o.underflow
+    assert not o.overflow
+    assert not o.circular
+    assert not o.growth
+
+    o = options(underflow=True, overflow=True)
+
+    assert o.underflow
+    assert o.overflow
+    assert not o.circular
+    assert not o.growth

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -37,6 +37,16 @@ storages = (
 )
 
 
+@pytest.mark.parametrize("copy_fn", copies)
+@pytest.mark.parametrize(
+    "opts", ({}, {"growth": True}, {"underflow": True, "overflow": True})
+)
+def test_options(copy_fn, opts):
+    orig = bh.axis.options(**opts)
+    new = copy_fn(orig)
+    assert new == orig
+
+
 @pytest.mark.parametrize("accum,args", accumulators)
 @pytest.mark.parametrize("copy_fn", copies)
 def test_accumulators(accum, args, copy_fn):

--- a/tests/test_public_axis.py
+++ b/tests/test_public_axis.py
@@ -2,7 +2,7 @@ import pytest
 from pytest import approx
 
 import boost_histogram.core.axis as _bha
-import boost_histogram.axis.options as bhao
+from boost_histogram.axis import options
 
 from boost_histogram.axis import (
     regular,
@@ -65,37 +65,37 @@ class TestRegular(Axis):
         ax = regular(1, 2, 3)
         assert isinstance(regular(1, 2, 3), regular)
         assert isinstance(ax, _bha._regular_uoflow)
-        assert ax.options() == bhao.underflow | bhao.overflow
+        assert ax.options == options(underflow=True, overflow=True)
 
         ax = regular(1, 2, 3, overflow=False)
         assert isinstance(ax, regular)
         assert isinstance(ax, _bha._regular_uflow)
-        assert ax.options() == bhao.underflow
+        assert ax.options == options(underflow=True)
 
         ax = regular(1, 2, 3, underflow=False)
         assert isinstance(ax, regular)
         assert isinstance(ax, _bha._regular_oflow)
-        assert ax.options() == bhao.overflow
+        assert ax.options == options(overflow=True)
 
         ax = regular(1, 2, 3, flow=False)
         assert isinstance(ax, regular)
         assert isinstance(ax, _bha._regular_noflow)
-        assert ax.options() == bhao.none
+        assert ax.options == options()
 
         ax = regular(1, 2, 3, underflow=False, overflow=False)
         assert isinstance(ax, regular)
         assert isinstance(ax, _bha._regular_noflow)
-        assert ax.options() == bhao.none
+        assert ax.options == options()
 
         ax = regular(1, 2, 3, underflow=False, overflow=False, flow=True)
         assert isinstance(ax, regular)
         assert isinstance(ax, _bha._regular_uoflow)
-        assert ax.options() == bhao.underflow | bhao.overflow
+        assert ax.options == options(underflow=True, overflow=True)
 
         ax = regular(1, 2, 3, growth=True)
         assert isinstance(ax, regular)
         assert isinstance(ax, _bha._regular_growth)
-        assert ax.options() == bhao.growth
+        assert ax.options == options(growth=True)
 
     def test_init(self):
         # Should not throw
@@ -366,32 +366,32 @@ class TestVariable(Axis):
         ax = variable([1, 2, 3])
         assert isinstance(ax, variable)
         assert isinstance(ax, _bha._variable_uoflow)
-        assert ax.options() == bhao.underflow | bhao.overflow
+        assert ax.options == options(underflow=True, overflow=True)
 
         ax = variable([1, 2, 3], overflow=False)
         assert isinstance(ax, variable)
         assert isinstance(ax, _bha._variable_uflow)
-        assert ax.options() == bhao.underflow
+        assert ax.options == options(underflow=True)
 
         ax = variable([1, 2, 3], underflow=False)
         assert isinstance(ax, variable)
         assert isinstance(ax, _bha._variable_oflow)
-        assert ax.options() == bhao.overflow
+        assert ax.options == options(overflow=True)
 
         ax = variable([1, 2, 3], flow=False)
         assert isinstance(ax, variable)
         assert isinstance(ax, _bha._variable_noflow)
-        assert ax.options() == bhao.none
+        assert ax.options == options()
 
         ax = variable([1, 2, 3], underflow=False, overflow=False)
         assert isinstance(ax, variable)
         assert isinstance(ax, _bha._variable_noflow)
-        assert ax.options() == bhao.none
+        assert ax.options == options()
 
         ax = variable([1, 2, 3], underflow=False, overflow=False, flow=True)
         assert isinstance(ax, variable)
         assert isinstance(ax, _bha._variable_uoflow)
-        assert ax.options() == bhao.underflow | bhao.overflow
+        assert ax.options == options(underflow=True, overflow=True)
 
     def test_init(self):
         variable([0, 1])
@@ -476,37 +476,37 @@ class TestInteger:
         ax = integer(1, 3)
         assert isinstance(ax, integer)
         assert isinstance(ax, _bha._integer_uoflow)
-        assert ax.options() == bhao.underflow | bhao.overflow
+        assert ax.options == options(underflow=True, overflow=True)
 
         ax = integer(1, 3, overflow=False)
         assert isinstance(ax, integer)
         assert isinstance(ax, _bha._integer_uflow)
-        assert ax.options() == bhao.underflow
+        assert ax.options == options(underflow=True)
 
         ax = integer(1, 3, underflow=False)
         assert isinstance(ax, integer)
         assert isinstance(ax, _bha._integer_oflow)
-        assert ax.options() == bhao.overflow
+        assert ax.options == options(overflow=True)
 
         ax = integer(1, 3, flow=False)
         assert isinstance(ax, integer)
         assert isinstance(ax, _bha._integer_noflow)
-        assert ax.options() == bhao.none
+        assert ax.options == options()
 
         ax = integer(1, 3, underflow=False, overflow=False)
         assert isinstance(ax, integer)
         assert isinstance(ax, _bha._integer_noflow)
-        assert ax.options() == bhao.none
+        assert ax.options == options()
 
         ax = integer(1, 3, underflow=False, overflow=False, flow=True)
         assert isinstance(ax, integer)
         assert isinstance(ax, _bha._integer_uoflow)
-        assert ax.options() == bhao.underflow | bhao.overflow
+        assert ax.options == options(underflow=True, overflow=True)
 
         ax = integer(1, 3, growth=True)
         assert isinstance(ax, integer)
         assert isinstance(ax, _bha._integer_growth)
-        assert ax.options() == bhao.growth
+        assert ax.options == options(growth=True)
 
     def test_init(self):
         integer(-1, 2, flow=True)
@@ -605,22 +605,22 @@ class TestCategory(Axis):
         ax = category([1, 2, 3])
         assert isinstance(ax, category)
         assert isinstance(ax, _bha._category_int)
-        assert ax.options() == bhao.overflow
+        assert ax.options == options(overflow=True)
 
         ax = category([1, 2, 3], growth=True)
         assert isinstance(ax, category)
         assert isinstance(ax, _bha._category_int_growth)
-        assert ax.options() == bhao.growth
+        assert ax.options == options(growth=True)
 
         ax = category(["1", "2", "3"])
         assert isinstance(ax, category)
         assert isinstance(ax, _bha._category_str)
-        assert ax.options() == bhao.overflow
+        assert ax.options == options(overflow=True)
 
         ax = category(["1", "2", "3"], growth=True)
         assert isinstance(ax, category)
         assert isinstance(ax, _bha._category_str_growth)
-        assert ax.options() == bhao.growth
+        assert ax.options == options(growth=True)
 
     def test_len(self):
         assert category([1, 2, 3]).size == 3


### PR DESCRIPTION
Something like this is what I'm thinking. I'm not fond of namedtuple for this use case due to *some* of the reasons listed [here](http://www.attrs.org/en/stable/why.html#namedtuples), though the current design I've used is similar and could switch to using them. I can't think of anywhere in the standard library they are used like this; normally the Python standard library would use a [SimpleNamespace](https://docs.python.org/3/library/types.html#types.SimpleNamespace), but that's Python 3.3+ only.

NamedTuples are good for functions that return multiple values and maintaining backward compatibility, but they are inherently structured, so support unpacking, comparing, iteration, etc. They are also almost the only place in Python where `_X` names are not intended to be private (due to potential clashes with possible names)!

Needs test changes, etc.

Issues/changes:
* this is no longer static, since properties are usually only available on instances (`ax.__class__.options.overflow` does not work while the equivalent did before)
* this does not trigger the auto completion in iPython (`ax.options.<tab>`), since it is dynamic