### PR TITLE
Move make functions to Python, keyword only

### DIFF
--- a/boost_histogram/axis.py
+++ b/boost_histogram/axis.py
@@ -2,21 +2,77 @@ from .core.axis import regular_log, regular_sqrt, regular_pow, circular, options
 
 from .core import axis as ca
 
-from .utils import FactoryMeta
+from .utils import FactoryMeta, KWArgs
+
+
+# When Python 2 is dropped, this could use keyword
+# only argument syntax instead of kwargs
+def _make_regular(bins, start, stop, **kwargs):
+    """
+    Make a regular axis with nice keyword arguments for underflow,
+    overflow, and growth.
+    """
+    with KWArgs(kwargs) as k:
+        metadata = k.optional("metadata")
+        options = k.options(underflow=True, overflow=True, growth=False, circular=False)
+
+    if options == {"growth", "underflow", "overflow"}:
+        return ca._regular_uoflow_growth(bins, start, stop, metadata)
+    elif options == {"underflow", "overflow"}:
+        return ca._regular_uoflow(bins, start, stop, metadata)
+    elif options == {"underflow"}:
+        return ca._regular_uflow(bins, start, stop, metadata)
+    elif options == {"overflow"}:
+        return ca._regular_oflow(bins, start, stop, metadata)
+    elif options == {"circular", "underflow", "overflow"}:
+        return circular(bins, start, stop, metadata)
+    elif options == set():
+        return ca._regular_none(bins, start, stop, metadata)
+    else:
+        raise KeyError("Unsupported collection of options")
+
 
 regular = FactoryMeta(
-    ca._make_regular,
+    _make_regular,
     (
         ca._regular_none,
         ca._regular_uflow,
         ca._regular_oflow,
         ca._regular_uoflow,
         ca._regular_uoflow_growth,
+        regular_log,
+        regular_sqrt,
+        regular_pow,
+        circular,
     ),
 )
 
+
+def _make_variable(edges, **kwargs):
+    """
+    Make a variable axis with nice keyword arguments for underflow,
+    overflow, and growth.
+    """
+    with KWArgs(kwargs) as k:
+        metadata = k.optional("metadata")
+        options = k.options(underflow=True, overflow=True, growth=False)
+
+    if options == {"growth", "underflow", "overflow"}:
+        return ca._variable_uoflow_growth(edges, metadata)
+    elif options == {"underflow", "overflow"}:
+        return ca._variable_uoflow(edges, metadata)
+    elif options == {"underflow"}:
+        return ca._variable_uflow(edges, metadata)
+    elif options == {"overflow"}:
+        return ca._variable_oflow(edges, metadata)
+    elif options == set():
+        return ca._variable_none(edges, metadata)
+    else:
+        raise KeyError("Unsupported collection of options")
+
+
 variable = FactoryMeta(
-    ca._make_variable,
+    _make_variable,
     (
         ca._variable_none,
         ca._variable_uflow,
@@ -26,8 +82,34 @@ variable = FactoryMeta(
     ),
 )
 
+
+def _make_integer(start, stop, **kwargs):
+    """
+    Make an integer axis with nice keyword arguments for underflow,
+    overflow, and growth.
+    """
+    with KWArgs(kwargs) as k:
+        metadata = k.optional("metadata")
+        options = k.options(underflow=True, overflow=True, growth=False)
+
+    # underflow and overflow settings are ignored, integers are always
+    # finite and thus cannot end up in a flow bin when growth is on
+    if "growth" in options and "circular" not in options:
+        return ca._integer_growth(start, stop, metadata)
+    elif options == {"underflow", "overflow"}:
+        return ca._integer_uoflow(start, stop, metadata)
+    elif options == {"underflow"}:
+        return ca._integer_uflow(start, stop, metadata)
+    elif options == {"overflow"}:
+        return ca._integer_oflow(start, stop, metadata)
+    elif options == set():
+        return ca._integer_none(start, stop, metadata)
+    else:
+        raise KeyError("Unsupported collection of options")
+
+
 integer = FactoryMeta(
-    ca._make_integer,
+    _make_integer,
     (
         ca._integer_none,
         ca._integer_uflow,
@@ -37,8 +119,35 @@ integer = FactoryMeta(
     ),
 )
 
+
+def _make_category(categories, **kwargs):
+    """
+    Make a category axis with ints or strings and with nice keyword
+    arguments for growth.
+    """
+    with KWArgs(kwargs) as k:
+        metadata = k.optional("metadata")
+        options = k.options(growth=False)
+
+    if isinstance(categories, str):
+        categories = list(categories)
+
+    if options == {"growth"}:
+        try:
+            return ca._category_int_growth(categories, metadata)
+        except TypeError:
+            return ca._category_str_growth(categories, metadata)
+    elif options == set():
+        try:
+            return ca._category_int(categories, metadata)
+        except TypeError:
+            return ca._category_str(categories, metadata)
+    else:
+        raise KeyError("Unsupported collection of options")
+
+
 category = FactoryMeta(
-    ca._make_category,
+    _make_category,
     (
         ca._category_int,
         ca._category_int_growth,
@@ -47,4 +156,4 @@ category = FactoryMeta(
     ),
 )
 
-del ca, FactoryMeta
+del FactoryMeta

--- a/boost_histogram/utils.py
+++ b/boost_histogram/utils.py
@@ -36,3 +36,30 @@ project = _project
 def indexed(histogram, flow=False):
     """Set up an iterator, returns a special accessor for bin info and content."""
     return histogram.indexed(flow=flow)
+
+
+class KWArgs(object):
+    def __init__(self, kwargs):
+        self.kwargs = kwargs
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        if self.kwargs:
+            raise TypeError("Keyword(s) {} not expected".format(", ".join(self.kwargs)))
+
+    def required(self, name):
+        if name in self.kwargs:
+            self.kwargs.pop(name)
+        else:
+            raise KeyError("{0} is required".format(name))
+
+    def optional(self, name, default=None):
+        if name in self.kwargs:
+            return self.kwargs.pop(name)
+        else:
+            return default
+
+    def options(self, **options):
+        return {option for option in options if self.optional(option, options[option])}

--- a/include/boost/histogram/python/kwargs.hpp
+++ b/include/boost/histogram/python/kwargs.hpp
@@ -41,7 +41,7 @@ inline void finalize_args(const py::kwargs &kwargs) {
     if(kwargs.size() > 0) {
         std::stringstream out;
         for(const auto &item : kwargs) {
-            out << " " << item.first;
+            out << ", " << item.first;
         }
         throw py::key_error("Unidentfied keywords found:" + out.str());
     }

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -510,7 +510,6 @@ class TestInteger:
     def test_init(self):
         integer(-1, 2)
         integer(-1, 2, metadata="foo")
-        integer(-1, 2, "foo")
         integer(-1, 2, underflow=False)
         integer(-1, 2, underflow=False, overflow=False)
         integer(-1, 2, growth=True)
@@ -523,6 +522,10 @@ class TestInteger:
             integer("1", 2)
         with pytest.raises(ValueError):
             integer(2, -1)
+        with pytest.raises(TypeError):
+            integer(-1, 2, "foo")
+        with pytest.raises(TypeError):
+            integer(20, 30, 40)
 
         ax = integer(1, 3)
         assert isinstance(ax, integer)
@@ -621,15 +624,18 @@ class TestCategory(Axis):
         # should not raise
         category([1, 2])
         category((1, 2), metadata="foo")
-        category([1, 2], "foo")
         category(["A", "B"])
         category("AB")
         category("AB", metadata="foo")
-        category("AB", "foo")
+
+        with pytest.raises(TypeError):
+            category([1, 2], "foo")
+        with pytest.raises(TypeError):
+            category("AB", "foo")
 
         with pytest.raises(TypeError):
             category()
-        with pytest.raises(RuntimeError):
+        with pytest.raises(TypeError):
             category([1, "2"])
         with pytest.raises(TypeError):
             category([1, 2, 3], underflow=True)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -56,26 +56,26 @@ def test_accumulators(accum, args, copy_fn):
 
 
 axes_creations = (
-    (bh.core.axis._regular_none, (4, 2, 4, None)),
-    (bh.core.axis._regular_uoflow, (4, 2, 4, None)),
-    (bh.core.axis._regular_uoflow_growth, (4, 2, 4, None)),
-    (bh.axis.regular_log, (4, 2, 4, None)),
-    (bh.axis.regular_sqrt, (4, 2, 4, None)),
-    (bh.axis.regular_pow, (4, 2, 4, 0.5, None)),
-    (bh.axis.circular, (4, 2, 4, None)),
-    (bh.axis.variable, ([1, 2, 3, 4], None)),
-    (bh.core.axis._integer_uoflow, (1, 4, None)),
-    (bh.core.axis._category_int, ([1, 2, 3], None)),
-    (bh.core.axis._category_int_growth, ([1, 2, 3], None)),
-    (bh.core.axis._category_str, (["1", "2", "3"], None)),
-    (bh.core.axis._category_str_growth, (["1", "2", "3"], None)),
+    (bh.core.axis._regular_none, (4, 2, 4)),
+    (bh.core.axis._regular_uoflow, (4, 2, 4)),
+    (bh.core.axis._regular_uoflow_growth, (4, 2, 4)),
+    (bh.axis.regular_log, (4, 2, 4)),
+    (bh.axis.regular_sqrt, (4, 2, 4)),
+    (bh.axis.regular_pow, (4, 2, 4, 0.5)),
+    (bh.axis.circular, (4, 2, 4)),
+    (bh.axis.variable, ([1, 2, 3, 4],)),
+    (bh.core.axis._integer_uoflow, (1, 4)),
+    (bh.core.axis._category_int, ([1, 2, 3],)),
+    (bh.core.axis._category_int_growth, ([1, 2, 3],)),
+    (bh.core.axis._category_str, (["1", "2", "3"],)),
+    (bh.core.axis._category_str_growth, (["1", "2", "3"],)),
 )
 
 
 @pytest.mark.parametrize("axis,args", axes_creations)
 @pytest.mark.parametrize("copy_fn", copies)
 def test_axes(axis, args, copy_fn):
-    orig = axis(*args)
+    orig = axis(*args, metadata=None)
     new = copy_fn(orig)
     assert new == orig
 
@@ -83,8 +83,7 @@ def test_axes(axis, args, copy_fn):
 @pytest.mark.parametrize("axis,args", axes_creations)
 @pytest.mark.parametrize("copy_fn", copies)
 def test_metadata_str(axis, args, copy_fn):
-    orig = axis(*args)
-    orig.metadata = "foo"
+    orig = axis(*args, metadata="foo")
     new = copy_fn(orig)
     assert new.metadata == orig.metadata
     new.metadata = orig.metadata
@@ -118,8 +117,7 @@ def test_compare_copy_hist(metadata):
 @pytest.mark.parametrize("axis,args", axes_creations)
 @pytest.mark.parametrize("copy_fn", copies)
 def test_metadata_any(axis, args, copy_fn):
-    orig = axis(*args)
-    orig.metadata = (1, 2, 3)
+    orig = axis(*args, metadata=(1, 2, 3))
     new = copy_fn(orig)
     assert new.metadata == orig.metadata
     new.metadata = orig.metadata


### PR DESCRIPTION
All arguments are now keyword only, except the basic ones unique to an axis type. The creation functions are now written in Python. The axis init c++ function is now able to add init arguments like arguments names. All creation functions support keyword arguments now, including private ones.

Not that direct axis creation, like `regular_*`, still allow metadata to be passed by position for now. Help and signature are not ideal yet.