### PR TITLE
Adding accumulator fill and kw arguments

### DIFF
--- a/src/register_accumulators.cpp
+++ b/src/register_accumulators.cpp
@@ -10,8 +10,46 @@
 #include <boost/histogram/accumulators/sum.hpp>
 #include <boost/histogram/accumulators/weighted_mean.hpp>
 #include <boost/histogram/accumulators/weighted_sum.hpp>
+#include <boost/histogram/python/kwargs.hpp>
 #include <boost/histogram/python/register_accumulator.hpp>
 #include <pybind11/operators.h>
+
+/// The mean fill can be implemented once. (sum fill varies slightly)
+template <class T>
+decltype(auto) make_mean_fill() {
+    return [](T &self, py::object value, py::kwargs kwargs) {
+        py::object weight = optional_arg(kwargs, "weight", py::none());
+        finalize_args(kwargs);
+        if(weight.is_none()) {
+            py::vectorize([](T &self, double val) {
+                self(val);
+                return false;
+            })(self, value);
+        } else {
+            py::vectorize([](T &self, double wei, double val) {
+                self(wei, val);
+                return false;
+            })(self, weight, value);
+        }
+        return self;
+    };
+}
+
+/// The mean call can be implemented once. (sum uses +=)
+template <class T>
+decltype(auto) make_mean_call() {
+    return [](T &self, double value, py::kwargs kwargs) {
+        py::object weight = optional_arg(kwargs, "weight", py::none());
+        finalize_args(kwargs);
+
+        if(weight.is_none())
+            self(value);
+        else
+            self(py::cast<double>(weight), value);
+
+        return self;
+    };
+}
 
 void register_accumulators(py::module &accumulators) {
     using weighted_sum = bh::accumulators::weighted_sum<double>;
@@ -26,6 +64,27 @@ void register_accumulators(py::module &accumulators) {
 
         .def(py::self += double())
 
+        .def(
+            "fill",
+            [](weighted_sum &self, py::object value, py::kwargs kwargs) {
+                py::object variance = optional_arg(kwargs, "variance", py::none());
+                finalize_args(kwargs);
+                if(variance.is_none()) {
+                    py::vectorize([](weighted_sum &self, double val) {
+                        self += val;
+                        return false;
+                    })(self, value);
+                } else {
+                    py::vectorize([](weighted_sum &self, double val, double var) {
+                        self += weighted_sum(val, var);
+                        return false;
+                    })(self, value, variance);
+                }
+                return self;
+            },
+            "value"_a,
+            "Fill the accumulator with values. Optional variance parameter.")
+
         ;
 
     using sum = bh::accumulators::sum<double>;
@@ -37,6 +96,19 @@ void register_accumulators(py::module &accumulators) {
             "value", &sum::operator double, [](sum &s, double v) { s = v; })
 
         .def(py::self += double())
+
+        .def(
+            "fill",
+            [](sum &self, py::object value) {
+                py::vectorize([](sum &self, double v) {
+                    self += v;
+                    return false; // Required in PyBind11 2.4.2,
+                                  // requirement may be removed
+                })(self, value);
+                return self;
+            },
+            "value"_a,
+            "Run over an array with the accumulator")
 
         .def_property_readonly("small", &sum::small)
         .def_property_readonly("large", &sum::large)
@@ -56,21 +128,15 @@ void register_accumulators(py::module &accumulators) {
         .def_property_readonly("variance", &weighted_mean::variance)
         .def_property_readonly("value", &weighted_mean::value)
 
-        .def(
-            "__call__",
-            [](weighted_mean &self, double value) {
-                self(value);
-                return self;
-            },
-            "value"_a)
-        .def(
-            "__call__",
-            [](weighted_mean &self, double weight, double value) {
-                self(weight, value);
-                return self;
-            },
-            "weight"_a,
-            "value"_a)
+        .def("__call__",
+             make_mean_call<weighted_mean>(),
+             "value"_a,
+             "Fill with value and optional keyword-only weight")
+
+        .def("fill",
+             make_mean_fill<weighted_mean>(),
+             "value"_a,
+             "Fill the accumulator with values. Optional weight parameter.")
 
         ;
 
@@ -86,21 +152,15 @@ void register_accumulators(py::module &accumulators) {
         .def_property_readonly("variance", &mean::variance)
         .def_property_readonly("value", &mean::value)
 
-        .def(
-            "__call__",
-            [](mean &self, double value) {
-                self(value);
-                return self;
-            },
-            "value"_a)
-        .def(
-            "__call__",
-            [](mean &self, double weight, double value) {
-                self(weight, value);
-                return self;
-            },
-            "weight"_a,
-            "value"_a)
+        .def("__call__",
+             make_mean_call<mean>(),
+             "value"_a,
+             "Fill with value and optional keyword-only weight")
+
+        .def("fill",
+             make_mean_fill<mean>(),
+             "value"_a,
+             "Fill the accumulator with values. Optional weight parameter.")
 
         ;
 }

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -6,49 +6,74 @@ import numpy as np
 
 
 def test_weighted_sum():
-    v = bh.accumulators.weighted_sum(1.5, 2.5)
+    a = bh.accumulators.weighted_sum(1.5, 2.5)
 
-    assert v.value == 1.5
-    assert v.variance == 2.5
+    assert a.value == 1.5
+    assert a.variance == 2.5
 
-    v += 1.5
+    a += 1.5
 
-    assert v.value == 3.0
-    assert v.variance == 4.75
+    assert a.value == 3.0
+    assert a.variance == 4.75
 
-    v = bh.accumulators.weighted_sum()
-    for a, b in zip([1, 2, 3], [4, 5, 6]):
-        v += bh.accumulators.weighted_sum(a, b)
+    vals = [1, 2, 3]
+    vari = [4, 5, 6]
 
-    assert v.value == 6
-    assert v.variance == 15
+    a = bh.accumulators.weighted_sum()
+    for val, var in zip(vals, vari):
+        a += bh.accumulators.weighted_sum(val, variance=var)
 
+    assert a.value == 6
+    assert a.variance == 15
 
-def test_weighted_mean():
-    v = bh.accumulators.weighted_mean()
-    v(1, 4)
-    v(2, 1)
+    a2 = bh.accumulators.weighted_sum().fill(vals, variance=vari)
+    assert a == a2
 
-    assert v.sum_of_weights == 3.0
-    assert v.variance == 4.5
-    assert v.value == 2.0
-
-
-def test_mean():
-    v = bh.accumulators.mean()
-    v(1)
-    v(2)
-    v(3)
-
-    assert v.count == 3
-    assert v.value == 2
-    assert v.variance == 1
+    assert a == bh.accumulators.weighted_sum(6, 15)
 
 
 def test_sum():
-    v = bh.accumulators.sum()
-    v += 1
-    v += 2
-    v += 3
+    vals = [1, 2, 3]
+    a = bh.accumulators.sum()
+    for val in vals:
+        a += val
 
-    assert v.value == 6
+    assert a.value == 6
+
+    a2 = bh.accumulators.sum().fill(vals)
+    assert a == a2
+
+    assert a == bh.accumulators.sum(6)
+
+
+def test_weighted_mean():
+    vals = [4, 1]
+    weights = [1, 2]
+    a = bh.accumulators.weighted_mean()
+    for v, w in zip(vals, weights):
+        a(v, weight=w)
+
+    assert a.sum_of_weights == 3.0
+    assert a.variance == 4.5
+    assert a.value == 2.0
+
+    a2 = bh.accumulators.weighted_mean().fill(vals, weight=weights)
+    assert a == a2
+
+    assert a == bh.accumulators.weighted_mean(3, 5, 2, 4.5)
+
+
+def test_mean():
+    vals = [1, 2, 3]
+    a = bh.accumulators.mean()
+    for val in vals:
+        a(val)
+
+    assert a.count == 3
+    assert a.value == 2
+    assert a.variance == 1
+
+    a2 = bh.accumulators.mean().fill([1, 2, 3])
+    assert a == a2
+
+    assert a == bh.accumulators.mean(3, 2, 1)


### PR DESCRIPTION
Closes #129. Provides a `.fill` method and makes weight/variance keyword only.