### PR TITLE
Numpy compat

### DIFF
--- a/boost_histogram/__init__.py
+++ b/boost_histogram/__init__.py
@@ -1,6 +1,6 @@
 from ._hist import histogram
 
-from . import axis, storage, accumulators, algorithm
+from . import axis, storage, accumulators, algorithm, numpy
 
 from .utils import loc, rebin, project, indexed, underflow, overflow
 

--- a/boost_histogram/__init__.py
+++ b/boost_histogram/__init__.py
@@ -1,6 +1,8 @@
 from ._hist import histogram
 
-from . import axis, storage, accumulators, algorithm, numpy
+from . import axis, storage, accumulators, algorithm
+
+# The numpy module is not imported yet - waiting until it is stable
 
 from .utils import loc, rebin, project, indexed, underflow, overflow
 

--- a/boost_histogram/__init__.py
+++ b/boost_histogram/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from ._hist import histogram
 
 from . import axis, storage, accumulators, algorithm

--- a/boost_histogram/_hist.py
+++ b/boost_histogram/_hist.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from .utils import FactoryMeta, KWArgs
 
 from . import core as _core

--- a/boost_histogram/accumulators.py
+++ b/boost_histogram/accumulators.py
@@ -1,1 +1,3 @@
+from __future__ import absolute_import, division, print_function
+
 from .core.accumulators import sum, mean, weighted_sum, weighted_mean

--- a/boost_histogram/algorithm.py
+++ b/boost_histogram/algorithm.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from .core.algorithm import shrink_and_rebin, slice_and_rebin, rebin, shrink, slice
 
 

--- a/boost_histogram/axis.py
+++ b/boost_histogram/axis.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from .core.axis import regular_log, regular_sqrt, regular_pow, circular, options
 
 from .core import axis as ca

--- a/boost_histogram/numpy.py
+++ b/boost_histogram/numpy.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from . import axis as _axis
 from . import _hist as _hist
 from . import core as _core

--- a/boost_histogram/numpy.py
+++ b/boost_histogram/numpy.py
@@ -1,0 +1,68 @@
+from . import axis as _axis
+from . import _hist as _hist
+
+
+def histogramdd(a, bins=10, range=None, normed=None, weights=None, density=None):
+    import numpy as np
+
+    if normed is not None:
+        raise KeyError(
+            "normed is not recommended for use in Numpy, and is not supported in boost-histogram; use density instead"
+        )
+    if density is not None:
+        raise KeyError(
+            "boost-histogram does not support the density keyword at the moment"
+        )
+
+    # Odd design here. Oh well.
+    if isinstance(a, np.ndarray):
+        a = a.T
+
+    rank = len(a)
+
+    # Integer bins: all the same
+    try:
+        bins = [int(bins)] * rank
+    except TypeError:
+        pass
+
+    # Single None -> list of Nones
+    if range is None:
+        range = [None] * rank
+
+    axs = []
+    for n, (b, r) in enumerate(zip(bins, range)):
+        if isinstance(b, int):
+            if r is None:
+                # Nextafter may affect bin edges slightly
+                r = (
+                    np.min(a[n]),
+                    np.nextafter(np.max(np.double(a[n])), np.finfo("d").max),
+                )
+            axs.append(_axis.regular(b, r[0], r[1]))
+        else:
+            b = np.asarray(b, dtype=np.double)
+            b[-1] = np.nextafter(b[-1], np.finfo("d").max)
+            axs.append(_axis.variable(b))
+
+    if weights is None:
+        return _hist.histogram(*axs).fill(*a)
+    else:
+        return _hist.histogram(*axis).fill(*a, weight=weights)
+
+
+def histogram2d(x, y, bins=10, range=None, normed=None, weights=None, density=None):
+    return histogramdd((x, y), bins, range, normed, weights, density)
+
+
+def histogram(x, bins=10, range=None, normed=None, weights=None, density=None):
+    import numpy as np
+
+    if isinstance(bins, str):
+        if tuple(int(x) for x in np.__version__.split(".")[:2]) < (1, 13):
+            raise KeyError(
+                "Upgrade numpy to 1.13+ to use string arguments to boost-histogram's histogram function"
+            )
+        bins = np.histogram_bin_edges(x, bins, range, weights)
+    return histogramdd((x,), (bins,), (range,), normed, weights, density)
+    # TODO: this also supports a few more tricks in Numpy, those can be added for numpy 1.13+

--- a/boost_histogram/numpy.py
+++ b/boost_histogram/numpy.py
@@ -2,6 +2,13 @@ from . import axis as _axis
 from . import _hist as _hist
 from . import core as _core
 
+import warnings
+
+warnings.warn(
+    "The boost_histogram.numpy module is provisional and may change in future releases",
+    FutureWarning,
+)
+
 
 def histogramdd(a, bins=10, range=None, normed=None, weights=None, density=None):
     import numpy as np

--- a/boost_histogram/numpy.py
+++ b/boost_histogram/numpy.py
@@ -1,5 +1,6 @@
 from . import axis as _axis
 from . import _hist as _hist
+from . import core as _core
 
 
 def histogramdd(a, bins=10, range=None, normed=None, weights=None, density=None):
@@ -35,11 +36,8 @@ def histogramdd(a, bins=10, range=None, normed=None, weights=None, density=None)
         if isinstance(b, int):
             if r is None:
                 # Nextafter may affect bin edges slightly
-                r = (
-                    np.min(a[n]),
-                    np.nextafter(np.max(np.double(a[n])), np.finfo("d").max),
-                )
-            axs.append(_axis.regular(b, r[0], r[1]))
+                r = (np.min(a[n]), np.max(a[n]))
+            axs.append(_core.axis._regular_numpy(b, r[0], r[1]))
         else:
             b = np.asarray(b, dtype=np.double)
             b[-1] = np.nextafter(b[-1], np.finfo("d").max)

--- a/boost_histogram/storage.py
+++ b/boost_histogram/storage.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from .core.storage import (
     int,
     double,

--- a/boost_histogram/utils.py
+++ b/boost_histogram/utils.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, division, print_function
+
+
 class FactoryMeta(object):
     def __init__(self, f, types):
         self._f = f

--- a/include/boost/histogram/python/axis_setup.hpp
+++ b/include/boost/histogram/python/axis_setup.hpp
@@ -1,0 +1,42 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/python/pybind11.hpp>
+
+#include <boost/histogram/axis.hpp>
+
+#include <string>
+#include <type_traits>
+#include <vector>
+
+/// Register bh::axis::variant as a variant for PyBind11
+namespace pybind11 {
+namespace detail {
+template <class... Ts>
+struct type_caster<bh::axis::variant<Ts...>>
+    : variant_caster<bh::axis::variant<Ts...>> {};
+} // namespace detail
+} // namespace pybind11
+
+inline bool PyObject_Check(void *value) { return value != nullptr; }
+
+struct metadata_t : py::object {
+    PYBIND11_OBJECT_DEFAULT(metadata_t, object, PyObject_Check);
+
+    bool operator==(const metadata_t &other) const { return py::object::equal(other); }
+    bool operator!=(const metadata_t &other) const {
+        return py::object::not_equal(other);
+    }
+};
+
+template <class Iterable>
+std::string::size_type max_string_length(const Iterable &c) {
+    std::string::size_type n = 0;
+    for(auto &&s : c)
+        n = std::max(n, s.size());
+    return n;
+}

--- a/include/boost/histogram/python/options.hpp
+++ b/include/boost/histogram/python/options.hpp
@@ -1,0 +1,37 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/python/pybind11.hpp>
+
+#include <boost/histogram/axis/option.hpp>
+
+using namespace std::literals;
+
+struct options {
+    unsigned option;
+
+    options(unsigned value)
+        : option(value) {}
+    options(bool uflow, bool oflow, bool circ, bool grow)
+        : option(
+            uflow * bh::axis::option::underflow | oflow * bh::axis::option::overflow
+            | circ * bh::axis::option::circular | grow * bh::axis::option::growth) {}
+
+    bool operator==(const options &other) const { return option == other.option; }
+    bool operator!=(const options &other) const { return option != other.option; }
+
+    bool underflow() const {
+        return static_cast<bool>(option & bh::axis::option::underflow);
+    }
+    bool overflow() const {
+        return static_cast<bool>(option & bh::axis::option::overflow);
+    }
+    bool circular() const {
+        return static_cast<bool>(option & bh::axis::option::circular);
+    }
+    bool growth() const { return static_cast<bool>(option & bh::axis::option::growth); }
+};

--- a/include/boost/histogram/python/register_axis.hpp
+++ b/include/boost/histogram/python/register_axis.hpp
@@ -12,6 +12,7 @@
 #include <boost/histogram/detail/iterator_adaptor.hpp>
 #include <boost/histogram/python/axis.hpp>
 #include <boost/histogram/python/axis_ostream.hpp>
+#include <boost/histogram/python/options.hpp>
 #include <boost/histogram/python/serializion.hpp>
 
 #include <algorithm>
@@ -27,31 +28,6 @@
 #include <vector>
 
 using namespace std::literals;
-
-struct options {
-    unsigned option;
-
-    options(unsigned value)
-        : option(value) {}
-    options(bool uflow, bool oflow, bool circ, bool grow)
-        : option(
-            uflow * bh::axis::option::underflow | oflow * bh::axis::option::overflow
-            | circ * bh::axis::option::circular | grow * bh::axis::option::growth) {}
-
-    bool operator==(const options &other) const { return option == other.option; }
-    bool operator!=(const options &other) const { return option != other.option; }
-
-    bool underflow() const {
-        return static_cast<bool>(option & bh::axis::option::underflow);
-    }
-    bool overflow() const {
-        return static_cast<bool>(option & bh::axis::option::overflow);
-    }
-    bool circular() const {
-        return static_cast<bool>(option & bh::axis::option::circular);
-    }
-    bool growth() const { return static_cast<bool>(option & bh::axis::option::growth); }
-};
 
 template <class A>
 void vectorized_index_and_value_methods(py::class_<A> &axis) {

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -138,7 +138,7 @@ register_histogram(py::module &m, const char *name, const char *desc) {
 
                 // Add the axis edges
                 h.for_each_axis([&tup, flow, i = 0u](const auto &ax) mutable {
-                    unchecked_set(tup, ++i, axis::edges(ax, flow));
+                    unchecked_set(tup, ++i, axis::edges(ax, flow, true));
                 });
 
                 return tup;

--- a/include/boost/histogram/python/regular_numpy.hpp
+++ b/include/boost/histogram/python/regular_numpy.hpp
@@ -1,0 +1,38 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/python/pybind11.hpp>
+
+#include <boost/histogram/axis/regular.hpp>
+#include <boost/histogram/python/axis_setup.hpp>
+
+namespace bh = boost::histogram;
+
+namespace axis {
+
+/// Mimics the numpy behavoir exactly.
+class regular_numpy : public bh::axis::regular<double, bh::use_default, metadata_t> {
+    using value_type = double;
+    double stop_;
+
+  public:
+    regular_numpy(unsigned n, value_type start, value_type stop, metadata_t meta = {})
+        : regular(n, start, stop, meta)
+        , stop_(stop) {}
+
+    regular_numpy()
+        : regular()
+        , stop_(0){};
+
+    boost::histogram::axis::index_type index(value_type v) const {
+        return v <= stop_ ? std::min(regular::index(v), size() - 1) : regular::index(v);
+    }
+};
+
+} // namespace axis
+
+// TODO: Support Serialize

--- a/include/boost/histogram/python/regular_numpy.hpp
+++ b/include/boost/histogram/python/regular_numpy.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/histogram/axis/regular.hpp>
 #include <boost/histogram/python/axis_setup.hpp>
+#include <boost/histogram/python/serializion.hpp>
 
 namespace bh = boost::histogram;
 
@@ -29,10 +30,16 @@ class regular_numpy : public bh::axis::regular<double, bh::use_default, metadata
         , stop_(0){};
 
     boost::histogram::axis::index_type index(value_type v) const {
+        std::cout << "stop: " << stop_ << std::endl;
         return v <= stop_ ? std::min(regular::index(v), size() - 1) : regular::index(v);
+    }
+
+    template <class Archive>
+    void serialize(Archive &ar, unsigned version) {
+        static_cast<bh::axis::regular<double, bh::use_default, metadata_t> *>(this)
+            ->serialize(ar, version);
+        ar &serialization::make_nvp("stop", stop_);
     }
 };
 
 } // namespace axis
-
-// TODO: Support Serialize

--- a/src/register_axis.cpp
+++ b/src/register_axis.cpp
@@ -8,6 +8,7 @@
 #include <boost/histogram/python/axis.hpp>
 #include <boost/histogram/python/kwargs.hpp>
 #include <boost/histogram/python/register_axis.hpp>
+#include <boost/histogram/python/regular_numpy.hpp>
 #include <boost/mp11.hpp>
 #include <vector>
 
@@ -68,13 +69,15 @@ void register_axes(py::module &mod) {
                             axis::regular_uflow,
                             axis::regular_oflow,
                             axis::regular_uoflow,
-                            axis::regular_uoflow_growth>(
+                            axis::regular_uoflow_growth,
+                            axis::regular_numpy>(
         mod,
         {"_regular_none",
          "_regular_uflow",
          "_regular_oflow",
          "_regular_uoflow",
-         "_regular_uoflow_growth"},
+         "_regular_uoflow_growth",
+         "_regular_numpy"},
         "Evenly spaced bins",
         py::init<unsigned, double, double, metadata_t>(),
         "bins"_a,

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -3,6 +3,12 @@ import pytest
 import boost_histogram as bh
 import numpy as np
 
+import warnings
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import boost_histogram.numpy as bhnp
+
 
 @pytest.mark.parametrize(
     "a",
@@ -38,7 +44,7 @@ import numpy as np
 def test_histogram1d(a, opt):
     v = np.array(a)
     h1, e1 = np.histogram(v, **opt)
-    h2, e2 = bh.numpy.histogram(v, **opt).to_numpy()
+    h2, e2 = bhnp.histogram(v, **opt).to_numpy()
 
     np.testing.assert_array_almost_equal(e1, e2)
     np.testing.assert_array_equal(h1, h2)
@@ -49,7 +55,7 @@ def test_histogram2d():
     y = np.array([0.4, 0.5, 0.22, 0.65, 0.32, 0.01, 0.23, 1.98])
 
     h1, e1x, e1y = np.histogram2d(x, y)
-    h2, e2x, e2y = bh.numpy.histogram2d(x, y).to_numpy()
+    h2, e2x, e2y = bhnp.histogram2d(x, y).to_numpy()
 
     np.testing.assert_array_almost_equal(e1x, e2x)
     np.testing.assert_array_almost_equal(e1y, e2y)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,0 +1,56 @@
+import pytest
+
+import boost_histogram as bh
+import numpy as np
+
+
+@pytest.mark.parametrize(
+    "a",
+    (
+        [1, 2, 3, 4, 3, 4, 5, 10, 9, 11, 21, -2],
+        [
+            0.27237556,
+            0.72020987,
+            0.75204098,
+            -0.29265003,
+            -2.67332888,
+            0.68420365,
+            -0.60629843,
+            -0.6375687,
+            -1.00017927,
+            -0.07707552,
+        ],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    ),
+)
+@pytest.mark.parametrize(
+    "opt",
+    (
+        {},
+        {"bins": 10},
+        {"bins": "auto"},  # Only for numpy 1.13+
+        {"range": (0, 5), "bins": 30},
+        {"bins": [0, 1, 1.2, 1.3, 4, 21]},
+    ),
+)
+def test_histogram1d(a, opt):
+    v = np.array(a)
+    h1, e1 = np.histogram(v, **opt)
+    h2, e2 = bh.numpy.histogram(v, **opt).to_numpy()
+
+    np.testing.assert_array_almost_equal(e1, e2)
+    np.testing.assert_array_equal(h1, h2)
+
+
+def test_histogram2d():
+    x = np.array([0.3, 0.3, 0.1, 0.8, 0.34, 0.03, 0.32, 0.65])
+    y = np.array([0.4, 0.5, 0.22, 0.65, 0.32, 0.01, 0.23, 1.98])
+
+    h1, e1x, e1y = np.histogram2d(x, y)
+    h2, e2x, e2y = bh.numpy.histogram2d(x, y).to_numpy()
+
+    np.testing.assert_array_almost_equal(e1x, e2x)
+    np.testing.assert_array_almost_equal(e1y, e2y)
+    np.testing.assert_array_equal(h1, h2)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -9,6 +9,8 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     import boost_histogram.numpy as bhnp
 
+np113 = tuple(int(x) for x in np.__version__.split(".")[:2]) >= (1, 13)
+
 
 @pytest.mark.parametrize(
     "a",
@@ -36,7 +38,7 @@ with warnings.catch_warnings():
     (
         {},
         {"bins": 10},
-        {"bins": "auto"},  # Only for numpy 1.13+
+        {"bins": "auto" if np113 else 20},
         {"range": (0, 5), "bins": 30},
         {"bins": [0, 1, 1.2, 1.3, 4, 21]},
     ),


### PR DESCRIPTION
This adds numpy compatibilty functions, as well as corrected to_numpy, now designed to properly perform a round-trip conversion to a numpy edges array. Variable bins fully round trip.  ~~The other direction is not quite correct for regular bins, since `regular()` does not have numpy's special final edge handling - this is as close as possible for the moment.~~ Adds a custom `_regular_numpy` axis type, only used by this method, that has the special case edge handling. See [histogram.guide.expert.user_defined_axes](https://www.boost.org/doc/libs/1_71_0/libs/histogram/doc/html/histogram/guide.html#histogram.guide.expert.user_defined_axes).

Will check an item off on #91; the rest of that issue will be deferred till a later release.

Note there are rounding differences on bin edges. But this does the correct thing on the maximum value in the filled array, which is the most important difference to avoid. `len(arr) == sum(np.histogram(arr)[0])` should be preserved!

Adding a provisional warning so this can be in the beta, but still can change later. Will require explicit import.