### PR TITLE
Adding setitem, overflow/underflow

### DIFF
--- a/boost_histogram/__init__.py
+++ b/boost_histogram/__init__.py
@@ -2,6 +2,6 @@ from ._hist import histogram
 
 from . import axis, storage, accumulators, algorithm
 
-from .utils import loc, rebin, project, indexed
+from .utils import loc, rebin, project, indexed, underflow, overflow
 
 from .version import __version__

--- a/boost_histogram/utils.py
+++ b/boost_histogram/utils.py
@@ -26,12 +26,16 @@ class rebin(object):
         self.factor = value
 
 
-class _project(object):
-    __slots__ = ()
+class project(object):
     projection = True
 
 
-project = _project
+class underflow(object):
+    flow = -1
+
+
+class overflow(object):
+    flow = 1
 
 
 def indexed(histogram, flow=False):

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -65,6 +65,7 @@ template <class A, class S>
 py::class_<bh::histogram<A, S>>
 register_histogram(py::module &m, const char *name, const char *desc) {
     using histogram_t = bh::histogram<A, S>;
+    using value_type  = typename histogram_t::value_type;
     namespace bv2     = boost::variant2;
 
     py::class_<histogram_t> hist(m, name, desc, py::buffer_protocol());
@@ -160,11 +161,19 @@ register_histogram(py::module &m, const char *name, const char *desc) {
         .def(
             "at",
             [](const histogram_t &self, py::args &args) {
-                // Optimize for no dynamic?
                 auto int_args = py::cast<std::vector<int>>(args);
                 return self.at(int_args);
             },
-            "Access bin counter at indices")
+            "Select a contents given indices. Also consider [] indexing to get "
+            "contents.")
+
+        .def(
+            "_at_set",
+            [](histogram_t &self, const value_type &input, py::args &args) {
+                auto int_args     = py::cast<std::vector<int>>(args);
+                self.at(int_args) = input;
+            },
+            "Use [] indexing to set instead")
 
         .def("__repr__", &shift_to_string<histogram_t>)
 


### PR DESCRIPTION
Closes #35.

Improvements to setitem indexing are shared with getitem.

Array/histogram setting is deferred for a later release.