### PR TITLE
Adding offset to UHI

### DIFF
--- a/boost_histogram/__init__.py
+++ b/boost_histogram/__init__.py
@@ -6,6 +6,6 @@ from ._hist import histogram
 
 from . import axis, storage, accumulators, algorithm, numpy
 
-from .utils import loc, rebin, project, underflow, overflow
+from .uhi import loc, rebin, project, underflow, overflow
 
 from .version import __version__

--- a/boost_histogram/_hist.py
+++ b/boost_histogram/_hist.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 del absolute_import, division, print_function
 
-from .utils import FactoryMeta, KWArgs
+from ._utils import FactoryMeta, KWArgs
 
 from . import core as _core
 
@@ -92,8 +92,8 @@ def _compute_commonindex(self, index, expand):
 
     # Allow [bh.loc(...)] to work
     for i in range(len(indexes)):
-        if hasattr(indexes[i], "value"):
-            indexes[i] = self.axis(i).index(indexes[i].value)
+        if hasattr(indexes[i], "value") and hasattr(indexes[i], "offset"):
+            indexes[i] = self.axis(i).index(indexes[i].value) + indexes[i].offset
         elif hasattr(indexes[i], "flow"):
             if indexes[i].flow == 1:
                 indexes[i] = self.axis(i).size

--- a/boost_histogram/_utils.py
+++ b/boost_histogram/_utils.py
@@ -16,33 +16,6 @@ class FactoryMeta(object):
         return isinstance(other, self._types)
 
 
-class loc(object):
-    __slots__ = ("value",)
-
-    def __init__(self, value):
-        self.value = value
-
-
-class rebin(object):
-    __slots__ = ("factor",)
-    projection = False
-
-    def __init__(self, value):
-        self.factor = value
-
-
-class project(object):
-    projection = True
-
-
-class underflow(object):
-    flow = -1
-
-
-class overflow(object):
-    flow = 1
-
-
 class KWArgs(object):
     def __init__(self, kwargs):
         self.kwargs = kwargs

--- a/boost_histogram/axis.py
+++ b/boost_histogram/axis.py
@@ -6,8 +6,8 @@ from .core.axis import regular_log, regular_sqrt, regular_pow, circular, options
 
 from .core import axis as ca
 
-from .utils import FactoryMeta
-from .utils import KWArgs as _KWArgs
+from ._utils import FactoryMeta
+from ._utils import KWArgs as _KWArgs
 
 
 # When Python 2 is dropped, this could use keyword

--- a/boost_histogram/numpy.py
+++ b/boost_histogram/numpy.py
@@ -6,7 +6,7 @@ from . import axis as _axis
 from . import _hist as _hist
 from . import core as _core
 
-from .utils import KWArgs as _KWArgs
+from ._utils import KWArgs as _KWArgs
 
 import numpy as _np
 

--- a/boost_histogram/uhi.py
+++ b/boost_histogram/uhi.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import, division, print_function
+
+del absolute_import, division, print_function
+
+
+class loc(object):
+    __slots__ = ("value", "offset")
+
+    def __init__(self, value, offset=0):
+        if not isinstance(offset, int):
+            raise ValueError("The offset must be an integer")
+
+        self.value = value
+        self.offset = offset
+
+    def __add__(self, offset):
+        return self.__class__(self.value, self.offset + offset)
+
+    def __sub__(self, offset):
+        return self.__class__(self.value, self.offset - offset)
+
+
+class rebin(object):
+    __slots__ = ("factor",)
+    projection = False
+
+    def __init__(self, value):
+        self.factor = value
+
+
+class project(object):
+    projection = True
+
+
+class underflow(object):
+    flow = -1
+
+
+class overflow(object):
+    flow = 1

--- a/docs/usage/indexing.rst
+++ b/docs/usage/indexing.rst
@@ -13,9 +13,10 @@ Access:
 
 .. code:: python
 
-   v = h[b]         # Returns bin contents, indexed by bin number
-   v = h[loc(b)]    # Returns the bin containing the value
-   v = h[underflow] # Underflow and overflow can be accessed with special tags
+   v = h[b]          # Returns bin contents, indexed by bin number
+   v = h[loc(b)]     # Returns the bin containing the value
+   v = h[loc(b) + 1] # Returns the bin above the one containing the value
+   v = h[underflow]  # Underflow and overflow can be accessed with special tags
 
 Slicing:
 ^^^^^^^^
@@ -26,7 +27,7 @@ Slicing:
    h2 = h[a:b]           # Slice of histogram (includes flow bins)
    h2 = h[:b]            # Leaving out endpoints is okay
    h2 = h[loc(v):]       # Slices can be in data coordinates, too
-   h2 = h[::project]     # Projection operations
+   h2 = h[::project]     # Projection operations # (name may change)
    h2 = h[::rebin(2)]    # Modification operations (rebin)
    h2 = h[a:b:rebin(2)]  # Modifications can combine with slices
    h2 = h[a:b, ...]      # Ellipsis work just like normal numpy
@@ -78,7 +79,7 @@ Rejected proposals or proposals for future consideration, maybe ``hist``-only:
 
 .. code:: python
 
-   h2 = h[1j:2j] # Adding a j suffix to a number could be used in place of `loc(x)`
+   h2 = h[1.0j:2.5j + 1] # Adding a j suffix to a number could be used in place of `loc(x)`
    h2 = h[1.0] # Floats in place of `loc(x)`: too easy to make a mistake
 
 --------------
@@ -101,7 +102,7 @@ here <https://gist.github.com/henryiii/d545a673ea2b3225cb985c9c02ac958b>`__.
 `Extra doc
 here <https://docs.google.com/document/d/1bJKA7Y0QXf46w53UFizJ4bnZlVIkb4aCqx6m2hoN0HM/edit#heading=h.jvegm6z8f387>`__.
 
-Note that the API comes in two forms; the ``__call__``/``__new__`` operator form is more powerful, slower, optional, and is not supported by boost-histogram.
+Note that the API comes in two forms; the ``__call__``/``__new__`` operator form is more powerful, slower, optional, and is currently not supported by boost-histogram.
 A fully conforming UHI implementation must allow the tag form without the operators.
 
 Basic implementation (WIP):
@@ -110,8 +111,11 @@ Basic implementation (WIP):
 
    class loc:
        "When used in the start or stop of a Histogram's slice, x is taken to be the position in data coordinates."
-       def __init__(self, x):
-           self.value = x
+       def __init__(self, value, offset):
+           self.value = value
+           self.offset = offest
+
+       # supporting __add__ and __sub__ also recommended
 
    # Other flags, such as callable functions, could be added and detected later.
 

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -14,6 +14,7 @@ def test_1D_get_bin():
 
     assert h[bh.loc(0)] == 0
     assert h[bh.loc(0.1)] == 1
+    assert h[bh.loc(0.1) + 1] == 3
     assert h[bh.loc(0.2)] == 3
 
     assert h.view()[2] == h[2]
@@ -32,6 +33,7 @@ def test_2D_get_bin():
     assert h[1, 1] == 1
     assert h[1, 2] == 3
     assert h[bh.loc(0.1), bh.loc(0.2)] == 3
+    assert h[bh.loc(0) + 1, bh.loc(0.3) - 1] == 3
 
     assert h.view()[1, 2] == h[1, 2]
 


### PR DESCRIPTION
This also moves the files around just a bit - UHI components are now exported from `uhi.py` instead of `utils.py`, and `_utils.py` is now private. Closes #152 