### PR TITLE
Adding copy_in

### DIFF
--- a/include/boost/histogram/python/accumulators_ostream.hpp
+++ b/include/boost/histogram/python/accumulators_ostream.hpp
@@ -72,8 +72,8 @@ std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> 
                                               const weighted_mean<W> &x) {
     if(os.width() == 0)
         return os << "weighted_mean(wsum=" << x.sum_of_weights()
-                  << " wsum2=..., value=" << x.value() << ", variance=" << x.variance()
-                  << ")";
+                  << ", wsum2=" << x.sum_of_weights_squared() << ", value=" << x.value()
+                  << ", variance=" << x.variance() << ")";
     return detail::handle_nonzero_width(os, x);
 }
 

--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -8,6 +8,7 @@
 #include <boost/histogram/python/pybind11.hpp>
 
 #include <boost/histogram/axis.hpp>
+#include <boost/histogram/indexed.hpp>
 #include <boost/histogram/python/axis_setup.hpp>
 #include <boost/histogram/python/regular_numpy.hpp>
 

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -148,6 +148,9 @@ register_histogram(py::module &m, const char *name, const char *desc) {
             "flow"_a = false,
             "convert to a numpy style tuple of returns")
 
+        .def("_copy_in",
+             [](histogram_t &h, py::array_t<double> input) { copy_in(h, input); })
+
         .def(
             "view",
             [](histogram_t &h, bool flow) { return py::array(make_buffer(h, flow)); },

--- a/src/register_histograms.cpp
+++ b/src/register_histograms.cpp
@@ -11,6 +11,62 @@
 #include <boost/histogram/python/storage.hpp>
 #include <boost/histogram/storage_adaptor.hpp>
 
+template <>
+inline void copy_in<>(bh::histogram<vector_axis_variant, bh::dense_storage<double>> &h,
+                      const py::array_t<double> &input) {
+    // Works on simple datatypes only
+    // TODO: Add other types
+    if(h.rank() != input.ndim())
+        throw py::value_error(
+            "The input array dimensions must match the histogram rank");
+
+    // Quick check to ensure the input array is valid
+    for(unsigned r = 0; r < h.rank(); r++) {
+        auto input_shape = input.shape(static_cast<py::ssize_t>(r));
+        if(input_shape != bh::axis::traits::extent(h.axis(r))
+           && input_shape != h.axis(r).size() && input_shape != 1)
+            throw py::value_error("The input array sizes must match the histogram "
+                                  "(with or without flow), or be broadcastable to it");
+    }
+
+    std::vector<py::ssize_t> indexes;
+    indexes.resize(h.rank());
+
+    for(auto &&ind : bh::indexed(h, bh::coverage::all)) {
+        bool skip = false;
+
+        for(unsigned r = 0; r < h.rank(); r++) {
+            auto input_shape   = input.shape(static_cast<py::ssize_t>(r));
+            bool use_flow      = input_shape == bh::axis::traits::extent(h.axis(r));
+            bool has_underflow = h.axis(r).options() & bh::axis::option::underflow;
+
+            // Broadcast size 1
+            if(input_shape == 1)
+                indexes[r] = 0;
+
+            // If this is using flow bins and has an underflow bin, convert -1 to 0
+            // (etc)
+            else if(use_flow && has_underflow)
+                indexes[r] = ind.index(r) + 1;
+
+            // If not using flow bins, skip the flow bins
+            else if(!use_flow
+                    && (ind.index(r) < 0 || ind.index(r) >= h.axis(r).size())) {
+                skip = true;
+                break;
+
+                // Otherwise, this is normal
+            } else
+                indexes[r] = ind.index(r);
+        }
+
+        if(skip)
+            continue;
+
+        *ind = pyarray_at(input, indexes);
+    }
+}
+
 void register_histograms(py::module &hist) {
     hist.attr("_axes_limit") = BOOST_HISTOGRAM_DETAIL_AXES_LIMIT;
 


### PR DESCRIPTION
This is the beginning of work for a `_copy_in` function; this will power (at least) `h[...] = np.array(...)`, and maybe operations with histograms and arrays. Going to get this working with doubles first, then generalize.

Currently, double only.