### PR TITLE
Nicer reprs

### DIFF
--- a/boost_histogram/uhi.py
+++ b/boost_histogram/uhi.py
@@ -19,6 +19,13 @@ class loc(object):
     def __sub__(self, offset):
         return self.__class__(self.value, self.offset - offset)
 
+    def __repr__(self):
+        s = "{self.__class__.__name__}({self.value}"
+        if offset != 0:
+            s += ", offset={self.offset}"
+        s += ")"
+        return s.format(self=self)
+
 
 class rebin(object):
     __slots__ = ("factor",)
@@ -26,6 +33,9 @@ class rebin(object):
 
     def __init__(self, value):
         self.factor = value
+
+    def __repr__(self):
+        return "{self.__class__.__name__}({self.factor})".format(self=self)
 
 
 class project(object):

--- a/include/boost/histogram/python/accumulators_ostream.hpp
+++ b/include/boost/histogram/python/accumulators_ostream.hpp
@@ -1,0 +1,88 @@
+// Copyright 2015-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+//
+// Based on boost/histogram/axis/ostream.hpp
+// String representations here evaluate correctly in Python.
+
+#pragma once
+
+#include <boost/histogram/detail/counting_streambuf.hpp>
+#include <boost/histogram/fwd.hpp>
+#include <iosfwd>
+
+namespace boost {
+namespace histogram {
+
+namespace detail {
+
+template <class CharT, class Traits, class T>
+std::basic_ostream<CharT, Traits> &
+handle_nonzero_width(std::basic_ostream<CharT, Traits> &os, const T &x) {
+    const auto w = os.width();
+    os.width(0);
+    counting_streambuf<CharT, Traits> cb;
+    const auto saved = os.rdbuf(&cb);
+    os << x;
+    os.rdbuf(saved);
+    if(os.flags() & std::ios::left) {
+        os << x;
+        for(auto i = cb.count; i < w; ++i)
+            os << os.fill();
+    } else {
+        for(auto i = cb.count; i < w; ++i)
+            os << os.fill();
+        os << x;
+    }
+    return os;
+}
+
+} // namespace detail
+
+namespace accumulators {
+template <class CharT, class Traits, class W>
+std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> &os,
+                                              const sum<W> &x) {
+    if(os.width() == 0)
+        return os << "sum(" << x.large() << " + " << x.small() << ")";
+    return detail::handle_nonzero_width(os, x);
+}
+
+template <class CharT, class Traits, class W>
+std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> &os,
+                                              const weighted_sum<W> &x) {
+    if(os.width() == 0)
+        return os << "weighted_sum(value=" << x.value() << ", variance=" << x.variance()
+                  << ")";
+    return detail::handle_nonzero_width(os, x);
+}
+
+template <class CharT, class Traits, class W>
+std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> &os,
+                                              const mean<W> &x) {
+    if(os.width() == 0)
+        return os << "mean(count=" << x.count() << ", value=" << x.value()
+                  << ", variance=" << x.variance() << ")";
+    return detail::handle_nonzero_width(os, x);
+}
+
+template <class CharT, class Traits, class W>
+std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> &os,
+                                              const weighted_mean<W> &x) {
+    if(os.width() == 0)
+        return os << "weighted_mean(wsum=" << x.sum_of_weights()
+                  << " wsum2=..., value=" << x.value() << ", variance=" << x.variance()
+                  << ")";
+    return detail::handle_nonzero_width(os, x);
+}
+
+template <class CharT, class Traits, class T>
+std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> &os,
+                                              const thread_safe<T> &x) {
+    os << x.load();
+    return os;
+}
+} // namespace accumulators
+} // namespace histogram
+} // namespace boost

--- a/include/boost/histogram/python/histogram_ostream.hpp
+++ b/include/boost/histogram/python/histogram_ostream.hpp
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include <boost/histogram/accumulators/ostream.hpp>
 #include <boost/histogram/fwd.hpp>
+#include <boost/histogram/python/accumulators_ostream.hpp>
 #include <boost/histogram/python/axis_ostream.hpp>
 #include <boost/histogram/python/storage.hpp>
 #include <iosfwd>

--- a/include/boost/histogram/python/histogram_ostream.hpp
+++ b/include/boost/histogram/python/histogram_ostream.hpp
@@ -19,8 +19,15 @@ std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> 
                                               const histogram<A, S> &h) {
     os << "histogram(";
     h.for_each_axis([&](const auto &a) { os << "\n  " << a << ","; });
-    os << (h.rank() ? "\n  " : " ") << "storage=" << storage::name<S>();
-    os << (h.rank() ? "\n)" : ")");
+    os << "\n  "
+       << "storage=" << storage::name<S>();
+    os << "\n)";
+    auto inner = sum_histogram(h, false);
+    auto outer = sum_histogram(h, true);
+    if(outer != decltype(outer){})
+        os << " # Sum: " << inner;
+    if(inner != outer)
+        os << " (" << outer << " with flow)";
     return os;
 }
 

--- a/include/boost/histogram/python/register_accumulator.hpp
+++ b/include/boost/histogram/python/register_accumulator.hpp
@@ -23,6 +23,8 @@ py::class_<A> register_accumulator(py::module acc, Args &&... args) {
 
         .def(py::self *= double())
 
+        .def("__repr__", &shift_to_string<A>)
+
         .def("__copy__", [](const A &self) { return A(self); })
         .def("__deepcopy__", [](const A &self, py::object) { return A(self); })
 

--- a/include/boost/histogram/python/register_accumulator.hpp
+++ b/include/boost/histogram/python/register_accumulator.hpp
@@ -7,7 +7,6 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
-#include <boost/histogram/accumulators/ostream.hpp> // TODO: replace with internal repr
 #include <boost/histogram/python/serializion.hpp>
 
 #include <pybind11/operators.h>
@@ -23,8 +22,6 @@ py::class_<A> register_accumulator(py::module acc, Args &&... args) {
         .def(py::self != py::self)
 
         .def(py::self *= double())
-
-        .def("__repr__", &shift_to_string<A>)
 
         .def("__copy__", [](const A &self) { return A(self); })
         .def("__deepcopy__", [](const A &self, py::object) { return A(self); })

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -18,6 +18,7 @@
 #include <boost/histogram/python/kwargs.hpp>
 #include <boost/histogram/python/serializion.hpp>
 #include <boost/histogram/python/storage.hpp>
+#include <boost/histogram/python/sum.hpp>
 #include <boost/histogram/python/variant.hpp>
 #include <boost/histogram/unsafe_access.hpp>
 #include <boost/mp11.hpp>
@@ -188,20 +189,7 @@ register_histogram(py::module &m, const char *name, const char *desc) {
         .def(
             "sum",
             [](const histogram_t &self, bool flow) {
-                if(flow) {
-                    return bh::algorithm::sum(self);
-                } else {
-                    using T = typename bh::histogram<A, S>::value_type;
-                    using AddType
-                        = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
-                    using Sum = boost::mp11::
-                        mp_if<std::is_arithmetic<T>, bh::accumulators::sum<double>, T>;
-                    Sum sum;
-                    for(auto &&x : bh::indexed(self))
-                        sum += (AddType)*x;
-                    using R = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
-                    return static_cast<R>(sum);
-                }
+                return sum_histogram(self, flow);
             },
             "flow"_a = false)
 

--- a/include/boost/histogram/python/sum.hpp
+++ b/include/boost/histogram/python/sum.hpp
@@ -1,0 +1,27 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <boost/histogram/algorithm/sum.hpp>
+#include <boost/mp11.hpp>
+#include <type_traits>
+
+template <class histogram_t>
+decltype(auto) sum_histogram(const histogram_t &self, bool flow) {
+    if(flow) {
+        return bh::algorithm::sum(self);
+    } else {
+        using T       = typename histogram_t::value_type;
+        using AddType = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
+        using Sum     = boost::mp11::
+            mp_if<std::is_arithmetic<T>, bh::accumulators::sum<double>, T>;
+        Sum sum;
+        for(auto &&x : bh::indexed(self))
+            sum += (AddType)*x;
+        using R = boost::mp11::mp_if<std::is_arithmetic<T>, double, T>;
+        return static_cast<R>(sum);
+    }
+}

--- a/src/register_accumulators.cpp
+++ b/src/register_accumulators.cpp
@@ -6,10 +6,10 @@
 #include <boost/histogram/python/pybind11.hpp>
 
 #include <boost/histogram/accumulators/mean.hpp>
-#include <boost/histogram/accumulators/ostream.hpp>
 #include <boost/histogram/accumulators/sum.hpp>
 #include <boost/histogram/accumulators/weighted_mean.hpp>
 #include <boost/histogram/accumulators/weighted_sum.hpp>
+#include <boost/histogram/python/accumulators_ostream.hpp>
 #include <boost/histogram/python/kwargs.hpp>
 #include <boost/histogram/python/register_accumulator.hpp>
 #include <pybind11/operators.h>
@@ -59,16 +59,10 @@ void register_accumulators(py::module &accumulators) {
         .def(py::init<const double &>(), "value"_a)
         .def(py::init<const double &, const double &>(), "value"_a, "variance"_a)
 
-        .def_property_readonly("variance", &weighted_sum::variance)
         .def_property_readonly("value", &weighted_sum::value)
+        .def_property_readonly("variance", &weighted_sum::variance)
 
         .def(py::self += double())
-
-        .def("__repr__",
-             [](const weighted_sum &self) {
-                 return py::str("weighted_sum(value={}, variance={})")
-                     .format(self.value(), self.variance());
-             })
 
         .def(
             "fill",
@@ -103,11 +97,6 @@ void register_accumulators(py::module &accumulators) {
 
         .def(py::self += double())
 
-        .def("__repr__",
-             [](const weighted_sum &self) {
-                 return py::str("sum({})").format(double(self));
-             })
-
         .def(
             "fill",
             [](sum &self, py::object value) {
@@ -136,15 +125,8 @@ void register_accumulators(py::module &accumulators) {
              "variance"_a)
 
         .def_property_readonly("sum_of_weights", &weighted_mean::sum_of_weights)
-        .def_property_readonly("variance", &weighted_mean::variance)
         .def_property_readonly("value", &weighted_mean::value)
-
-        .def("__repr__",
-             [](const weighted_mean &self) {
-                 return py::str(
-                            "weighted_mean(wsum={}, wsum2=..., mean={}, variance={})")
-                     .format(self.sum_of_weights(), self.value(), self.variance());
-             })
+        .def_property_readonly("variance", &weighted_mean::variance)
 
         .def("__call__",
              make_mean_call<weighted_mean>(),
@@ -179,12 +161,6 @@ void register_accumulators(py::module &accumulators) {
              make_mean_fill<mean>(),
              "value"_a,
              "Fill the accumulator with values. Optional weight parameter.")
-
-        .def("__repr__",
-             [](const mean &self) {
-                 return py::str("mean(count={}, mean={}, variance={})")
-                     .format(self.count(), self.value(), self.variance());
-             })
 
         ;
 }

--- a/src/register_accumulators.cpp
+++ b/src/register_accumulators.cpp
@@ -64,6 +64,12 @@ void register_accumulators(py::module &accumulators) {
 
         .def(py::self += double())
 
+        .def("__repr__",
+             [](const weighted_sum &self) {
+                 return py::str("weighted_sum(value={}, variance={})")
+                     .format(self.value(), self.variance());
+             })
+
         .def(
             "fill",
             [](weighted_sum &self, py::object value, py::kwargs kwargs) {
@@ -97,6 +103,11 @@ void register_accumulators(py::module &accumulators) {
 
         .def(py::self += double())
 
+        .def("__repr__",
+             [](const weighted_sum &self) {
+                 return py::str("sum({})").format(double(self));
+             })
+
         .def(
             "fill",
             [](sum &self, py::object value) {
@@ -121,12 +132,19 @@ void register_accumulators(py::module &accumulators) {
         .def(py::init<const double &, const double &, const double &, const double &>(),
              "wsum"_a,
              "wsum2"_a,
-             "mean"_a,
+             "value"_a,
              "variance"_a)
 
         .def_property_readonly("sum_of_weights", &weighted_mean::sum_of_weights)
         .def_property_readonly("variance", &weighted_mean::variance)
         .def_property_readonly("value", &weighted_mean::value)
+
+        .def("__repr__",
+             [](const weighted_mean &self) {
+                 return py::str(
+                            "weighted_mean(wsum={}, wsum2=..., mean={}, variance={})")
+                     .format(self.sum_of_weights(), self.value(), self.variance());
+             })
 
         .def("__call__",
              make_mean_call<weighted_mean>(),
@@ -144,13 +162,13 @@ void register_accumulators(py::module &accumulators) {
 
     register_accumulator<mean>(accumulators, "mean")
         .def(py::init<const double &, const double &, const double &>(),
+             "count"_a,
              "value"_a,
-             "mean"_a,
              "variance"_a)
 
         .def_property_readonly("count", &mean::count)
-        .def_property_readonly("variance", &mean::variance)
         .def_property_readonly("value", &mean::value)
+        .def_property_readonly("variance", &mean::variance)
 
         .def("__call__",
              make_mean_call<mean>(),
@@ -161,6 +179,12 @@ void register_accumulators(py::module &accumulators) {
              make_mean_fill<mean>(),
              "value"_a,
              "Fill the accumulator with values. Optional weight parameter.")
+
+        .def("__repr__",
+             [](const mean &self) {
+                 return py::str("mean(count={}, mean={}, variance={})")
+                     .format(self.count(), self.value(), self.variance());
+             })
 
         ;
 }

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -300,16 +300,22 @@ def test_add_2d_w(flow):
 
 
 def test_repr():
-    h = histogram(regular(3, 0, 1), integer(0, 1))
-    hr = repr(h)
-    assert (
-        hr
-        == """histogram(
+    hrepr = """histogram(
   regular(3, 0, 1),
   integer(0, 1),
   storage=double
 )"""
-    )
+
+    h = histogram(regular(3, 0, 1), integer(0, 1))
+    assert repr(h) == hrepr
+
+    h.fill([0.3, 0.5], [0, 0])
+    hrepr += " # Sum: 2"
+    assert repr(h) == hrepr
+
+    h.fill([0.3, 12], [3, 0])
+    hrepr += " (4 with flow)"
+    assert repr(h) == hrepr
 
 
 def test_axis():


### PR DESCRIPTION
Added:

* Sum (with and without flow) on histogram repr
* UHI objects have nicer reprs
* Accumulators have keywords in reprs
* Sum is factored out into standalone (could `bh::sum` support a flow argument, like `bh::coverage::inner`/`bh::coverage::outer`, @HDembinski ?)