### PR TITLE
Deprecation for at and axis

### DIFF
--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -154,7 +154,7 @@ register_histogram(py::module &m, const char *name, const char *desc) {
             "Return a view into the data, optionally with overflow turned on")
 
         .def(
-            "axis",
+            "_axis",
             [](const histogram_t &self, int i) {
                 unsigned ii = i < 0 ? self.rank() - (unsigned)std::abs(i) : (unsigned)i;
                 if(ii < self.rank())
@@ -168,7 +168,7 @@ register_histogram(py::module &m, const char *name, const char *desc) {
             py::return_value_policy::move)
 
         .def(
-            "at",
+            "_at",
             [](const histogram_t &self, py::args &args) {
                 auto int_args = py::cast<std::vector<int>>(args);
                 return self.at(int_args);

--- a/tests/test_histogram_internal.py
+++ b/tests/test_histogram_internal.py
@@ -34,8 +34,8 @@ def test_1D_fill_int(hist_func):
     assert_array_equal(hist.view(flow=False), H)
     assert_array_equal(hist.view(flow=True)[1:-1], H)
 
-    assert hist.axis(0).size == bins
-    assert hist.axis(0).extent == bins + 2
+    assert hist.axes[0].size == bins
+    assert hist.axes[0].extent == bins + 2
 
 
 @pytest.mark.parametrize("hist_func", methods)
@@ -56,11 +56,11 @@ def test_2D_fill_int(hist_func):
     assert_array_equal(hist.view(flow=True)[1:-1, 1:-1], H)
     assert_array_equal(hist.view(flow=False), H)
 
-    assert hist.axis(0).size == bins[0]
-    assert hist.axis(0).extent == bins[0] + 2
+    assert hist.axes[0].size == bins[0]
+    assert hist.axes[0].extent == bins[0] + 2
 
-    assert hist.axis(1).size == bins[1]
-    assert hist.axis(1).extent == bins[1] + 2
+    assert hist.axes[1].size == bins[1]
+    assert hist.axes[1].extent == bins[1] + 2
 
 
 def test_edges_histogram():
@@ -108,7 +108,7 @@ def test_numpy_flow():
 
     for i in range(10):
         for j in range(5):
-            x, y = h.axis(0).centers[i], h.axis(1).centers[j]
+            x, y = h.axes[0].centers[i], h.axes[1].centers[j]
             v = i + j * 10 + 1
             h.fill([x] * v, [y] * v)
 
@@ -132,7 +132,7 @@ def test_numpy_compare():
     ys = []
     for i in range(10):
         for j in range(5):
-            x, y = h.axis(0).centers[i], h.axis(1).centers[j]
+            x, y = h.axes[0].centers[i], h.axes[1].centers[j]
             v = i + j * 10 + 1
             xs += [x] * v
             ys += [y] * v

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -11,18 +11,18 @@ def test_make_regular_1D(opt, extent):
     )
 
     assert hist.rank == 1
-    assert hist.axis(0).size == 3
-    assert hist.axis(0).extent == 3 + extent
-    assert hist.axis(0).bin(1) == (3, 4)
+    assert hist.axes[0].size == 3
+    assert hist.axes[0].extent == 3 + extent
+    assert hist.axes[0].bin(1) == (3, 4)
 
 
 def test_shortcuts():
     hist = bh.histogram((1, 2, 3), (10, 0, 1))
     assert hist.rank == 2
     for i in range(2):
-        assert isinstance(hist.axis(i), bh.axis.regular)
-        assert isinstance(hist.axis(i), bh.core.axis._regular_uoflow)
-        assert not isinstance(hist.axis(i), bh.axis.variable)
+        assert isinstance(hist.axes[i], bh.axis.regular)
+        assert isinstance(hist.axes[i], bh.core.axis._regular_uoflow)
+        assert not isinstance(hist.axes[i], bh.axis.variable)
 
 
 def test_shortcuts_with_metadata():
@@ -42,13 +42,13 @@ def test_make_regular_2D(opt, extent):
     )
 
     assert hist.rank == 2
-    assert hist.axis(0).size == 3
-    assert hist.axis(0).extent == 3 + extent
-    assert hist.axis(0).bin(1) == approx((3, 4))
+    assert hist.axes[0].size == 3
+    assert hist.axes[0].extent == 3 + extent
+    assert hist.axes[0].bin(1) == approx((3, 4))
 
-    assert hist.axis(1).size == 5
-    assert hist.axis(1).extent == 5 + extent
-    assert hist.axis(1).bin(1) == approx((2, 3))
+    assert hist.axes[1].size == 5
+    assert hist.axes[1].extent == 5 + extent
+    assert hist.axes[1].bin(1) == approx((2, 3))
 
 
 @pytest.mark.parametrize(
@@ -69,15 +69,15 @@ def test_make_any_hist(storage):
     )
 
     assert hist.rank == 3
-    assert hist.axis(0).size == 3
-    assert hist.axis(0).extent == 5
-    assert hist.axis(0).bin(1) == approx((2, 3))
-    assert hist.axis(1).size == 2
-    assert hist.axis(1).extent == 2
-    assert hist.axis(1).bin(1) == approx((3, 4))
-    assert hist.axis(2).size == 4
-    assert hist.axis(2).extent == 5
-    assert hist.axis(2).bin(1) == approx((2, 3))
+    assert hist.axes[0].size == 3
+    assert hist.axes[0].extent == 5
+    assert hist.axes[0].bin(1) == approx((2, 3))
+    assert hist.axes[1].size == 2
+    assert hist.axes[1].extent == 2
+    assert hist.axes[1].bin(1) == approx((3, 4))
+    assert hist.axes[2].size == 4
+    assert hist.axes[2].extent == 5
+    assert hist.axes[2].bin(1) == approx((2, 3))
 
 
 def test_make_any_hist_storage():
@@ -96,14 +96,14 @@ def test_issue_axis_bin_swan():
         bh.axis.circular(10, 0, 1, metadata="y"),
     )
 
-    b = hist.axis(1).bin(1)
+    b = hist.axes[1].bin(1)
     assert repr(b) == "(0.1, 0.2)"
     assert b[0] == approx(0.1)
     assert b[1] == approx(0.2)
 
-    assert hist.axis(0).bin(0)[0] == 0
-    assert hist.axis(0).bin(1)[0] == approx(0.1)
-    assert hist.axis(0).bin(2)[0] == approx(0.4)
+    assert hist.axes[0].bin(0)[0] == 0
+    assert hist.axes[0].bin(1)[0] == approx(0.1)
+    assert hist.axes[0].bin(2)[0] == approx(0.4)
 
 
 options = (

--- a/tests/test_make_histogram.py
+++ b/tests/test_make_histogram.py
@@ -83,10 +83,10 @@ def test_make_any_hist(storage):
 def test_make_any_hist_storage():
 
     assert float != type(
-        bh.histogram(bh.axis.regular(5, 1, 2), storage=bh.storage.int()).at(0)
+        bh.histogram(bh.axis.regular(5, 1, 2), storage=bh.storage.int())[0]
     )
     assert float == type(
-        bh.histogram(bh.axis.regular(5, 1, 2), storage=bh.storage.double()).at(0)
+        bh.histogram(bh.axis.regular(5, 1, 2), storage=bh.storage.double())[0]
     )
 
 

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -108,9 +108,9 @@ def test_compare_copy_hist(metadata):
     new = copy.copy(orig)
     dnew = copy.deepcopy(orig)
 
-    assert orig.axis(0).metadata is new.axis(0).metadata
-    assert orig.axis(0).metadata == dnew.axis(0).metadata
-    assert orig.axis(0).metadata is not dnew.axis(0).metadata
+    assert orig.axes[0].metadata is new.axes[0].metadata
+    assert orig.axes[0].metadata == dnew.axes[0].metadata
+    assert orig.axes[0].metadata is not dnew.axes[0].metadata
 
 
 @pytest.mark.parametrize("axis,args", axes_creations)

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -52,9 +52,9 @@ def test_init():
 
     h = histogram(integer(-1, 2))
     assert h.rank == 1
-    assert h.axis(0) == integer(-1, 2)
-    assert h.axis(0).extent == 5
-    assert h.axis(0).size == 3
+    assert h.axes[0] == integer(-1, 2)
+    assert h.axes[0].extent == 5
+    assert h.axes[0].size == 3
     assert h != histogram(regular(1, -1, 1))
     assert h != histogram(integer(-1, 1, metadata="ia"))
 
@@ -85,7 +85,7 @@ def test_fill_int_1d():
         h.fill(x)
     assert h.sum() == 6
     assert h.sum(flow=True) == 8
-    assert h.axis(0).extent == 5
+    assert h.axes[0].extent == 5
 
     with pytest.raises(TypeError):
         h.at(0, foo=None)
@@ -125,7 +125,7 @@ def test_fill_1d(flow):
 
     assert h.sum() == 6
     assert h.sum(flow=True) == 6 + 2 * flow
-    assert h.axis(0).extent == 3 + 2 * flow
+    assert h.axes[0].extent == 3 + 2 * flow
 
     with pytest.raises(TypeError):
         h.at(0, foo=None)
@@ -217,8 +217,8 @@ def test_fill_2d(flow):
 
     for get in (lambda h, x, y: h.at(x, y),):
         # lambda h, x, y: h[x, y]):
-        for i in range(-flow, h.axis(0).size + flow):
-            for j in range(-flow, h.axis(1).size + flow):
+        for i in range(-flow, h.axes[0].size + flow):
+            for j in range(-flow, h.axes[1].size + flow):
                 assert get(h, i, j) == m[i][j]
 
 
@@ -248,8 +248,8 @@ def test_add_2d(flow):
 
     h += h
 
-    for i in range(-flow, h.axis(0).size + flow):
-        for j in range(-flow, h.axis(1).size + flow):
+    for i in range(-flow, h.axes[0].size + flow):
+        for j in range(-flow, h.axes[1].size + flow):
             assert h.at(i, j) == 2 * m[i][j]
 
 
@@ -294,8 +294,8 @@ def test_add_2d_w(flow):
     h += h
     assert h == h2
 
-    for i in range(-flow, h.axis(0).size + flow):
-        for j in range(-flow, h.axis(1).size + flow):
+    for i in range(-flow, h.axes[0].size + flow):
+        for j in range(-flow, h.axes[1].size + flow):
             assert h.at(i, j) == 2 * m[i][j]
 
 
@@ -322,13 +322,13 @@ def test_axis():
     axes = (regular(10, 0, 1), integer(0, 1))
     h = histogram(*axes)
     for i, a in enumerate(axes):
-        assert h.axis(i) == a
+        assert h.axes[i] == a
     with pytest.raises(IndexError):
-        h.axis(2)
-    assert h.axis(-1) == axes[-1]
-    assert h.axis(-2) == axes[-2]
+        h.axes[2]
+    assert h.axes[-1] == axes[-1]
+    assert h.axes[-2] == axes[-2]
     with pytest.raises(IndexError):
-        h.axis(-3)
+        h.axes[-3]
 
 
 def test_out_of_limit_axis():
@@ -390,12 +390,12 @@ def test_project():
 
     h0 = h.project(0)
     assert h0.rank == 1
-    assert h0.axis(0) == integer(0, 2)
+    assert h0.axes[0] == integer(0, 2)
     assert [h0.at(i) for i in range(2)] == [2, 1]
 
     h1 = h.project(1)
     assert h1.rank == 1
-    assert h1.axis(0) == integer(1, 4)
+    assert h1.axes[0] == integer(1, 4)
     assert [h1.at(i) for i in range(3)] == [1, 1, 1]
 
     with pytest.raises(ValueError):
@@ -442,15 +442,15 @@ def test_pickle_0():
         variable([0.0, 1.0, 2.0]),
         circular(4, 0, 2 * np.pi),
     )
-    for i in range(a.axis(0).extent):
+    for i in range(a.axes[0].extent):
         a.fill(i, 0, 0, 0, 0)
-        for j in range(a.axis(1).extent):
+        for j in range(a.axes[1].extent):
             a.fill(i, j, 0, 0, 0)
-            for k in range(a.axis(2).extent):
+            for k in range(a.axes[2].extent):
                 a.fill(i, j, k, 0, 0)
-                for l in range(a.axis(3).extent):
+                for l in range(a.axes[3].extent):
                     a.fill(i, j, k, l, 0)
-                    for m in range(a.axis(4).extent):
+                    for m in range(a.axes[4].extent):
                         a.fill(i, j, k, l, m * 0.5 * np.pi)
 
     io = pickle.dumps(a, -1)
@@ -458,11 +458,11 @@ def test_pickle_0():
 
     assert id(a) != id(b)
     assert a.rank == b.rank
-    assert a.axis(0) == b.axis(0)
-    assert a.axis(1) == b.axis(1)
-    assert a.axis(2) == b.axis(2)
-    assert a.axis(3) == b.axis(3)
-    assert a.axis(4) == b.axis(4)
+    assert a.axes[0] == b.axes[0]
+    assert a.axes[1] == b.axes[1]
+    assert a.axes[2] == b.axes[2]
+    assert a.axes[3] == b.axes[3]
+    assert a.axes[4] == b.axes[4]
     assert a.sum() == b.sum()
     assert repr(a) == repr(b)
     assert str(a) == str(b)
@@ -478,13 +478,13 @@ def test_pickle_1():
     )
     assert isinstance(a, histogram)
 
-    for i in range(a.axis(0).extent):
+    for i in range(a.axes[0].extent):
         a.fill(i, 0, 0, 0, weight=3)
-        for j in range(a.axis(1).extent):
+        for j in range(a.axes[1].extent):
             a.fill(i, j, 0, 0, weight=10)
-            for k in range(a.axis(2).extent):
+            for k in range(a.axes[2].extent):
                 a.fill(i, j, k, 0, weight=2)
-                for l in range(a.axis(3).extent):
+                for l in range(a.axes[3].extent):
                     a.fill(i, j, k, l, weight=5)
 
     io = BytesIO()
@@ -494,10 +494,10 @@ def test_pickle_1():
 
     assert id(a) != id(b)
     assert a.rank == b.rank
-    assert a.axis(0) == b.axis(0)
-    assert a.axis(1) == b.axis(1)
-    assert a.axis(2) == b.axis(2)
-    assert a.axis(3) == b.axis(3)
+    assert a.axes[0] == b.axes[0]
+    assert a.axes[1] == b.axes[1]
+    assert a.axes[2] == b.axes[2]
+    assert a.axes[3] == b.axes[3]
     assert a.sum() == b.sum()
     assert repr(a) == repr(b)
     assert str(a) == str(b)
@@ -554,17 +554,17 @@ def test_numpy_conversion_2():
         integer(0, 4, underflow=False, overflow=False),
     )
     r = np.zeros((2, 3, 4), dtype=np.int8)
-    for i in range(a.axis(0).extent):
-        for j in range(a.axis(1).extent):
-            for k in range(a.axis(2).extent):
+    for i in range(a.axes[0].extent):
+        for j in range(a.axes[1].extent):
+            for k in range(a.axes[2].extent):
                 for m in range(i + j + k):
                     a.fill(i, j, k)
                 r[i, j, k] = i + j + k
 
     d = np.zeros((2, 3, 4), dtype=np.int8)
-    for i in range(a.axis(0).extent):
-        for j in range(a.axis(1).extent):
-            for k in range(a.axis(2).extent):
+    for i in range(a.axes[0].extent):
+        for j in range(a.axes[1].extent):
+            for k in range(a.axes[2].extent):
                 d[i, j, k] = a.at(i, j, k)
 
     assert_array_equal(d, r)
@@ -583,17 +583,17 @@ def test_numpy_conversion_3():
     )
 
     r = np.zeros((4, 5, 6))
-    for i in range(a.axis(0).extent):
-        for j in range(a.axis(1).extent):
-            for k in range(a.axis(2).extent):
+    for i in range(a.axes[0].extent):
+        for j in range(a.axes[1].extent):
+            for k in range(a.axes[2].extent):
                 a.fill(i - 1, j - 1, k - 1, weight=i + j + k)
                 r[i, j, k] = i + j + k
     c = a.view(flow=True)
 
     c2 = np.zeros((4, 5, 6))
-    for i in range(a.axis(0).extent):
-        for j in range(a.axis(1).extent):
-            for k in range(a.axis(2).extent):
+    for i in range(a.axes[0].extent):
+        for j in range(a.axes[1].extent):
+            for k in range(a.axes[2].extent):
                 c2[i, j, k] = a.at(i - 1, j - 1, k - 1)
 
     assert_array_equal(c, c2)


### PR DESCRIPTION
See #155. This should keep too many users from depending on these features slated for removal from the "pythonic" part of the bindings when the `cpp` module is added.