### PR TITLE
UHI update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 #### User changes
 
+* You can now sum over a range with endpoints [#185][]
 * You can now access the functional regular axis directly, `regular_sqrt` becomes `regular.sqrt`, etc.. [#183][]
 * `h.axis()` and `h.at()` are now completely removed unless you use the cpp version of histogram. [#183][]
 * `h.axes` now has the functions from axis as well. [#183][]
+* `bh.project` has become `bh.sum` [#185][]
 
 
 #### Developer changes
@@ -13,8 +15,11 @@
 * Most internal names changed, `core->_core`, etc. [#183][]
 * The `uhi` module is now `tag`. [#183][]
 * `boost_histogram.cpp as bh` provides C++ high-compatibility mode. [#183][]
+* Indexing tags now use full UHI instead of workarounds [#185][]
 
 
+[#183]: https://github.com/scikit-hep/boost-histogram/pull/183
+[#185]: https://github.com/scikit-hep/boost-histogram/pull/185
 
 
 ### Version 0.5.2

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Python bindings for [Boost::Histogram][] ([source][Boost::Histogram source]), a 
 > #### Known issues:
 > * Non-simple storages do not support `.view()` or the buffer interface; you can access and set one element at a time
 > * Docstrings and signatures will improve in later versions (especially on Python 3)
-> * `bh.project` is expected to change names
 > * Setting with an array is not yet supported (`h[...] = np.array(...)`)
 > * A compiler is required to install on Python 3.8 on Windows (waiting on CI update for wheels)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Python bindings for [Boost::Histogram][] ([source][Boost::Histogram source]), a 
 > * Docstrings and signatures will improve in later versions (especially on Python 3)
 > * `bh.project` is expected to change names
 > * Setting with an array is not yet supported (`h[...] = np.array(...)`)
-> * Projections with a limited range ("cropped first") are not yet supported
 > * A compiler is required to install on Python 3.8 on Windows (waiting on CI update for wheels)
 
 

--- a/boost_histogram/__init__.py
+++ b/boost_histogram/__init__.py
@@ -6,6 +6,9 @@ from ._internal.hist import Histogram as histogram
 
 from . import axis, storage, accumulators, algorithm, numpy
 
-from .tag import loc, rebin, project, underflow, overflow
+from .tag import loc, rebin, sum, underflow, overflow
+
+# Workaround for bh.project being available
+project = sum
 
 from .version import __version__

--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -66,8 +66,8 @@ def _compute_commonindex(hist, index, expand):
 
     # Allow [bh.loc(...)] to work
     for i in range(len(indexes)):
-        if hasattr(indexes[i], "value") and hasattr(indexes[i], "offset"):
-            indexes[i] = hist.axis(i).index(indexes[i].value) + indexes[i].offset
+        if callable(indexes[i]):
+            indexes[i] = indexes[i](_to_axis(hist.axis(i)))
         elif hasattr(indexes[i], "flow"):
             if indexes[i].flow == 1:
                 indexes[i] = hist.axis(i).size
@@ -351,7 +351,9 @@ class Histogram(BaseHistogram):
                 process_loc = (
                     lambda x, y: y
                     if x is None
-                    else (self._axis(i).index(x.value) if hasattr(x, "value") else x)
+                    else x(self._axis(i))
+                    if callable(x)
+                    else x
                 )
                 begin = process_loc(ind.start, 0)
                 end = process_loc(ind.stop, len(self._axis(i)))

--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -321,6 +321,8 @@ class Histogram(BaseHistogram):
 
         integrations = set()
         slices = []
+        zeroes_start = []
+        zeroes_stop = []
 
         # Compute needed slices and projections
         for i, ind in enumerate(indexes):
@@ -335,10 +337,10 @@ class Histogram(BaseHistogram):
                     if hasattr(ind.step, "projection"):
                         if ind.step.projection:
                             integrations.add(i)
-                            if ind.start is not None or ind.stop is not None:
-                                raise IndexError(
-                                    "Currently cut projections are not supported"
-                                )
+                            if ind.start is not None:  # TODO: Support callables too
+                                zeroes_start.append(i)
+                            if ind.stop is not None:
+                                zeroes_stop.append(i)
                         elif hasattr(ind.step, "factor"):
                             merge = ind.step.factor
                         else:
@@ -365,10 +367,19 @@ class Histogram(BaseHistogram):
             return self.__class__(reduced)
         else:
             projections = [i for i in range(self.rank) if i not in integrations]
+
+            # Replacement for crop missing in BH
+            for i in zeroes_start:
+                if self.axes[i].options.underflow:
+                    reduced._hist._reset_row(i, -1)
+            for i in zeroes_stop:
+                if self.axes[i].options.underflow:
+                    reduced._hist._reset_row(i, reduced.axes[i].size)
+
             return (
                 self.__class__(reduced.project(*projections))
                 if projections
-                else self.sum(flow=True)
+                else reduced.sum(flow=True)
             )
 
     def __setitem__(self, index, value):

--- a/boost_histogram/tag.py
+++ b/boost_histogram/tag.py
@@ -13,6 +13,9 @@ class loc(object):
         self.value = value
         self.offset = offset
 
+    def __call__(self, axis):
+        return axis.index(self.value) + self.offset
+
     def __add__(self, offset):
         return self.__class__(self.value, self.offset + offset)
 
@@ -41,10 +44,30 @@ class rebin(object):
 class project(object):
     projection = True
 
+    def __new__(cls, *args, **kargs):
+        return sum(*args, **kargs)
 
-class underflow(object):
-    flow = -1
+
+def underflow(axis):
+    return -1
 
 
-class overflow(object):
-    flow = 1
+def overflow(axis):
+    return len(axis)
+
+
+def end(axis):
+    return len(axis) - 1
+
+
+class at(object):
+    __slots__ = ("value",)
+
+    def __init__(self, value):
+        self.value = value
+
+    def __call__(self, axis):
+        if self.value < -2:
+            raise IndexError("Index cannot be less than -1")
+
+        return self.value

--- a/boost_histogram/tag.py
+++ b/boost_histogram/tag.py
@@ -32,12 +32,12 @@ class Locator(object):
         return ""
 
     def __repr__(self):
-        s = "{self.__class__.__name__}("
-        v = _print_self()
-        if offset != 0:
-            s += (", " if v else "") + " + offset={self.offset}"
-        s += ")"
-        return s.format(self=self)
+        s = self.__class__.__name__
+        s += self._print_self_()
+        if self.offset != 0:
+            s += " + " if self.offset > 0 else " - "
+            s += str(abs(self.offset))
+        return s
 
 
 class loc(Locator):
@@ -47,8 +47,8 @@ class loc(Locator):
         super(loc, self).__init__(offset)
         self.value = value
 
-    def _print_self(self):
-        return "{self.value}"
+    def _print_self_(self):
+        return "({0})".format(self.value)
 
     def __call__(self, axis):
         return axis.index(self.value) + self.offset
@@ -108,7 +108,3 @@ class sum(object):
     # if imported from boost_histogram directly
     def __new__(cls, *args, **kargs):
         return _np.sum(*args, **kargs)
-
-
-# Workaround for bh.project being available
-project = sum

--- a/boost_histogram/tag.py
+++ b/boost_histogram/tag.py
@@ -56,8 +56,9 @@ def overflow(axis):
     return len(axis)
 
 
+# Only valid in :: indexing, use -1 instead for normal indexing
 def end(axis):
-    return len(axis) - 1
+    return len(axis)
 
 
 class at(object):

--- a/docs/usage/indexing.rst
+++ b/docs/usage/indexing.rst
@@ -117,25 +117,27 @@ Basic implementation (WIP):
 
        # supporting __add__ and __sub__ also recommended
 
+       def __call__(self, axis):
+           return axis.index(self.value) + self.offset
+
    # Other flags, such as callable functions, could be added and detected later.
 
-   class project:
+   class sum:
        "When used in the step of a Histogram's slice, project sums over and eliminates what remains of the axis after slicing."
        projection = True
 
-       # Optional, not supported in boost-histogram
+       # Optional, not supported in boost-histogram yet
        def __new__(cls, binning, axis, counts):
-         return None, numpy.add.reduce(counts, axis=axis)
+           return None, numpy.add.reduce(counts, axis=axis)
 
 
    class end:
        ?
 
-   # Only these values have defined behavior
-   class underflow:
-       flow = -1
-   class overflow:
-       flow = 1
+   def underflow(axis):
+       return -1
+   def overflow(axis):
+       return len(axis)
 
 
    class rebin:

--- a/docs/usage/indexing.rst
+++ b/docs/usage/indexing.rst
@@ -2,10 +2,10 @@ Indexing
 ========
 
 This is the design document for Unified Histogram Indexing (UHI).  Much of the original plan is now implemented in boost-histogram.
-Other histogramming libraries can implement support for this as well, and the "tag" functors, like ``project`` and ``loc`` can be
+Other histogramming libraries can implement support for this as well, and the "tag" functors, like ``sum`` and ``loc`` can be
 used between libraries.
 
-The following examples assume you have imported ``loc``, ``project``, ``rebin``, ``end``, ``underflow``, and ``overflow`` from boost-histogram or any other
+The following examples assume you have imported ``loc``, ``sum``, ``rebin``, ``end``, ``underflow``, and ``overflow`` from boost-histogram or any other
 library that implements UHI.
 
 Access:
@@ -29,9 +29,9 @@ Slicing:
    h2 = h[loc(v):]       # Slices can be in data coordinates, too
    h2 = h[::rebin(2)]    # Modification operations (rebin)
    h2 = h[a:b:rebin(2)]  # Modifications can combine with slices
-   h2 = h[::project]     # Projection operations # (name may change)
-   h2 = h[a:b:project]   # Adding endpoints to projection operations
-   h2 = h[0:end:project] #   removes under or overflow from the calculation
+   h2 = h[::sum]     # Projection operations # (name may change)
+   h2 = h[a:b:sum]   # Adding endpoints to projection operations
+   h2 = h[0:end:sum] #   removes under or overflow from the calculation
    h2 = h[a:b, ...]      # Ellipsis work just like normal numpy
 
 Setting
@@ -91,7 +91,7 @@ TODO: Possibly extend to axes. Would follow the 1D cases above.
 Implementation notes
 --------------------
 
-loc, rebin, and project are *not* unique tags, or special types, but rather
+loc, rebin, and sum are *not* unique tags, or special types, but rather
 APIs for classes. New versions of these could be added, and
 implementations could be shared among Histogram libraries. For clarity,
 the following code is written in Python 3.6+. `Prototype
@@ -120,7 +120,7 @@ Basic implementation (WIP):
    # Other flags, such as callable functions, could be added and detected later.
 
    class sum:
-       "When used in the step of a Histogram's slice, project sums over and eliminates what remains of the axis after slicing."
+       "When used in the step of a Histogram's slice, sum sums over and eliminates what remains of the axis after slicing."
        projection = True
 
        # Optional, not supported in boost-histogram yet

--- a/docs/usage/indexing.rst
+++ b/docs/usage/indexing.rst
@@ -27,15 +27,12 @@ Slicing:
    h2 = h[a:b]           # Slice of histogram (includes flow bins)
    h2 = h[:b]            # Leaving out endpoints is okay
    h2 = h[loc(v):]       # Slices can be in data coordinates, too
-   h2 = h[::project]     # Projection operations # (name may change)
    h2 = h[::rebin(2)]    # Modification operations (rebin)
    h2 = h[a:b:rebin(2)]  # Modifications can combine with slices
+   h2 = h[::project]     # Projection operations # (name may change)
+   h2 = h[a:b:project]   # Adding endpoints to projection operations
+   h2 = h[0:end:project] #   removes under or overflow from the calculation
    h2 = h[a:b, ...]      # Ellipsis work just like normal numpy
-
-   # Not yet supported!
-   h2 = h[a:b:project] # Adding endpoints to projection operations removes under or overflow from the calculation
-   h2 = h[0:end:project] # Special end functor (TBD)
-   h2 = h[0:len(h2.axis(0)):project] # Projection without flow bins
 
 Setting
 ^^^^^^^

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -302,6 +302,18 @@ register_histogram(py::module &m, const char *name, const char *desc) {
                  return self;
              })
 
+        .def("_reset_row",
+             [](histogram_t &self, unsigned ax, int row) {
+                 // Reset just a single row. Used by indexing as a workaround
+                 // to remove the flow bins when missing crop
+
+                 for(auto &&ind : bh::indexed(self, bh::coverage::all)) {
+                     if(ind.index(ax) == row) {
+                         *ind = typename histogram_t::value_type();
+                     }
+                 }
+             })
+
         .def(make_pickle<histogram_t>())
 
         ;

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -125,15 +125,10 @@ def test_slicing_projection():
 
     assert h1[:: bh.project, :: bh.project, :: bh.project] == 12 ** 3
     assert (
-        h1[
-            0 : bh.tag.end : bh.project,
-            0 : bh.tag.end : bh.project,
-            0 : len : bh.project,
-        ]
-        == 10 ** 3
+        h1[0 : len : bh.project, 0 : len : bh.project, 0 : len : bh.project] == 10 ** 3
     )
     assert (
-        h1[0 : bh.tag.end : bh.project, 0 : len : bh.project, :: bh.project]
+        h1[0 : bh.overflow : bh.project, 0 : len : bh.project, :: bh.project]
         == 10 * 10 * 12
     )
     assert h1[:: bh.project, 0 : len : bh.project, :: bh.project] == 10 * 12 * 12

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -107,9 +107,9 @@ def test_basic_projection():
     h1.fill(contents[0])
     h2.fill(*contents)
 
-    assert h1 == h2[:, :: bh.project, :: bh.project]
-    assert h1 == h2[..., :: bh.project, :: bh.project]
-    assert h2.sum(flow=True) == h2[:: bh.project, :: bh.project, :: bh.project]
+    assert h1 == h2[:, :: bh.sum, :: bh.sum]
+    assert h1 == h2[..., :: bh.sum, :: bh.sum]
+    assert h2.sum(flow=True) == h2[:: bh.sum, :: bh.sum, :: bh.sum]
 
 
 def test_slicing_projection():
@@ -123,22 +123,33 @@ def test_slicing_projection():
 
     h1.fill(X.ravel(), Y.ravel(), Z.ravel())
 
-    assert h1[:: bh.project, :: bh.project, :: bh.project] == 12 ** 3
-    assert (
-        h1[0 : len : bh.project, 0 : len : bh.project, 0 : len : bh.project] == 10 ** 3
-    )
-    assert (
-        h1[0 : bh.overflow : bh.project, 0 : len : bh.project, :: bh.project]
-        == 10 * 10 * 12
-    )
-    assert h1[:: bh.project, 0 : len : bh.project, :: bh.project] == 10 * 12 * 12
+    assert h1[:: bh.sum, :: bh.sum, :: bh.sum] == 12 ** 3
+    assert h1[0 : len : bh.sum, 0 : len : bh.sum, 0 : len : bh.sum] == 10 ** 3
+    assert h1[0 : bh.overflow : bh.sum, 0 : len : bh.sum, :: bh.sum] == 10 * 10 * 12
+    assert h1[:: bh.sum, 0 : len : bh.sum, :: bh.sum] == 10 * 12 * 12
 
     # make sure nothing was modified
     assert h1.sum() == 10 ** 3
     assert h1.sum(flow=True) == 12 ** 3
 
-    h2 = h1[0 : 3 : bh.project, ...]
+    h2 = h1[0 : 3 : bh.sum, ...]
     assert h2[1, 2] == 3
 
-    h3 = h2[:, 5 : 7 : bh.project]
+    h3 = h2[:, 5 : 7 : bh.sum]
     assert h3[1] == 6
+
+
+def test_repr():
+    assert repr(bh.loc(2)) == "loc(2)"
+    assert repr(bh.loc(3) + 1) == "loc(3) + 1"
+    assert repr(bh.loc(1) - 2) == "loc(1) - 2"
+
+    assert repr(bh.underflow) == "underflow"
+    assert repr(bh.underflow + 1) == "underflow + 1"
+    assert repr(bh.underflow - 1) == "underflow - 1"
+
+    assert repr(bh.overflow) == "overflow"
+    assert repr(bh.overflow + 1) == "overflow + 1"
+    assert repr(bh.overflow - 1) == "overflow - 1"
+
+    assert repr(bh.rebin(2)) == "rebin(2)"

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -109,9 +109,10 @@ def test_fill_int_1d():
         # assert get(h, 1).variance == 1
         # assert get(h, 2).variance == 3
 
-    assert h[bh.tag.end] == 3
+    assert h[bh.overflow - 1] == 3
     assert h[bh.overflow] == 1
     assert h[bh.underflow] == 1
+    assert h[bh.underflow + 1] == 2
 
     assert h[-1] == 3
 
@@ -185,6 +186,7 @@ def test_growth():
     h.fill(0)
     for i in range(1000 - 256):
         h.fill(0)
+    print(h.view(flow=True))
     assert h[bh.underflow] == 0
     assert h[0] == 1
     assert h[1] == 1000

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -109,6 +109,7 @@ def test_fill_int_1d():
         # assert get(h, 1).variance == 1
         # assert get(h, 2).variance == 3
 
+    assert h[bh.tag.end] == 3
     assert h[bh.overflow] == 1
     assert h[bh.underflow] == 1
 
@@ -218,7 +219,7 @@ def test_fill_2d(flow):
         [0, 0, 0, 0, 0, 0],
     ]
 
-    for get in (lambda h, x, y: h._at(x, y),):
+    for get in (lambda h, x, y: h[bh.tag.at(x), bh.tag.at(y)],):
         # lambda h, x, y: h[x, y]):
         for i in range(-flow, h.axes[0].size + flow):
             for j in range(-flow, h.axes[1].size + flow):
@@ -253,7 +254,7 @@ def test_add_2d(flow):
 
     for i in range(-flow, h.axes[0].size + flow):
         for j in range(-flow, h.axes[1].size + flow):
-            assert h._at(i, j) == 2 * m[i][j]
+            assert h[bh.tag.at(i), bh.tag.at(j)] == 2 * m[i][j]
 
 
 def test_add_2d_bad():
@@ -299,7 +300,7 @@ def test_add_2d_w(flow):
 
     for i in range(-flow, h.axes[0].size + flow):
         for j in range(-flow, h.axes[1].size + flow):
-            assert h._at(i, j) == 2 * m[i][j]
+            assert h[bh.tag.at(i), bh.tag.at(j)] == 2 * m[i][j]
 
 
 def test_repr():


### PR DESCRIPTION
This brings UHI more inline with the original proposal from @jpivarski , and removes the internal tags originally required (`.value` and `.offset`). The original proposal is that the indexers would be callable functors, and they would receive the axis when being called. This simplifies `bh.loc`, and also makes it much easier for users to write there own. In fact, `len` naturally works:

```python
h[0:len:bh.project]
```

Will sum without including the flow bins. This also includes the trick proposed by @HDembinski, where cropping is simulated through setting flow bins on a copy to 0, so it now finally allows limits on sums! Closes #135. `bh.sum` is available now, as well, though `bh.project` is still around for the moment.

We need to think a little about the difference in slicing and direct access. Currently,
```python
h[bh.overflow]
```
gets the overflow bin. While:

```python
h[bh.underflow:bh.overflow:bh.project]
```

does not include the overflow bin, following the standard meaning of Python indexing. While this is incorrect (you should leave endpoints off to get the overflow bin). I *think* this is consistent and correct, but might be surprising to users. ~~It also means `bh.end` would only work in `h[bh.end]`, while `h[:bh.end]` would be one less than the end~~ (`len` or `bh.overflow` would be used to slice to the end). I've removed end.