### PR TITLE
WIP: Access accumulator storages

### DIFF
--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -4,6 +4,7 @@ from .kwargs import KWArgs
 
 from .. import _core
 from .axis import _to_axis, Axis
+from .view import _to_view
 from .axistuple import AxesTuple
 from .sig_tools import inject_signature
 from .storage import Double, _to_storage
@@ -137,7 +138,7 @@ class BaseHistogram(object):
         return self.__class__.__name__ + repr(self._hist)[9:]
 
     def __array__(self):
-        return np.asarray(self._hist)
+        return _to_view(np.asarray(self._hist))
         # TODO: .view does not seem to return an editable view
         #        so we have to use the buffer interface here
 
@@ -298,7 +299,7 @@ class Histogram(BaseHistogram):
         """
         Return a view into the data, optionally with overflow turned on.
         """
-        return self._hist.view(flow)
+        return _to_view(self._hist.view(flow))
 
     def reset(self):
         """

--- a/boost_histogram/_internal/view.py
+++ b/boost_histogram/_internal/view.py
@@ -1,0 +1,92 @@
+from __future__ import absolute_import, division, print_function
+
+from ..accumulators import Mean, WeightedMean, WeightedSum
+
+import numpy as np
+
+
+class View(np.ndarray):
+    __slots__ = ()
+
+    def __getitem__(self, ind):
+        sliced = super(View, self).__getitem__(ind)
+        if sliced.shape:
+            return sliced
+        else:
+            return self._PARENT._make(*sliced)
+
+    def __repr__(self):
+        return repr(self.view(np.ndarray))
+
+    def __str__(self):
+        return str(self.view(np.ndarray))
+
+
+class MeanView(View):
+    __slots__ = ()
+    _PARENT = Mean
+    _FIELDS = ("sum_", "mean_", "sum_of_deltas_squared_")
+
+    @property
+    def count(self):
+        return self["mean_"]
+
+    @property
+    def value(self):
+        return self["sum_"]
+
+    # Variance is a computation
+    @property
+    def variance(self):
+        return self["sum_of_deltas_squared_"] / (self["sum_"] - 1)
+
+
+class WeightedSumView(View):
+    __slots__ = ()
+    _PARENT = WeightedSum
+    _FIELDS = ("sum_of_weights_", "sum_of_weights_squared_")
+
+    @property
+    def sum_of_weights(self):
+        return self["sum_of_weights_"]
+
+    @property
+    def sum_of_weights_squared(self):
+        return self["sum_of_weights_squared_"]
+
+
+class WeightedMeanView(View):
+    __slots__ = ()
+    _PARENT = WeightedMean
+    _FIELDS = (
+        "sum_of_weights_",
+        "sum_of_weights_squared_",
+        "weighted_mean_",
+        "sum_of_weighted_deltas_squared_",
+    )
+
+    @property
+    def sum_of_weights(self):
+        return self["sum_of_weights_"]
+
+    @property
+    def sum_of_weights_squared(self):
+        return self["sum_of_weights_squared_"]
+
+    @property
+    def value(self):
+        return self["weighted_mean_"]
+
+    @property
+    def variance(self):
+        return self["sum_of_weighted_deltas_squared_"] / (
+            self["sum_of_weights_"]
+            - self["sum_of_weights_squared_"] / self["sum_of_weights_"]
+        )
+
+
+def _to_view(item):
+    for cls in View.__subclasses__():
+        if cls._FIELDS == item.dtype.fields:
+            return item.view(cls)
+    return item

--- a/include/boost/histogram/python/accumulators/mean.hpp
+++ b/include/boost/histogram/python/accumulators/mean.hpp
@@ -1,0 +1,128 @@
+// Copyright 2015-2019 Hans Dembinski and Henry Schreiner
+//
+// Distributed under the Boost Software License, version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Based on boost/histogram/accumulators/mean.hpp
+
+#pragma once
+
+#include <boost/assert.hpp>
+#include <boost/core/nvp.hpp>
+#include <boost/histogram/fwd.hpp> // for mean<>
+#include <boost/throw_exception.hpp>
+#include <stdexcept>
+#include <type_traits>
+
+namespace boost {
+namespace histogram {
+namespace python {
+
+/** Calculates mean and variance of sample.
+
+  Uses Welfords's incremental algorithm to improve the numerical
+  stability of mean and variance computation.
+*/
+template <class RealType>
+class mean {
+  public:
+    mean() = default;
+    mean(const RealType &n, const RealType &mean, const RealType &variance) noexcept
+        : sum_(n)
+        , mean_(mean)
+        , sum_of_deltas_squared_(variance * (n - 1)) {}
+
+    void operator()(const RealType &x) noexcept {
+        sum_ += static_cast<RealType>(1);
+        const auto delta = x - mean_;
+        mean_ += delta / sum_;
+        sum_of_deltas_squared_ += delta * (x - mean_);
+    }
+
+    void operator()(const weight_type<RealType> &w, const RealType &x) noexcept {
+        sum_ += w.value;
+        const auto delta = x - mean_;
+        mean_ += w.value * delta / sum_;
+        sum_of_deltas_squared_ += w.value * delta * (x - mean_);
+    }
+
+    template <class T>
+    mean &operator+=(const mean<T> &rhs) noexcept {
+        if(sum_ != 0 || rhs.sum_ != 0) {
+            const auto tmp = mean_ * sum_ + static_cast<RealType>(rhs.mean_ * rhs.sum_);
+            sum_ += rhs.sum_;
+            mean_ = tmp / sum_;
+        }
+        sum_of_deltas_squared_ += static_cast<RealType>(rhs.sum_of_deltas_squared_);
+        return *this;
+    }
+
+    mean &operator*=(const RealType &s) noexcept {
+        mean_ *= s;
+        sum_of_deltas_squared_ *= s * s;
+        return *this;
+    }
+
+    template <class T>
+    bool operator==(const mean<T> &rhs) const noexcept {
+        return sum_ == rhs.sum_ && mean_ == rhs.mean_
+               && sum_of_deltas_squared_ == rhs.sum_of_deltas_squared_;
+    }
+
+    template <class T>
+    bool operator!=(const mean<T> &rhs) const noexcept {
+        return !operator==(rhs);
+    }
+
+    const RealType &count() const noexcept { return sum_; }
+    const RealType &value() const noexcept { return mean_; }
+    RealType variance() const noexcept { return sum_of_deltas_squared_ / (sum_ - 1); }
+
+    template <class Archive>
+    void serialize(Archive &ar, unsigned version) {
+        if(version == 0) {
+            // read only
+            std::size_t sum;
+            ar &make_nvp("sum", sum);
+            sum_ = static_cast<RealType>(sum);
+        } else {
+            ar &make_nvp("sum", sum_);
+        }
+        ar &make_nvp("mean", mean_);
+        ar &make_nvp("sum_of_deltas_squared", sum_of_deltas_squared_);
+    }
+
+  private:
+    RealType sum_ = 0, mean_ = 0, sum_of_deltas_squared_ = 0;
+};
+
+} // namespace python
+} // namespace histogram
+} // namespace boost
+
+#ifndef BOOST_HISTOGRAM_DOXYGEN_INVOKED
+
+namespace boost {
+namespace serialization {
+
+template <class T>
+struct version;
+
+// version 1 for boost::histogram::accumulators::mean<RealType>
+template <class RealType>
+struct version<histogram::python::mean<RealType>> : std::integral_constant<int, 1> {};
+
+} // namespace serialization
+} // namespace boost
+
+namespace std {
+template <class T, class U>
+/// Specialization for boost::histogram::accumulators::mean.
+struct common_type<boost::histogram::accumulators::mean<T>,
+                   boost::histogram::accumulators::mean<U>> {
+    using type = boost::histogram::accumulators::mean<common_type_t<T, U>>;
+};
+} // namespace std
+
+#endif

--- a/include/boost/histogram/python/accumulators/mean.hpp
+++ b/include/boost/histogram/python/accumulators/mean.hpp
@@ -25,13 +25,21 @@ namespace python {
   stability of mean and variance computation.
 */
 template <class RealType>
-class mean {
+struct mean {
   public:
     mean() = default;
     mean(const RealType &n, const RealType &mean, const RealType &variance) noexcept
         : sum_(n)
         , mean_(mean)
         , sum_of_deltas_squared_(variance * (n - 1)) {}
+
+    mean(const RealType &sum,
+         const RealType &mean,
+         const RealType &sum_of_deltas_squared,
+         bool /* Tag to trigger python internal constructor */)
+        : sum_(sum)
+        , mean_(mean)
+        , sum_of_deltas_squared_(sum_of_deltas_squared) {}
 
     void operator()(const RealType &x) noexcept {
         sum_ += static_cast<RealType>(1);
@@ -93,7 +101,6 @@ class mean {
         ar &make_nvp("sum_of_deltas_squared", sum_of_deltas_squared_);
     }
 
-  private:
     RealType sum_ = 0, mean_ = 0, sum_of_deltas_squared_ = 0;
 };
 

--- a/include/boost/histogram/python/accumulators/weighted_mean.hpp
+++ b/include/boost/histogram/python/accumulators/weighted_mean.hpp
@@ -25,7 +25,7 @@ namespace python {
   of mean and variance computation.
 */
 template <typename RealType>
-class weighted_mean {
+struct weighted_mean {
   public:
     weighted_mean() = default;
     weighted_mean(const RealType &wsum,
@@ -38,6 +38,16 @@ class weighted_mean {
         , sum_of_weighted_deltas_squared_(
               variance
               * (sum_of_weights_ - sum_of_weights_squared_ / sum_of_weights_)) {}
+
+    weighted_mean(const RealType &wsum,
+                  const RealType &wsum2,
+                  const RealType &mean,
+                  const RealType &sum_of_weighted_deltas_squared,
+                  bool)
+        : sum_of_weights_(wsum)
+        , sum_of_weights_squared_(wsum2)
+        , weighted_mean_(mean)
+        , sum_of_weighted_deltas_squared_(sum_of_weighted_deltas_squared) {}
 
     void operator()(const RealType &x) { operator()(weight(1), x); }
 
@@ -103,7 +113,6 @@ class weighted_mean {
         ar &make_nvp("sum_of_weighted_deltas_squared", sum_of_weighted_deltas_squared_);
     }
 
-  private:
     RealType sum_of_weights_ = RealType(), sum_of_weights_squared_ = RealType(),
              weighted_mean_ = RealType(), sum_of_weighted_deltas_squared_ = RealType();
 };

--- a/include/boost/histogram/python/accumulators/weighted_mean.hpp
+++ b/include/boost/histogram/python/accumulators/weighted_mean.hpp
@@ -1,0 +1,124 @@
+// Copyright 2018-2019 Hans Dembinski and Henry Schreiner
+//
+// Distributed under the Boost Software License, version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Based on boost/histogram/accumulators/weighted_mean.hpp
+
+#pragma once
+
+#include <boost/assert.hpp>
+#include <boost/core/nvp.hpp>
+#include <boost/histogram/fwd.hpp> // for weighted_mean<>
+#include <boost/histogram/weight.hpp>
+#include <type_traits>
+
+namespace boost {
+namespace histogram {
+namespace python {
+
+/**
+  Calculates mean and variance of weighted sample.
+
+  Uses West's incremental algorithm to improve numerical stability
+  of mean and variance computation.
+*/
+template <typename RealType>
+class weighted_mean {
+  public:
+    weighted_mean() = default;
+    weighted_mean(const RealType &wsum,
+                  const RealType &wsum2,
+                  const RealType &mean,
+                  const RealType &variance)
+        : sum_of_weights_(wsum)
+        , sum_of_weights_squared_(wsum2)
+        , weighted_mean_(mean)
+        , sum_of_weighted_deltas_squared_(
+              variance
+              * (sum_of_weights_ - sum_of_weights_squared_ / sum_of_weights_)) {}
+
+    void operator()(const RealType &x) { operator()(weight(1), x); }
+
+    void operator()(const weight_type<RealType> &w, const RealType &x) {
+        sum_of_weights_ += w.value;
+        sum_of_weights_squared_ += w.value * w.value;
+        const auto delta = x - weighted_mean_;
+        weighted_mean_ += w.value * delta / sum_of_weights_;
+        sum_of_weighted_deltas_squared_ += w.value * delta * (x - weighted_mean_);
+    }
+
+    template <typename T>
+    weighted_mean &operator+=(const weighted_mean<T> &rhs) {
+        if(sum_of_weights_ != 0 || rhs.sum_of_weights_ != 0) {
+            const auto tmp
+                = weighted_mean_ * sum_of_weights_
+                  + static_cast<RealType>(rhs.weighted_mean_ * rhs.sum_of_weights_);
+            sum_of_weights_ += static_cast<RealType>(rhs.sum_of_weights_);
+            sum_of_weights_squared_
+                += static_cast<RealType>(rhs.sum_of_weights_squared_);
+            weighted_mean_ = tmp / sum_of_weights_;
+        }
+        sum_of_weighted_deltas_squared_
+            += static_cast<RealType>(rhs.sum_of_weighted_deltas_squared_);
+        return *this;
+    }
+
+    weighted_mean &operator*=(const RealType &s) {
+        weighted_mean_ *= s;
+        sum_of_weighted_deltas_squared_ *= s * s;
+        return *this;
+    }
+
+    template <typename T>
+    bool operator==(const weighted_mean<T> &rhs) const noexcept {
+        return sum_of_weights_ == rhs.sum_of_weights_
+               && sum_of_weights_squared_ == rhs.sum_of_weights_squared_
+               && weighted_mean_ == rhs.weighted_mean_
+               && sum_of_weighted_deltas_squared_
+                      == rhs.sum_of_weighted_deltas_squared_;
+    }
+
+    template <typename T>
+    bool operator!=(const T &rhs) const noexcept {
+        return !operator==(rhs);
+    }
+
+    const RealType &sum_of_weights() const noexcept { return sum_of_weights_; }
+    const RealType &sum_of_weights_squared() const noexcept {
+        return sum_of_weights_squared_;
+    }
+    const RealType &value() const noexcept { return weighted_mean_; }
+    RealType variance() const {
+        return sum_of_weighted_deltas_squared_
+               / (sum_of_weights_ - sum_of_weights_squared_ / sum_of_weights_);
+    }
+
+    template <class Archive>
+    void serialize(Archive &ar, unsigned /* version */) {
+        ar &make_nvp("sum_of_weights", sum_of_weights_);
+        ar &make_nvp("sum_of_weights_squared", sum_of_weights_squared_);
+        ar &make_nvp("weighted_mean", weighted_mean_);
+        ar &make_nvp("sum_of_weighted_deltas_squared", sum_of_weighted_deltas_squared_);
+    }
+
+  private:
+    RealType sum_of_weights_ = RealType(), sum_of_weights_squared_ = RealType(),
+             weighted_mean_ = RealType(), sum_of_weighted_deltas_squared_ = RealType();
+};
+
+} // namespace python
+} // namespace histogram
+} // namespace boost
+
+#ifndef BOOST_HISTOGRAM_DOXYGEN_INVOKED
+namespace std {
+template <class T, class U>
+/// Specialization for boost::histogram::accumulators::weighted_mean.
+struct common_type<boost::histogram::accumulators::weighted_mean<T>,
+                   boost::histogram::accumulators::weighted_mean<U>> {
+    using type = boost::histogram::accumulators::weighted_mean<common_type_t<T, U>>;
+};
+} // namespace std
+#endif

--- a/include/boost/histogram/python/accumulators/weighted_sum.hpp
+++ b/include/boost/histogram/python/accumulators/weighted_sum.hpp
@@ -1,0 +1,117 @@
+// Copyright 2015-2019 Hans Dembinski and Henry Schreiner
+//
+// Distributed under the Boost Software License, version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Based on boost/histogram/accumulators/weighted_mean.hpp
+
+#pragma once
+
+#include <boost/core/nvp.hpp>
+#include <boost/histogram/fwd.hpp> // for weighted_sum<>
+#include <type_traits>
+
+namespace boost {
+namespace histogram {
+namespace python {
+
+/// Holds sum of weights and its variance estimate
+template <typename RealType>
+class weighted_sum {
+  public:
+    weighted_sum() = default;
+    explicit weighted_sum(const RealType &value) noexcept
+        : sum_of_weights_(value)
+        , sum_of_weights_squared_(value) {}
+    weighted_sum(const RealType &value, const RealType &variance) noexcept
+        : sum_of_weights_(value)
+        , sum_of_weights_squared_(variance) {}
+
+    /// Increment by one.
+    weighted_sum &operator++() { return operator+=(1); }
+
+    /// Increment by value.
+    template <typename T>
+    weighted_sum &operator+=(const T &value) {
+        sum_of_weights_ += value;
+        sum_of_weights_squared_ += value * value;
+        return *this;
+    }
+
+    /// Added another weighted sum.
+    template <typename T>
+    weighted_sum &operator+=(const weighted_sum<T> &rhs) {
+        sum_of_weights_ += static_cast<RealType>(rhs.sum_of_weights_);
+        sum_of_weights_squared_ += static_cast<RealType>(rhs.sum_of_weights_squared_);
+        return *this;
+    }
+
+    /// Scale by value.
+    weighted_sum &operator*=(const RealType &x) {
+        sum_of_weights_ *= x;
+        sum_of_weights_squared_ *= x * x;
+        return *this;
+    }
+
+    bool operator==(const RealType &rhs) const noexcept {
+        return sum_of_weights_ == rhs && sum_of_weights_squared_ == rhs;
+    }
+
+    template <typename T>
+    bool operator==(const weighted_sum<T> &rhs) const noexcept {
+        return sum_of_weights_ == rhs.sum_of_weights_
+               && sum_of_weights_squared_ == rhs.sum_of_weights_squared_;
+    }
+
+    template <typename T>
+    bool operator!=(const T &rhs) const noexcept {
+        return !operator==(rhs);
+    }
+
+    /// Return value of the sum.
+    const RealType &value() const noexcept { return sum_of_weights_; }
+
+    /// Return estimated variance of the sum.
+    const RealType &variance() const noexcept { return sum_of_weights_squared_; }
+
+    // lossy conversion must be explicit
+    template <class T>
+    explicit operator T() const {
+        return static_cast<T>(sum_of_weights_);
+    }
+
+    template <class Archive>
+    void serialize(Archive &ar, unsigned /* version */) {
+        ar &make_nvp("sum_of_weights", sum_of_weights_);
+        ar &make_nvp("sum_of_weights_squared", sum_of_weights_squared_);
+    }
+
+  private:
+    RealType sum_of_weights_         = RealType();
+    RealType sum_of_weights_squared_ = RealType();
+};
+
+} // namespace python
+} // namespace histogram
+} // namespace boost
+
+#ifndef BOOST_HISTOGRAM_DOXYGEN_INVOKED
+namespace std {
+template <class T, class U>
+struct common_type<boost::histogram::accumulators::weighted_sum<T>,
+                   boost::histogram::accumulators::weighted_sum<U>> {
+    using type = boost::histogram::accumulators::weighted_sum<common_type_t<T, U>>;
+};
+
+template <class T, class U>
+struct common_type<boost::histogram::accumulators::weighted_sum<T>, U> {
+    using type = boost::histogram::accumulators::weighted_sum<common_type_t<T, U>>;
+};
+
+template <class T, class U>
+struct common_type<T, boost::histogram::accumulators::weighted_sum<U>> {
+    using type = boost::histogram::accumulators::weighted_sum<common_type_t<T, U>>;
+};
+} // namespace std
+#endif

--- a/include/boost/histogram/python/accumulators/weighted_sum.hpp
+++ b/include/boost/histogram/python/accumulators/weighted_sum.hpp
@@ -18,7 +18,7 @@ namespace python {
 
 /// Holds sum of weights and its variance estimate
 template <typename RealType>
-class weighted_sum {
+struct weighted_sum {
   public:
     weighted_sum() = default;
     explicit weighted_sum(const RealType &value) noexcept
@@ -87,7 +87,6 @@ class weighted_sum {
         ar &make_nvp("sum_of_weights_squared", sum_of_weights_squared_);
     }
 
-  private:
     RealType sum_of_weights_         = RealType();
     RealType sum_of_weights_squared_ = RealType();
 };

--- a/include/boost/histogram/python/accumulators_ostream.hpp
+++ b/include/boost/histogram/python/accumulators_ostream.hpp
@@ -8,6 +8,10 @@
 
 #pragma once
 
+#include <boost/histogram/python/accumulators/mean.hpp>
+#include <boost/histogram/python/accumulators/weighted_mean.hpp>
+#include <boost/histogram/python/accumulators/weighted_sum.hpp>
+
 #include <boost/histogram/detail/counting_streambuf.hpp>
 #include <boost/histogram/fwd.hpp>
 #include <iosfwd>
@@ -40,10 +44,11 @@ handle_nonzero_width(std::basic_ostream<CharT, Traits> &os, const T &x) {
 
 } // namespace detail
 
-namespace accumulators {
+namespace python {
+
 template <class CharT, class Traits, class W>
 std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> &os,
-                                              const sum<W> &x) {
+                                              const accumulators::sum<W> &x) {
     if(os.width() == 0)
         return os << "sum(" << x.large() << " + " << x.small() << ")";
     return detail::handle_nonzero_width(os, x);
@@ -79,10 +84,10 @@ std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> 
 
 template <class CharT, class Traits, class T>
 std::basic_ostream<CharT, Traits> &operator<<(std::basic_ostream<CharT, Traits> &os,
-                                              const thread_safe<T> &x) {
+                                              const accumulators::thread_safe<T> &x) {
     os << x.load();
     return os;
 }
-} // namespace accumulators
+} // namespace python
 } // namespace histogram
 } // namespace boost

--- a/include/boost/histogram/python/histogram.hpp
+++ b/include/boost/histogram/python/histogram.hpp
@@ -7,6 +7,10 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
+#include <boost/histogram/python/accumulators/mean.hpp>
+#include <boost/histogram/python/accumulators/weighted_mean.hpp>
+#include <boost/histogram/python/accumulators/weighted_sum.hpp>
+
 #include <boost/histogram/detail/axes.hpp>
 #include <boost/histogram/histogram.hpp>
 #include <boost/histogram/unsafe_access.hpp>
@@ -19,46 +23,6 @@ namespace pybind11 {
 template <class T>
 struct format_descriptor<bh::accumulators::thread_safe<T>> : format_descriptor<T> {
     static_assert(std::is_standard_layout<bh::accumulators::thread_safe<T>>::value, "");
-};
-
-/// This descriptor depends on the memory format for mean<double> remaining unchanged
-template <>
-struct format_descriptor<bh::accumulators::mean<double>> {
-    static std::string format() {
-        return std::string("T{"
-                           "d:sum_:"
-                           "d:mean_:"
-                           "d:sum_of_deltas_squared_:}");
-    }
-};
-
-// If made public, could be:
-// PYBIND11_NUMPY_DTYPE(mean, sum_, mean_, sum_of_deltas_squared_);
-
-/// This descriptor depends on the memory format for weighted_mean<double> remaining
-/// unchanged
-template <>
-struct format_descriptor<bh::accumulators::weighted_mean<double>> {
-    static std::string format() {
-        return std::string("T{"
-                           "d:sum_of_weights_:"
-                           "d:sum_of_weights_squared_:"
-                           "d:weighted_mean_:"
-                           "d:sum_of_weighted_deltas_squared_:"
-                           "}");
-    }
-};
-
-/// This descriptor depends on the memory format for weighted_sum<double> remaining
-/// unchanged
-template <>
-struct format_descriptor<bh::accumulators::weighted_sum<double>> {
-    static std::string format() {
-        return std::string("T{"
-                           "d:sum_of_weights_:"
-                           "d:sum_of_weights_squared_:"
-                           "}");
-    }
 };
 
 } // namespace pybind11

--- a/include/boost/histogram/python/histogram.hpp
+++ b/include/boost/histogram/python/histogram.hpp
@@ -13,10 +13,54 @@
 #include <type_traits>
 
 namespace pybind11 {
+
+/// The descriptor for atomic_* is the same as the descriptor for *, as long this uses
+/// standard layout
 template <class T>
 struct format_descriptor<bh::accumulators::thread_safe<T>> : format_descriptor<T> {
     static_assert(std::is_standard_layout<bh::accumulators::thread_safe<T>>::value, "");
 };
+
+/// This descriptor depends on the memory format for mean<double> remaining unchanged
+template <>
+struct format_descriptor<bh::accumulators::mean<double>> {
+    static std::string format() {
+        return std::string("T{"
+                           "d:sum_:"
+                           "d:mean_:"
+                           "d:sum_of_deltas_squared_:}");
+    }
+};
+
+// If made public, could be:
+// PYBIND11_NUMPY_DTYPE(mean, sum_, mean_, sum_of_deltas_squared_);
+
+/// This descriptor depends on the memory format for weighted_mean<double> remaining
+/// unchanged
+template <>
+struct format_descriptor<bh::accumulators::weighted_mean<double>> {
+    static std::string format() {
+        return std::string("T{"
+                           "d:sum_of_weights_:"
+                           "d:sum_of_weights_squared_:"
+                           "d:weighted_mean_:"
+                           "d:sum_of_weighted_deltas_squared_:"
+                           "}");
+    }
+};
+
+/// This descriptor depends on the memory format for weighted_sum<double> remaining
+/// unchanged
+template <>
+struct format_descriptor<bh::accumulators::weighted_sum<double>> {
+    static std::string format() {
+        return std::string("T{"
+                           "d:sum_of_weights_:"
+                           "d:sum_of_weights_squared_:"
+                           "}");
+    }
+};
+
 } // namespace pybind11
 
 namespace detail {

--- a/include/boost/histogram/python/storage.hpp
+++ b/include/boost/histogram/python/storage.hpp
@@ -7,7 +7,11 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
-#include <boost/histogram/accumulators.hpp>
+#include <boost/histogram/accumulators/sum.hpp>
+#include <boost/histogram/accumulators/thread_safe.hpp>
+#include <boost/histogram/python/accumulators/mean.hpp>
+#include <boost/histogram/python/accumulators/weighted_mean.hpp>
+#include <boost/histogram/python/accumulators/weighted_sum.hpp>
 #include <boost/histogram/storage_adaptor.hpp>
 #include <boost/histogram/unlimited_storage.hpp>
 
@@ -20,9 +24,9 @@ using int_          = bh::dense_storage<uint64_t>;
 using atomic_int    = bh::dense_storage<bh::accumulators::thread_safe<uint64_t>>;
 using double_       = bh::dense_storage<double>;
 using unlimited     = bh::unlimited_storage<>;
-using weight        = bh::weight_storage;
-using mean          = bh::profile_storage;
-using weighted_mean = bh::weighted_profile_storage;
+using weight        = bh::dense_storage<bh::python::weighted_sum<double>>;
+using mean          = bh::dense_storage<bh::python::mean<double>>;
+using weighted_mean = bh::dense_storage<bh::python::weighted_mean<double>>;
 
 // Allow repr to show python name
 template <class S>

--- a/src/register_accumulators.cpp
+++ b/src/register_accumulators.cpp
@@ -5,10 +5,10 @@
 
 #include <boost/histogram/python/pybind11.hpp>
 
-#include <boost/histogram/accumulators/mean.hpp>
 #include <boost/histogram/accumulators/sum.hpp>
-#include <boost/histogram/accumulators/weighted_mean.hpp>
-#include <boost/histogram/accumulators/weighted_sum.hpp>
+#include <boost/histogram/python/accumulators/mean.hpp>
+#include <boost/histogram/python/accumulators/weighted_mean.hpp>
+#include <boost/histogram/python/accumulators/weighted_sum.hpp>
 #include <boost/histogram/python/accumulators_ostream.hpp>
 #include <boost/histogram/python/kwargs.hpp>
 #include <boost/histogram/python/register_accumulator.hpp>
@@ -52,7 +52,7 @@ decltype(auto) make_mean_call() {
 }
 
 void register_accumulators(py::module &accumulators) {
-    using weighted_sum = bh::accumulators::weighted_sum<double>;
+    using weighted_sum = bh::python::weighted_sum<double>;
 
     register_accumulator<weighted_sum>(accumulators, "weighted_sum")
 
@@ -115,7 +115,7 @@ void register_accumulators(py::module &accumulators) {
 
         ;
 
-    using weighted_mean = bh::accumulators::weighted_mean<double>;
+    using weighted_mean = bh::python::weighted_mean<double>;
 
     register_accumulator<weighted_mean>(accumulators, "weighted_mean")
         .def(py::init<const double &, const double &, const double &, const double &>(),
@@ -140,7 +140,7 @@ void register_accumulators(py::module &accumulators) {
 
         ;
 
-    using mean = bh::accumulators::mean<double>;
+    using mean = bh::python::mean<double>;
 
     register_accumulator<mean>(accumulators, "mean")
         .def(py::init<const double &, const double &, const double &>(),


### PR DESCRIPTION
This allows direct memory access to non-simple storages, no longer throws error/segfault and fixes the most common error reported by users, #175 and on gitter. Original issue: #21. Currently, it is mostly a proof of concept, as a future plan below must be chosen.

This method *requires* direct memory access into accumulators. This is currently not a public part of Boost.Histogram, so could potentially be broken in the future. This could be solved by:

1. Making this a promised ABI in Boost.Histogram. This would at least need special constructors for some accumulators to allow them to be made from the raw values.
2. Make the internal values public in Boost.Histogram, thereby officially making this available and unchangeable, which would allow `PYBIND11_NUMPY_DTYPE` to be used to make the RecordArray.
3. Copy the accumulator code into boost-histogram, so that we could use option 2) and not depend on cluttering/loosening/promising in Boost.Histogram. This would mean we would have to copy in changes (like to the weight that happened recently).

Direct memory access into accumulators is currently needed for getting and setting accumulator storages with array expressions. In the future, the proposed numbafication project will probably also need direct access to storage data.

Once we have this, we can provide a Python NDArray subclass or proxy object that will keep the details (partially) hidden from users, so they can access arrays of values with the same syntax. as a normal accumulator and perform some operations. 

I locally have started on the wrapper object, but since I can't construct accumulators from the raw values, this keeps `array[i]` from producing an accumulator.

Example of current (unwrapped) version:

```python
In [1]: h = bh.histogram((10,0,1), storage=bh.storage.weight)

In [2]: h.fill(np.random.rand(100), weight=np.random.rand(100))
Out[2]:
Histogram(
  regular(10, 0, 1),
  storage=weight
) # Sum: weighted_sum(value=50.34, variance=35.681)

In [3]: h.view()
Out[3]:
array([(6.7629267 , 5.11955394), (4.25568444, 2.48312512),
       (6.62707634, 5.08164912), (3.273183  , 2.09949326),
       (6.28007822, 4.4779143 ), (5.38847563, 3.6516565 ),
       (8.79954476, 6.84868563), (2.73569681, 1.65033745),
       (1.36933037, 0.86418926), (4.8479874 , 3.40439761)],
      dtype=[('sum_of_weights_', '<f8'), ('sum_of_weights_squared_', '<f8')])
```