### PR TITLE
Adding signature decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 [![Documentation Status][rtd-badge]][rtd-link]
 [![DOI](https://zenodo.org/badge/148885351.svg)](https://zenodo.org/badge/latestdoi/148885351)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
-[![PyPI version](https://badge.fury.io/py/boost-histogram.svg)](https://badge.fury.io/py/boost-histogram)
+[![PyPI version](https://badge.fury.io/py/boost-histogram.svg)](https://pypi.org/project/boost-histogram/)
+[![Conda-Forge](https://img.shields.io/conda/vn/conda-forge/boost-histogram)][conda-link]
 
 Python bindings for [Boost::Histogram][] ([source][Boost::Histogram source]), a C++14 library. This should become one of the [fastest libraries][] for histogramming, while still providing the power of a full histogram object.
 
@@ -16,12 +17,10 @@ Python bindings for [Boost::Histogram][] ([source][Boost::Histogram source]), a 
 > Please feel free to try out boost-histogram and give feedback.
 > Join the [discussion on gitter][gitter-link] or [open an issue](https://github.com/scikit-hep/boost-histogram/issues)!
 >
-> #### Known issues:
-> * Non-simple storages do not support `.view()` or the buffer interface; you can access and set one element at a time
-> * Docstrings and signatures will improve in later versions (especially on Python 3)
-> * Setting with an array is not yet supported (`h[...] = np.array(...)`)
-> * A compiler is required to install on Python 3.8 on Windows (waiting on CI update for wheels)
-
+> #### Known issues (develop):
+> * Non-simple storages do not support `.view()` or the buffer interface; you can access and set one element at a time.
+> * Setting with an array is not yet supported (`h[...] = np.array(...)`).
+> * A compiler is required to install on Python 3.8 on Windows with pip (waiting on CI update for wheels) (conda-forge already has Python 3.8 packages).
 
 
 ## Installation
@@ -141,6 +140,11 @@ The easiest way to get boost-histogram is to use a binary wheel. These are the s
 
 If you are on a Linux system that is not part of the "many" in manylinux, such as Alpine or ClearLinux, building from source is usually fine, since the compilers on those systems are often quite new. It will just take a little longer to install when it's using the sdist instead of a wheel.
 
+
+#### Conda-Forge
+
+The boost-histogram package is available on Conda-Forge, as well. All supported versions are available with the exception of Windows + Python 2.7, which cannot build due to the age of the compiler. Please use Pip if you *really* need Python 2.7 on Windows. You will also need the VS 2015 distributable, as described above.
+
 #### Source builds
 
 For a source build, for example from an "sdist" package, the only requirements are a C++14 compatible compiler. The compiler requirements are dictated by Boost.Histogram's C++ requirements: gcc >= 5.5, clang >= 3.8, msvc >= 14.1.
@@ -183,3 +187,4 @@ Support for this work was provided by the National Science Foundation cooperativ
 [Boost::Histogram]:        https://www.boost.org/doc/libs/1_71_0/libs/histogram/doc/html/index.html
 [Boost::Histogram source]: https://github.com/boostorg/histogram
 [fastest libraries]:       https://iscinumpy.gitlab.io/post/histogram-speeds-in-python/
+[conda-link]:              https://github.com/conda-forge/boost-histogram-feedstock

--- a/boost_histogram/_internal/axis.py
+++ b/boost_histogram/_internal/axis.py
@@ -7,6 +7,7 @@ from .._core.axis import options
 from .._core import axis as ca
 
 from .kwargs import KWArgs
+from .sig_tools import inject_signature
 
 
 class Axis(object):
@@ -131,6 +132,9 @@ class Regular(Axis):
         ca.circular,
     }
 
+    @inject_signature(
+        "self, bins, start, stop, *, metadata=None, underflow=True, overflow=True, growth=False"
+    )
     def __init__(self, bins, start, stop, **kwargs):
         """
         Make a regular axis with nice keyword arguments for underflow,
@@ -188,6 +192,7 @@ class Regular(Axis):
             raise KeyError("Unsupported collection of options")
 
     @classmethod
+    @inject_signature("cls, bins, start, stop, *, metadata=None")
     def sqrt(cls, bins, start, stop, **kwargs):
         self = cls.__new__(cls)
         with KWArgs(kwargs) as k:
@@ -196,6 +201,7 @@ class Regular(Axis):
         return self
 
     @classmethod
+    @inject_signature("cls, bins, start, stop, *, metadata=None")
     def log(cls, bins, start, stop, **kwargs):
         self = cls.__new__(cls)
         with KWArgs(kwargs) as k:
@@ -204,6 +210,7 @@ class Regular(Axis):
         return self
 
     @classmethod
+    @inject_signature("cls, bins, start, stop, power, *, metadata=None")
     def pow(cls, bins, start, stop, power, **kwargs):
         self = cls.__new__(cls)
         with KWArgs(kwargs) as k:
@@ -212,6 +219,7 @@ class Regular(Axis):
         return self
 
     @classmethod
+    @inject_signature("cls, bins, start, stop, *, metadata=None")
     def circular(cls, bins, start, stop, **kwargs):
         self = cls.__new__(cls)
         with KWArgs(kwargs) as k:
@@ -230,6 +238,9 @@ class Variable(Axis):
         ca.variable_uoflow_growth,
     }
 
+    @inject_signature(
+        "self, edges, *, metadata=None, underflow=True, overflow=True, growth=False"
+    )
     def __init__(self, edges, **kwargs):
         """
         Make an axis with irregularly spaced bins. Provide a list
@@ -277,6 +288,9 @@ class Integer(Axis):
         ca.integer_growth,
     }
 
+    @inject_signature(
+        "self, start, stop, *, metadata=None, underflow=True, overflow=True, growth=False"
+    )
     def __init__(self, start, stop, **kwargs):
         """
         Make an integer axis, with a collection of consecutive integers.
@@ -326,6 +340,7 @@ class Category(Axis):
         ca.category_str,
     }
 
+    @inject_signature("self, categories, *, metadata=None, growth=False")
     def __init__(self, categories, **kwargs):
         """
         Make a category axis with either ints or strings; items will

--- a/boost_histogram/_internal/sig_tools.py
+++ b/boost_histogram/_internal/sig_tools.py
@@ -1,0 +1,126 @@
+from __future__ import absolute_import, division, print_function
+
+del absolute_import, division, print_function
+
+import inspect
+import itertools
+import ast
+
+# Python 2 filter (function defs need to be Python 2 compatible)
+EMPTY = inspect.Parameter.empty if hasattr(inspect, "Parameter") else None
+
+
+def make_param(arg, kind, default=EMPTY):
+    empty = lambda x: inspect.Parameter.empty if x is None else x[0]
+    return inspect.Parameter(
+        arg.arg, kind, annotation=empty(arg.annotation), default=default
+    )
+
+
+def run_on(args, defaults, kind):
+    params = []
+    arg_def = reversed(
+        list(
+            itertools.zip_longest(
+                reversed(args), reversed(defaults), fillvalue=inspect.Parameter.empty
+            )
+        )
+    )
+
+    return [make_param(arg, kind, default) for arg, default in arg_def]
+
+
+class ArgTrans(ast.NodeTransformer):
+    def __init__(self, locals={}):
+        self.locals = locals
+
+    def visit_Tuple(self, node):
+        node = self.generic_visit(node)
+        return (tuple(node.elts),)
+
+    def visit_Set(self, node):
+        node = self.generic_visit(node)
+        return (set(node.elts),)
+
+    def visit_Dict(self, node):
+        node = self.generic_visit(node)
+        return (dict(zip(node.keys, node.values)),)
+
+    def visit_Name(self, node):
+        return (eval(node.id, globals(), self.locals),)
+
+    def visit_Attribute(self, node):
+        node = self.generic_visit(node)
+        return (getattr(node.value[0], node.attr),)
+
+    def visit_Call(self, node):
+        "Simplified - can only do f(), no args"
+        node = self.generic_visit(node)
+        return (node.func[0](*node.args),)
+
+    # Python 3.8+
+    def visit_Constant(self, node):
+        return (node.value,)
+
+    # Python < 3.8
+    def visit_NameConstant(self, node):
+        return (node.value,)
+
+    # Python < 3.8
+    def visit_Str(self, node):
+        return (node.s,)
+
+        # Python < 3.8
+
+    def visit_Bytes(self, node):
+        return (node.s,)
+
+    # Python < 3.8
+    def visit_Num(self, node):
+        return (node.n,)
+
+    def visit_Ellipsis(self, node):
+        return (Ellipsis,)
+
+    def visit_arguments(self, node):
+        node = self.generic_visit(node)
+        empty = lambda x: inspect.Parameter.empty if x is None else x
+        params = []
+
+        params += run_on(
+            node.args, node.defaults, inspect.Parameter.POSITIONAL_OR_KEYWORD
+        )
+        if node.vararg:
+            params.append(make_param(node.vararg, inspect.Parameter.VAR_POSITIONAL))
+        params += run_on(
+            node.kwonlyargs, node.kw_defaults, inspect.Parameter.KEYWORD_ONLY
+        )
+        if node.kwarg:
+            params.append(make_param(node.kwarg, inspect.Parameter.VAR_KEYWORD))
+
+        return params
+
+
+def make_signature_params(sig, locals={}):
+    s = ast.parse("def f({0}): pass".format(sig))
+    return ArgTrans(locals).visit(s.body[0].args)
+
+
+def inject_signature(sig, locals={}):
+    def wrap(f):
+        # Don't add on Python 2
+        if not hasattr(inspect, "Parameter"):
+            return f
+
+        # It is invalid to have a positonal only argument till Python 3.8
+        # If we avoided the ast, we could do it earlier here
+        # We could split on / as well
+
+        params = make_signature_params(sig, locals)
+
+        signature = inspect.signature(f)
+        signature = signature.replace(parameters=params)
+        f.__signature__ = signature
+        return f
+
+    return wrap

--- a/boost_histogram/_internal/sig_tools.py
+++ b/boost_histogram/_internal/sig_tools.py
@@ -3,107 +3,11 @@ from __future__ import absolute_import, division, print_function
 del absolute_import, division, print_function
 
 import inspect
-import itertools
-import ast
-
-# Python 2 filter (function defs need to be Python 2 compatible)
-EMPTY = inspect.Parameter.empty if hasattr(inspect, "Parameter") else None
-
-
-def make_param(arg, kind, default=EMPTY):
-    empty = lambda x: inspect.Parameter.empty if x is None else x[0]
-    return inspect.Parameter(
-        arg.arg, kind, annotation=empty(arg.annotation), default=default
-    )
-
-
-def run_on(args, defaults, kind):
-    params = []
-    arg_def = reversed(
-        list(
-            itertools.zip_longest(
-                reversed(args), reversed(defaults), fillvalue=inspect.Parameter.empty
-            )
-        )
-    )
-
-    return [make_param(arg, kind, default) for arg, default in arg_def]
-
-
-class ArgTrans(ast.NodeTransformer):
-    def __init__(self, locals={}):
-        self.locals = locals
-
-    def visit_Tuple(self, node):
-        node = self.generic_visit(node)
-        return (tuple(node.elts),)
-
-    def visit_Set(self, node):
-        node = self.generic_visit(node)
-        return (set(node.elts),)
-
-    def visit_Dict(self, node):
-        node = self.generic_visit(node)
-        return (dict(zip(node.keys, node.values)),)
-
-    def visit_Name(self, node):
-        return (eval(node.id, globals(), self.locals),)
-
-    def visit_Attribute(self, node):
-        node = self.generic_visit(node)
-        return (getattr(node.value[0], node.attr),)
-
-    def visit_Call(self, node):
-        "Simplified - can only do f(), no args"
-        node = self.generic_visit(node)
-        return (node.func[0](*node.args),)
-
-    # Python 3.8+
-    def visit_Constant(self, node):
-        return (node.value,)
-
-    # Python < 3.8
-    def visit_NameConstant(self, node):
-        return (node.value,)
-
-    # Python < 3.8
-    def visit_Str(self, node):
-        return (node.s,)
-
-        # Python < 3.8
-
-    def visit_Bytes(self, node):
-        return (node.s,)
-
-    # Python < 3.8
-    def visit_Num(self, node):
-        return (node.n,)
-
-    def visit_Ellipsis(self, node):
-        return (Ellipsis,)
-
-    def visit_arguments(self, node):
-        node = self.generic_visit(node)
-        empty = lambda x: inspect.Parameter.empty if x is None else x
-        params = []
-
-        params += run_on(
-            node.args, node.defaults, inspect.Parameter.POSITIONAL_OR_KEYWORD
-        )
-        if node.vararg:
-            params.append(make_param(node.vararg, inspect.Parameter.VAR_POSITIONAL))
-        params += run_on(
-            node.kwonlyargs, node.kw_defaults, inspect.Parameter.KEYWORD_ONLY
-        )
-        if node.kwarg:
-            params.append(make_param(node.kwarg, inspect.Parameter.VAR_KEYWORD))
-
-        return params
 
 
 def make_signature_params(sig, locals={}):
-    s = ast.parse("def f({0}): pass".format(sig))
-    return ArgTrans(locals).visit(s.body[0].args)
+    exec("def _({0}): pass".format(sig), globals(), locals)
+    return list(inspect.signature(locals["_"]).parameters.values())
 
 
 def inject_signature(sig, locals={}):
@@ -113,7 +17,6 @@ def inject_signature(sig, locals={}):
             return f
 
         # It is invalid to have a positonal only argument till Python 3.8
-        # If we avoided the ast, we could do it earlier here
         # We could split on / as well
 
         params = make_signature_params(sig, locals)

--- a/tests/test_sigs.py
+++ b/tests/test_sigs.py
@@ -1,0 +1,52 @@
+import pytest
+
+import boost_histogram as bh
+from boost_histogram._internal.sig_tools import make_signature_params
+
+import inspect
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(inspect, "Parameter"), reason="Python 3 only"
+)
+
+
+def test_simple_sigs():
+    from inspect import Parameter
+
+    assert make_signature_params("x, y") == [
+        Parameter("x", Parameter.POSITIONAL_OR_KEYWORD),
+        Parameter("y", Parameter.POSITIONAL_OR_KEYWORD),
+    ]
+
+    assert make_signature_params("x=True") == [
+        Parameter("x", Parameter.POSITIONAL_OR_KEYWORD, default=True)
+    ]
+    assert make_signature_params("*, x=None") == [
+        Parameter("x", Parameter.KEYWORD_ONLY, default=None)
+    ]
+    assert make_signature_params("y : 'wow'") == [
+        Parameter("y", Parameter.POSITIONAL_OR_KEYWORD, annotation="wow")
+    ]
+    assert make_signature_params("y : None = 2") == [
+        Parameter("y", Parameter.POSITIONAL_OR_KEYWORD, default=2, annotation=None)
+    ]
+    assert make_signature_params("*args, **kwargs") == [
+        Parameter("args", Parameter.VAR_POSITIONAL),
+        Parameter("kwargs", Parameter.VAR_KEYWORD),
+    ]
+
+    assert make_signature_params("*args, x={b'x':3}") == [
+        Parameter("args", Parameter.VAR_POSITIONAL),
+        Parameter("x", Parameter.KEYWORD_ONLY, default={b"x": 3}),
+    ]
+
+
+def test_fill_sig():
+    from inspect import Parameter
+
+    a, b, c, d = inspect.signature(bh.histogram.fill).parameters.values()
+
+    assert a == Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)
+    assert b == Parameter("args", Parameter.VAR_POSITIONAL)
+    assert c == Parameter("weight", Parameter.KEYWORD_ONLY, default=None)
+    assert d == Parameter("sample", Parameter.KEYWORD_ONLY, default=None)


### PR DESCRIPTION
This allows Python 3 to get nice signatures while still supporting Python 2. Closes #144.

The histogram and axes constructors (and fill) all have nice signatures now to go along with the nice docstring. When we drop Python 2.7, the contents of the decorator strings can replace current signatures and the decorator (and most/all of the KWArgs tool) will go away.