### PR TITLE
Warning for unintialized storage

### DIFF
--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -6,7 +6,7 @@ from .. import _core
 from .axis import _to_axis, Axis
 from .axistuple import AxesTuple
 from .sig_tools import inject_signature
-from .storage import Double, _to_storage
+from .storage import Storage, Double, _to_storage
 
 import warnings
 import numpy as np
@@ -98,7 +98,7 @@ class BaseHistogram(object):
         ----------
         *args : Axis
             Provide 1 or more axis instances.
-        storage : Storage = bh.storage.Double
+        storage : Storage = bh.storage.Double()
             Select a storage to use in the histogram
         """
 
@@ -114,6 +114,16 @@ class BaseHistogram(object):
         # Keyword only trick (change when Python2 is dropped)
         with KWArgs(kwargs) as k:
             storage = k.optional("storage", Double())
+
+        # Check for missed parenthesis
+        if not isinstance(storage, Storage) and callable(storage):
+            storage = storage()
+            if not isinstance(storage, Storage):
+                raise KeyError("Only storages allowed in storage argument")
+            else:
+                warnings.warn(
+                    "Passing in an initialized storage may be removed in the next release. Please add ()."
+                )
 
         storage = storage._get_storage_()
 

--- a/boost_histogram/_internal/storage.py
+++ b/boost_histogram/_internal/storage.py
@@ -6,17 +6,19 @@ from .._core import storage as store
 
 
 class Storage(object):
-    __slots__ = ()
+    __slots__ = "_storage"
+
+    def __init__(self):
+        self._storage = self._STORAGE()
 
     def __eq__(self, other):
-        return issubclass(other.__class__, self.__class__) or issubclass(
-            self.__class__, other.__class__
-        )
+        return self._storage == other._storage
 
-    # Override this to allow configurable storages
-    @classmethod
-    def _get_storage_(cls):
-        return cls._STORAGE()
+    def _get_storage_(self):
+        return self._storage
+
+    def __repr__(self):
+        return "{self.__class__.__name__}()".format(self=self)
 
 
 class Int(Storage):
@@ -48,6 +50,7 @@ class WeightedMean(Storage):
 
 
 def _to_storage(st):
+    """Get a storage class from C++ class"""
     for base in Storage.__subclasses__():
         if st == base._STORAGE:
             return base

--- a/boost_histogram/storage.py
+++ b/boost_histogram/storage.py
@@ -16,8 +16,7 @@ from ._internal.storage import (
 
 
 class DepStorageMixin(object):
-    @classmethod
-    def _get_storage_(cls):
+    def _get_storage_(self):
         warnings.warn("Use Int instead", DeprecationWarning)
         return cls._STORAGE()
 


### PR DESCRIPTION
This adds a warning for all uninitialized storages. If a user forgets the (), a warning is raised. In 0.7.0, this will become an error with an explicit, helpful error message.

@HDembinski, I implore you to look over the reasoning given by @jpivarski and me and carefully consider allowing default-constructible storages to be passed in without an error if a user forgets the `()`, either by mistake or by thinking they should pass a type. The function signature would be `storage : Union[Storage, Type[Storage]]` in that case. I will respect your wishes if you do not change your mind.

---

PS: This is the little program you can run through MyPy to verify that the types pass:

```python
from typing import Union, Callable, Type

class Storage: pass

def f(storage : Union[Storage, Type[Storage]]):
    pass

# Also passes with storage : Union[Storage, Callable[[], Storage]]

f(Storage())
f(Storage)
```

```
$ mypy tmp.py
Success: no issues found in 1 source file
```