### PR TITLE
Adding .copy()

### DIFF
--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -11,6 +11,7 @@ from .storage import Double, Storage
 from .utils import cast, register, set_family, MAIN_FAMILY, CPP_FAMILY, set_module
 
 import warnings
+import copy
 import numpy as np
 
 _histograms = (
@@ -300,6 +301,23 @@ class Histogram(BaseHistogram):
             The edges for each dimension
         """
         return self._hist.to_numpy(flow)
+
+    @inject_signature("self, *, deep=True")
+    def copy(self, **kwargs):
+        """
+        Make a copy of the histogram. Defaults to making a
+        deep copy (axis metadata copied); use deep=False
+        to avoid making a copy of axis metadata.
+        """
+
+        # Future versions may add new options here
+        with KWArgs(kwargs) as k:
+            deep = k.optional("deep", True)
+
+        if deep:
+            return copy.deepcopy(self)
+        else:
+            return copy.copy(self)
 
     def view(self, flow=False):
         """

--- a/tests/test_public_hist.py
+++ b/tests/test_public_hist.py
@@ -54,6 +54,14 @@ def test_copy():
     assert b == c
     assert id(b) != id(c)
 
+    b = a.copy(deep=False)
+    assert a == b
+    assert id(a) != id(b)
+
+    c = a.copy()
+    assert b == c
+    assert id(b) != id(c)
+
 
 def test_fill_int_1d():
 


### PR DESCRIPTION
Closes #209.

Matching Pandas in design, except we make `deep` a keyword only argument, since we don't have to be backward compatible and because we may end up adding other functionality to `.copy`.