### PR TITLE
Str/Int Categories

### DIFF
--- a/boost_histogram/_internal/axis.py
+++ b/boost_histogram/_internal/axis.py
@@ -504,7 +504,11 @@ class BaseStrCategory(Axis):
             categories = list(categories)
 
         if options == {"growth"}:
-            self._ax = ca.category_str_growth(categories, metadata)
+            if len(categories) == 0:
+                self._ax = ca.category_str_growth()
+                self._ax.metadata = metadata
+            else:
+                self._ax = ca.category_str_growth(categories, metadata)
         elif options == set():
             self._ax = ca.category_str(categories, metadata)
         else:
@@ -538,7 +542,11 @@ class BaseIntCategory(Axis):
             options = k.options(growth=False)
 
         if options == {"growth"}:
-            self._ax = ca.category_int_growth(categories, metadata)
+            if len(categories) == 0:
+                self._ax = ca.category_int_growth()
+                self._ax.metadata = metadata
+            else:
+                self._ax = ca.category_int_growth(categories, metadata)
         elif options == set():
             self._ax = ca.category_int(categories, metadata)
         else:

--- a/boost_histogram/_internal/axis.py
+++ b/boost_histogram/_internal/axis.py
@@ -504,11 +504,7 @@ class BaseStrCategory(Axis):
             categories = list(categories)
 
         if options == {"growth"}:
-            if len(categories) == 0:
-                self._ax = ca.category_str_growth()
-                self._ax.metadata = metadata
-            else:
-                self._ax = ca.category_str_growth(categories, metadata)
+            self._ax = ca.category_str_growth(categories, metadata)
         elif options == set():
             self._ax = ca.category_str(categories, metadata)
         else:
@@ -542,11 +538,7 @@ class BaseIntCategory(Axis):
             options = k.options(growth=False)
 
         if options == {"growth"}:
-            if len(categories) == 0:
-                self._ax = ca.category_int_growth()
-                self._ax.metadata = metadata
-            else:
-                self._ax = ca.category_int_growth(categories, metadata)
+            self._ax = ca.category_int_growth(categories, metadata)
         elif options == set():
             self._ax = ca.category_int(categories, metadata)
         else:

--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -26,7 +26,9 @@ _histograms = (
 
 
 def _arg_shortcut(item):
-    if isinstance(item, tuple):
+    if isinstance(item, tuple) and len(item) == 3:
+        return _core.axis.regular_uoflow(item[0], item[1], item[2], None)
+    elif isinstance(item, tuple) and len(item) == 4:
         return _core.axis.regular_uoflow(*item)
     elif isinstance(item, Axis):
         return item._ax

--- a/boost_histogram/axis/__init__.py
+++ b/boost_histogram/axis/__init__.py
@@ -6,7 +6,14 @@ __all__ = ("Regular", "Variable", "Integer", "Category", "Axis", "options", "tra
 
 from .._internal.axis import Axis, options
 from .._internal.utils import register as _register
-from .._internal.axis import Regular, Variable, Integer, Category
+from .._internal.axis import (
+    Regular,
+    Variable,
+    Integer,
+    Category,
+    IntCategory,
+    StrCategory,
+)
 from . import transform
 
 import warnings as _warnings
@@ -40,13 +47,9 @@ class integer(Integer):
         return super(integer, self).__init__(*args, **kwargs)
 
 
-@_register()
-class category(Category):
-    _CLASSES = set()
-
-    def __init__(self, *args, **kwargs):
-        _warnings.warn("Use Category instead")
-        return super(category, self).__init__(*args, **kwargs)
+def category(*args, **kwargs):
+    _warnings.warn("Use IntCategory or StrCategory instead")
+    return Category(*args, **kwargs)
 
 
 def regular_log(*args, **kwargs):

--- a/boost_histogram/cpp/axis/__init__.py
+++ b/boost_histogram/cpp/axis/__init__.py
@@ -6,5 +6,13 @@ __all__ = ("options", "regular", "variable", "integer", "category", "transorm")
 
 from ... import axis as _axis
 
-from ..._internal.axis import options, Axis, regular, variable, integer, category
+from ..._internal.axis import (
+    options,
+    Axis,
+    regular,
+    variable,
+    integer,
+    str_category,
+    int_category,
+)
 from . import transform

--- a/boost_histogram/numpy.py
+++ b/boost_histogram/numpy.py
@@ -55,7 +55,7 @@ def histogramdd(
             if r is None:
                 # Nextafter may affect bin edges slightly
                 r = (np.min(a[n]), np.max(a[n]))
-            cpp_ax = _core.axis.regular_numpy(b, r[0], r[1])
+            cpp_ax = _core.axis.regular_numpy(b, r[0], r[1], None)
             new_ax = _cast(None, cpp_ax, _axis.Axis)
             axs.append(new_ax)
         else:

--- a/include/boost/histogram/python/axis.hpp
+++ b/include/boost/histogram/python/axis.hpp
@@ -30,7 +30,7 @@ using uogrowth_t = decltype(option::growth | option::underflow | option::overflo
 // How edges, centers, and widths are handled
 //
 // We distinguish between continuous and discrete axes. The integer axis is a borderline
-// case. It has disrete values, but they are consecutive. It is possible although not
+// case. It has discrete values, but they are consecutive. It is possible although not
 // correct to treat it like a continuous axis with bin width of 1. For the sake of
 // computing bin edges and bin center, we will use this ansatz here. PS: This behavior
 // is already implemented in Boost::Histogram when you create an integer axis with a
@@ -243,7 +243,19 @@ py::array_t<double> widths(const A &ax) {
     return result;
 }
 
-// These match the Python names except for a possible underscore
+// Must be specialized for each type (compile warning if not)
+template <class T>
+inline const char *string_name();
+
+// Macro to make the string specializations more readable
+#define BHP_SPECIALIZE_NAME(name)                                                      \
+    template <>                                                                        \
+    inline const char *string_name<name>() {                                           \
+        return #name;                                                                  \
+    }
+
+// These match the Python names
+
 using regular_none
     = bh::axis::regular<double, bh::use_default, metadata_t, option::none_t>;
 using regular_uflow
@@ -254,10 +266,21 @@ using regular_uoflow = bh::axis::regular<double, bh::use_default, metadata_t>;
 using regular_uoflow_growth
     = bh::axis::regular<double, bh::use_default, metadata_t, uogrowth_t>;
 
+BHP_SPECIALIZE_NAME(regular_none)
+BHP_SPECIALIZE_NAME(regular_uflow)
+BHP_SPECIALIZE_NAME(regular_oflow)
+BHP_SPECIALIZE_NAME(regular_uoflow)
+BHP_SPECIALIZE_NAME(regular_uoflow_growth)
+
 using circular     = bh::axis::circular<double, metadata_t>;
 using regular_log  = bh::axis::regular<double, bh::axis::transform::log, metadata_t>;
 using regular_sqrt = bh::axis::regular<double, bh::axis::transform::sqrt, metadata_t>;
 using regular_pow  = bh::axis::regular<double, bh::axis::transform::pow, metadata_t>;
+
+BHP_SPECIALIZE_NAME(circular)
+BHP_SPECIALIZE_NAME(regular_log)
+BHP_SPECIALIZE_NAME(regular_sqrt)
+BHP_SPECIALIZE_NAME(regular_pow)
 
 using variable_none   = bh::axis::variable<double, metadata_t, option::none_t>;
 using variable_uflow  = bh::axis::variable<double, metadata_t, option::underflow_t>;
@@ -265,18 +288,41 @@ using variable_oflow  = bh::axis::variable<double, metadata_t, option::overflow_
 using variable_uoflow = bh::axis::variable<double, metadata_t>;
 using variable_uoflow_growth = bh::axis::variable<double, metadata_t, uogrowth_t>;
 
+BHP_SPECIALIZE_NAME(variable_none)
+BHP_SPECIALIZE_NAME(variable_uflow)
+BHP_SPECIALIZE_NAME(variable_oflow)
+BHP_SPECIALIZE_NAME(variable_uoflow)
+BHP_SPECIALIZE_NAME(variable_uoflow_growth)
+
 using integer_none   = bh::axis::integer<int, metadata_t, option::none_t>;
 using integer_uoflow = bh::axis::integer<int, metadata_t>;
 using integer_uflow  = bh::axis::integer<int, metadata_t, option::underflow_t>;
 using integer_oflow  = bh::axis::integer<int, metadata_t, option::overflow_t>;
 using integer_growth = bh::axis::integer<int, metadata_t, option::growth_t>;
 
+BHP_SPECIALIZE_NAME(integer_none)
+BHP_SPECIALIZE_NAME(integer_uoflow)
+BHP_SPECIALIZE_NAME(integer_uflow)
+BHP_SPECIALIZE_NAME(integer_oflow)
+BHP_SPECIALIZE_NAME(integer_growth)
+
 using category_int        = bh::axis::category<int, metadata_t>;
 using category_int_growth = bh::axis::category<int, metadata_t, option::growth_t>;
+
+BHP_SPECIALIZE_NAME(category_int)
+BHP_SPECIALIZE_NAME(category_int_growth)
 
 using category_str = bh::axis::category<std::string, metadata_t>;
 using category_str_growth
     = bh::axis::category<std::string, metadata_t, option::growth_t>;
+
+BHP_SPECIALIZE_NAME(category_str)
+BHP_SPECIALIZE_NAME(category_str_growth)
+
+// Axis defined elsewhere
+BHP_SPECIALIZE_NAME(regular_numpy)
+
+#undef BHP_SPECIALIZE_NAME
 
 } // namespace axis
 

--- a/include/boost/histogram/python/register_axis.hpp
+++ b/include/boost/histogram/python/register_axis.hpp
@@ -157,8 +157,8 @@ void vectorized_index_and_value_methods(
 
 /// Add helpers common to all axis types
 template <class A, class... Args>
-py::class_<A> register_axis(py::module &m, const char *name, Args &&... args) {
-    py::class_<A> ax(m, name, std::forward<Args>(args)...);
+py::class_<A> register_axis(py::module &m, Args &&... args) {
+    py::class_<A> ax(m, axis::string_name<A>(), std::forward<Args>(args)...);
 
     ax.def("__repr__", &shift_to_string<A>)
 

--- a/src/register_axis.cpp
+++ b/src/register_axis.cpp
@@ -138,12 +138,14 @@ void register_axes(py::module &mod) {
 
     register_axis_each<axis::category_int, axis::category_int_growth>(mod, [](auto ax) {
         ax.def(py::init<std::vector<int>, metadata_t>(), "categories"_a, "metadata"_a);
+        ax.def(py::init<>());
     });
 
     register_axis_each<axis::category_str, axis::category_str_growth>(mod, [](auto ax) {
         ax.def(py::init<std::vector<std::string>, metadata_t>(),
                "categories"_a,
                "metadata"_a);
+        ax.def(py::init<>());
     });
 
     ;

--- a/src/register_axis.cpp
+++ b/src/register_axis.cpp
@@ -12,18 +12,15 @@
 #include <boost/mp11.hpp>
 #include <vector>
 
-template <class... Ts, class Init, class... Passthrough>
-void register_axis_sub_types(py::module &mod,
-                             std::array<const char *, sizeof...(Ts)> names,
-                             const char *doc,
-                             Init &&init,
-                             Passthrough &&... passthrough) {
+template <class... Ts, class Func>
+void register_axis_each(py::module &mod, Func &&function) {
     using namespace boost::mp11;
     using types = mp_list<Ts...>;
+
     mp_for_each<mp_iota_c<sizeof...(Ts)>>([&](auto I) {
         using T = mp_at_c<types, I>;
-        register_axis<T>(mod, names.at(I), doc)
-            .def(std::forward<Init>(init), std::forward<Passthrough>(passthrough)...);
+        auto ax = register_axis<T>(mod);
+        function(ax);
     });
 }
 
@@ -65,55 +62,47 @@ void register_axes(py::module &mod) {
                     self.underflow(), self.overflow(), self.circular(), self.growth());
         });
 
-    register_axis_sub_types<axis::regular_none,
-                            axis::regular_uflow,
-                            axis::regular_oflow,
-                            axis::regular_uoflow,
-                            axis::regular_uoflow_growth,
-                            axis::regular_numpy>(
-        mod,
-        {{"regular_none",
-          "regular_uflow",
-          "regular_oflow",
-          "regular_uoflow",
-          "regular_uoflow_growth",
-          "regular_numpy"}},
-        "Evenly spaced bins",
+    register_axis_each<axis::regular_none,
+                       axis::regular_uflow,
+                       axis::regular_oflow,
+                       axis::regular_uoflow,
+                       axis::regular_uoflow_growth,
+                       axis::regular_numpy>(mod, [](auto ax) {
+        ax.def(py::init<unsigned, double, double, metadata_t>(),
+               "bins"_a,
+               "start"_a,
+               "stop"_a,
+               "metadata"_a);
+    });
+
+    register_axis<axis::circular>(mod).def(
         py::init<unsigned, double, double, metadata_t>(),
         "bins"_a,
         "start"_a,
         "stop"_a,
-        "metadata"_a = py::none());
+        "metadata"_a);
 
-    register_axis<axis::circular>(mod, "circular", "Evenly spaced bins with wraparound")
+    register_axis<axis::regular_log>(mod)
         .def(py::init<unsigned, double, double, metadata_t>(),
              "bins"_a,
              "start"_a,
              "stop"_a,
-             "metadata"_a = py::none());
-
-    register_axis<axis::regular_log>(mod, "regular_log", "Evenly spaced bins in log10")
-        .def(py::init<unsigned, double, double, metadata_t>(),
-             "bins"_a,
-             "start"_a,
-             "stop"_a,
-             "metadata"_a = py::none())
+             "metadata"_a)
         .def_property_readonly("transform", [](const axis::regular_log &self) {
             return self.transform();
         });
 
-    register_axis<axis::regular_sqrt>(mod, "regular_sqrt", "Evenly spaced bins in sqrt")
+    register_axis<axis::regular_sqrt>(mod)
         .def(py::init<unsigned, double, double, metadata_t>(),
              "bins"_a,
              "start"_a,
              "stop"_a,
-             "metadata"_a = py::none())
+             "metadata"_a)
         .def_property_readonly("transform", [](const axis::regular_sqrt &self) {
             return self.transform();
         });
 
-    register_axis<axis::regular_pow>(
-        mod, "regular_pow", "Evenly spaced bins in a power")
+    register_axis<axis::regular_pow>(mod)
         .def(py::init([](unsigned n,
                          double start,
                          double stop,
@@ -126,56 +115,36 @@ void register_axes(py::module &mod) {
              "start"_a,
              "stop"_a,
              "power"_a,
-             "metadata"_a = py::none())
+             "metadata"_a)
         .def_property_readonly("transform", [](const axis::regular_pow &self) {
             return self.transform();
         });
 
-    register_axis_sub_types<axis::variable_none,
-                            axis::variable_uflow,
-                            axis::variable_oflow,
-                            axis::variable_uoflow,
-                            axis::variable_uoflow_growth>(
-        mod,
-        {{"variable_none",
-          "variable_uflow",
-          "variable_oflow",
-          "variable_uoflow",
-          "variable_uoflow_growth"}},
-        "Unevenly spaced bins",
-        py::init<std::vector<double>, metadata_t>(),
-        "edges"_a,
-        "metadata"_a = py::none());
+    register_axis_each<axis::variable_none,
+                       axis::variable_uflow,
+                       axis::variable_oflow,
+                       axis::variable_uoflow,
+                       axis::variable_uoflow_growth>(mod, [](auto ax) {
+        ax.def(py::init<std::vector<double>, metadata_t>(), "edges"_a, "metadata"_a);
+    });
 
-    register_axis_sub_types<axis::integer_none,
-                            axis::integer_uflow,
-                            axis::integer_oflow,
-                            axis::integer_uoflow,
-                            axis::integer_growth>(mod,
-                                                  {{"integer_none",
-                                                    "integer_uflow",
-                                                    "integer_oflow",
-                                                    "integer_uoflow",
-                                                    "integer_growth"}},
-                                                  "Contiguous integers",
-                                                  py::init<int, int, metadata_t>(),
-                                                  "start"_a,
-                                                  "stop"_a,
-                                                  "metadata"_a = py::none());
+    register_axis_each<axis::integer_none,
+                       axis::integer_uflow,
+                       axis::integer_oflow,
+                       axis::integer_uoflow,
+                       axis::integer_growth>(mod, [](auto ax) {
+        ax.def(py::init<int, int, metadata_t>(), "start"_a, "stop"_a, "metadata"_a);
+    });
 
-    register_axis_sub_types<axis::category_int, axis::category_int_growth>(
-        mod,
-        {{"category_int", "category_int_growth"}},
-        "Axis with discontiguous integer bins",
-        py::init<std::vector<int>, metadata_t>(),
-        "categories"_a,
-        "metadata"_a = py::none());
+    register_axis_each<axis::category_int, axis::category_int_growth>(mod, [](auto ax) {
+        ax.def(py::init<std::vector<int>, metadata_t>(), "categories"_a, "metadata"_a);
+    });
 
-    register_axis_sub_types<axis::category_str, axis::category_str_growth>(
-        mod,
-        {{"category_str", "category_str_growth"}},
-        "Axis with text bins",
-        py::init<std::vector<std::string>, metadata_t>(),
-        "categories"_a,
-        "metadata"_a = py::none());
+    register_axis_each<axis::category_str, axis::category_str_growth>(mod, [](auto ax) {
+        ax.def(py::init<std::vector<std::string>, metadata_t>(),
+               "categories"_a,
+               "metadata"_a);
+    });
+
+    ;
 }

--- a/tests/test_axes_object.py
+++ b/tests/test_axes_object.py
@@ -9,7 +9,7 @@ def test_axes_all_at_once():
     h = bh.Histogram(
         bh.axis.Regular(10, 0, 10, metadata=2),
         bh.axis.Integer(0, 5, metadata="hi"),
-        bh.axis.Category(["HI", "HO"]),
+        bh.axis.StrCategory(["HI", "HO"]),
     )
 
     assert h.axes.bin(1, 2, 0) == ((1.0, 2.0), 2, "HI")

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -35,10 +35,10 @@ ABC = abc.ABCMeta("ABC", (object,), {"__slots__": ()})
         (bh.axis.Integer, (1, 2), "o", {}),
         (bh.axis.Integer, (1, 2), "uo", {}),
         (bh.axis.Integer, (1, 2), "g", {}),
-        (bh.axis.Category, ((1, 2, 3),), "", {}),
-        (bh.axis.Category, ((1, 2, 3),), "g", {}),
-        (bh.axis.Category, (tuple("ABC"),), "", {}),
-        (bh.axis.Category, (tuple("ABC"),), "g", {}),
+        (bh.axis.IntCategory, ((1, 2, 3),), "", {}),
+        (bh.axis.IntCategory, ((1, 2, 3),), "g", {}),
+        (bh.axis.StrCategory, (tuple("ABC"),), "", {}),
+        (bh.axis.StrCategory, (tuple("ABC"),), "g", {}),
     ],
 )
 def test_metadata(axis, args, opt, kwargs):
@@ -604,62 +604,72 @@ class TestInteger:
 class TestCategory(Axis):
     def test_init(self):
         # should not raise
-        bh.axis.Category([1, 2])
-        bh.axis.Category((1, 2), metadata="foo")
-        bh.axis.Category(["A", "B"])
-        bh.axis.Category("AB")
-        bh.axis.Category("AB", metadata="foo")
+        bh.axis.IntCategory([1, 2])
+        bh.axis.IntCategory((1, 2), metadata="foo")
+        bh.axis.StrCategory(["A", "B"])
+        bh.axis.StrCategory("AB")
+        bh.axis.StrCategory("AB", metadata="foo")
 
         with pytest.raises(TypeError):
-            bh.axis.Category([1, 2], "foo")
+            bh.axis.IntCategory(["A", "B"])
         with pytest.raises(TypeError):
-            bh.axis.Category("AB", "foo")
+            bh.axis.StrCategory([1, 2])
 
         with pytest.raises(TypeError):
-            bh.axis.Category()
+            bh.axis.IntCategory([1, 2], "foo")
         with pytest.raises(TypeError):
-            bh.axis.Category([1, "2"])
-        with pytest.raises(TypeError):
-            bh.axis.Category([1, 2, 3], underflow=True)
+            bh.axis.StrCategory("AB", "foo")
 
-        ax = bh.axis.Category([1, 2, 3])
+        with pytest.raises(TypeError):
+            bh.axis.StrCategory()
+        with pytest.raises(TypeError):
+            bh.axis.IntCategory()
+        with pytest.raises(TypeError):
+            bh.axis.StrCategory([1, "2"])
+        with pytest.raises(TypeError):
+            bh.axis.IntCategory([1, "2"])
+        with pytest.raises(TypeError):
+            bh.axis.IntCategory([1, 2, 3], underflow=True)
+
+        ax = bh.axis.IntCategory([1, 2, 3])
         assert isinstance(ax, bh.axis.IntCategory)
         assert ax.options == bh.axis.options(overflow=True)
 
-        ax = bh.axis.Category([1, 2, 3], growth=True)
+        ax = bh.axis.IntCategory([1, 2, 3], growth=True)
         assert isinstance(ax, bh.axis.IntCategory)
         assert ax.options == bh.axis.options(growth=True)
 
-        ax = bh.axis.Category(["1", "2", "3"])
+        ax = bh.axis.StrCategory(["1", "2", "3"])
         assert isinstance(ax, bh.axis.StrCategory)
         assert ax.options == bh.axis.options(overflow=True)
 
-        ax = bh.axis.Category(["1", "2", "3"], growth=True)
+        ax = bh.axis.StrCategory(["1", "2", "3"], growth=True)
         assert isinstance(ax, bh.axis.StrCategory)
         assert ax.options == bh.axis.options(growth=True)
 
     def test_equal(self):
-        assert bh.axis.Category([1, 2, 3]) == bh.axis.Category([1, 2, 3])
-        assert bh.axis.Category([1, 2, 3]) != bh.axis.Category([1, 3, 2])
-        assert bh.axis.Category(["A", "B"]) == bh.axis.Category("AB")
-        assert bh.axis.Category(["A", "B"]) != bh.axis.Category("BA")
+        assert bh.axis.IntCategory([1, 2, 3]) == bh.axis.IntCategory([1, 2, 3])
+        assert bh.axis.IntCategory([1, 2, 3]) != bh.axis.IntCategory([1, 3, 2])
+        assert bh.axis.StrCategory(["A", "B"]) == bh.axis.StrCategory("AB")
+        assert bh.axis.StrCategory(["A", "B"]) != bh.axis.StrCategory("BA")
 
     @pytest.mark.parametrize("ref", ([1, 2, 3], "ABC"))
     @pytest.mark.parametrize("growth", (False, True))
     def test_len(self, ref, growth):
-        a = bh.axis.Category(ref, growth=growth)
+        Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
+        a = Cat(ref, growth=growth)
         assert len(a) == 3
         assert a.size == 3
         assert a.extent == 3 if growth else 4
 
     def test_repr(self):
-        ax = bh.axis.Category([1, 2, 3])
+        ax = bh.axis.IntCategory([1, 2, 3])
         assert repr(ax) == "IntCategory([1, 2, 3])"
 
-        ax = bh.axis.Category([1, 2, 3], metadata="foo")
+        ax = bh.axis.IntCategory([1, 2, 3], metadata="foo")
         assert repr(ax) == "IntCategory([1, 2, 3], metadata='foo')"
 
-        ax = bh.axis.Category("ABC", metadata="foo")
+        ax = bh.axis.StrCategory("ABC", metadata="foo")
         # If unicode is the default (Python 3, generally)
         if type("") == type(u""):
             assert repr(ax) == "StrCategory(['A', 'B', 'C'], metadata='foo')"
@@ -669,7 +679,9 @@ class TestCategory(Axis):
     @pytest.mark.parametrize("ref", ([1, 2, 3], "ABC"))
     @pytest.mark.parametrize("growth", (False, True))
     def test_getitem(self, ref, growth):
-        a = bh.axis.Category(ref, growth=growth)
+        Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
+
+        a = Cat(ref, growth=growth)
 
         for i in range(3):
             assert a.bin(i) == ref[i]
@@ -681,7 +693,7 @@ class TestCategory(Axis):
 
         with pytest.raises(IndexError):
             a.bin(-1)
-        # Even if bh.axis.Category axis has overflow enabled, we cannot return a bin value for the overflow,
+        # Even if bh.axis.*Category axis has overflow enabled, we cannot return a bin value for the overflow,
         # because it is not clear what that value should be. So we raise an IndexError when this bin is accessed.
         with pytest.raises(IndexError):
             a.bin(3)
@@ -689,13 +701,15 @@ class TestCategory(Axis):
     @pytest.mark.parametrize("ref", ([1, 2, 3], ("A", "B", "C")))
     @pytest.mark.parametrize("growth", (False, True))
     def test_iter(self, ref, growth):
-        a = bh.axis.Category(ref, growth=growth)
+        Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
+        a = Cat(ref, growth=growth)
         assert_array_equal(a, ref)
 
     @pytest.mark.parametrize("ref", ([1, 2, 3], ("A", "B", "C")))
     @pytest.mark.parametrize("growth", (False, True))
     def test_index(self, ref, growth):
-        a = bh.axis.Category(ref, growth=growth)
+        Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
+        a = Cat(ref, growth=growth)
         for i, r in enumerate(ref):
             assert a.index(r) == i
         assert_array_equal(a.index(ref), [0, 1, 2])
@@ -703,7 +717,8 @@ class TestCategory(Axis):
     @pytest.mark.parametrize("ref", ([1, 2, 3], "ABC"))
     @pytest.mark.parametrize("growth", (False, True))
     def test_edges_centers_widths(self, ref, growth):
-        a = bh.axis.Category(ref, growth=growth)
+        Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
+        a = Cat(ref, growth=growth)
         assert_allclose(a.edges, [0, 1, 2, 3])
         assert_allclose(a.centers, [0.5, 1.5, 2.5])
         assert_allclose(a.widths, [1, 1, 1])

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -623,19 +623,19 @@ class TestCategory(Axis):
             bh.axis.Category([1, 2, 3], underflow=True)
 
         ax = bh.axis.Category([1, 2, 3])
-        assert isinstance(ax, bh.axis.Category)
+        assert isinstance(ax, bh.axis.IntCategory)
         assert ax.options == bh.axis.options(overflow=True)
 
         ax = bh.axis.Category([1, 2, 3], growth=True)
-        assert isinstance(ax, bh.axis.Category)
+        assert isinstance(ax, bh.axis.IntCategory)
         assert ax.options == bh.axis.options(growth=True)
 
         ax = bh.axis.Category(["1", "2", "3"])
-        assert isinstance(ax, bh.axis.Category)
+        assert isinstance(ax, bh.axis.StrCategory)
         assert ax.options == bh.axis.options(overflow=True)
 
         ax = bh.axis.Category(["1", "2", "3"], growth=True)
-        assert isinstance(ax, bh.axis.Category)
+        assert isinstance(ax, bh.axis.StrCategory)
         assert ax.options == bh.axis.options(growth=True)
 
     def test_equal(self):
@@ -654,17 +654,17 @@ class TestCategory(Axis):
 
     def test_repr(self):
         ax = bh.axis.Category([1, 2, 3])
-        assert repr(ax) == "Category([1, 2, 3])"
+        assert repr(ax) == "IntCategory([1, 2, 3])"
 
         ax = bh.axis.Category([1, 2, 3], metadata="foo")
-        assert repr(ax) == "Category([1, 2, 3], metadata='foo')"
+        assert repr(ax) == "IntCategory([1, 2, 3], metadata='foo')"
 
         ax = bh.axis.Category("ABC", metadata="foo")
         # If unicode is the default (Python 3, generally)
         if type("") == type(u""):
-            assert repr(ax) == "Category(['A', 'B', 'C'], metadata='foo')"
+            assert repr(ax) == "StrCategory(['A', 'B', 'C'], metadata='foo')"
         else:
-            assert repr(ax) == "Category([u'A', u'B', u'C'], metadata='foo')"
+            assert repr(ax) == "StrCategory([u'A', u'B', u'C'], metadata='foo')"
 
     @pytest.mark.parametrize("ref", ([1, 2, 3], "ABC"))
     @pytest.mark.parametrize("growth", (False, True))

--- a/tests/test_cpp_interface.py
+++ b/tests/test_cpp_interface.py
@@ -18,7 +18,7 @@ def test_usage_bh():
 
 def test_convert_bh():
     h = bhc.histogram(
-        bh.Histogram(bh.axis.Regular(10, 0, 1), bh.axis.Category(["one", "two"]))
+        bh.Histogram(bh.axis.Regular(10, 0, 1), bh.axis.StrCategory(["one", "two"]))
     )
     assert hasattr(h, "axis")
     assert not hasattr(h, "axes")

--- a/tests/test_cpp_interface.py
+++ b/tests/test_cpp_interface.py
@@ -7,9 +7,9 @@ import pytest
 
 
 def test_usage_bh():
-    h = bhc.histogram(bhc.axis.regular(10, 0, 1), bhc.axis.category(["one", "two"]))
+    h = bhc.histogram(bhc.axis.regular(10, 0, 1), bhc.axis.str_category(["one", "two"]))
     assert h.axis(0) == bhc.axis.regular(10, 0, 1)
-    assert h.axis(1) == bhc.axis.category(["one", "two"])
+    assert h.axis(1) == bhc.axis.str_category(["one", "two"])
 
     h(0, "one")
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -424,7 +424,7 @@ def test_shrink_rebin_1d():
 # CLASSIC: This used to have metadata too, but that does not compare equal
 def test_pickle_0():
     a = bh.Histogram(
-        bh.axis.Category([0, 1, 2]),
+        bh.axis.IntCategory([0, 1, 2]),
         bh.axis.Integer(0, 20),
         bh.axis.Regular(2, 0.0, 20.0, underflow=False, overflow=False),
         bh.axis.Variable([0.0, 1.0, 2.0]),
@@ -459,7 +459,7 @@ def test_pickle_0():
 
 def test_pickle_1():
     a = bh.Histogram(
-        bh.axis.Category([0, 1, 2]),
+        bh.axis.IntCategory([0, 1, 2]),
         bh.axis.Integer(0, 3, metadata="ia"),
         bh.axis.Regular(4, 0.0, 4.0, underflow=False, overflow=False),
         bh.axis.Variable([0.0, 1.0, 2.0]),
@@ -756,7 +756,7 @@ def test_fill_with_numpy_array_1():
 
 
 def test_fill_with_numpy_array_2():
-    a = bh.Histogram(bh.axis.Category(["A", "B"]))
+    a = bh.Histogram(bh.axis.StrCategory(["A", "B"]))
     a.fill(("A", "B", "C"))
     a.fill(np.array(("D", "A"), dtype="S5"))
     assert a[0] == 2
@@ -765,7 +765,7 @@ def test_fill_with_numpy_array_2():
 
     b = bh.Histogram(
         bh.axis.Integer(0, 2, underflow=False, overflow=False),
-        bh.axis.Category(["A", "B"]),
+        bh.axis.StrCategory(["A", "B"]),
     )
     b.fill((1, 0, 10), ("C", "B", "A"))
     assert b[0, 0] == 0

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -190,6 +190,16 @@ def test_growth():
     assert h[bh.overflow] == 0
 
 
+def test_growing_cats():
+    h = bh.Histogram(
+        bh.axis.IntCategory([], growth=True), bh.axis.StrCategory([], growth=True)
+    )
+
+    h.fill([1, 2, 1, 1], ["hi", "ho", "hi", "ho"])
+
+    assert h.size == 4
+
+
 @pytest.mark.parametrize("flow", [True, False])
 def test_fill_2d(flow):
     h = bh.Histogram(

--- a/tests/test_internal_histogram.py
+++ b/tests/test_internal_histogram.py
@@ -93,7 +93,7 @@ def test_int_histogram():
 
 
 def test_str_categories_histogram():
-    hist = bh.Histogram(bh.axis.Category(["a", "b", "c"]), storage=bh.storage.Int())
+    hist = bh.Histogram(bh.axis.StrCategory(["a", "b", "c"]), storage=bh.storage.Int())
 
     vals = ["a", "b", "b", "c"]
     # Can't fill yet
@@ -195,7 +195,7 @@ def test_sums():
 
 
 def test_int_cat_hist():
-    h = bh.Histogram(bh.axis.Category([1, 2, 3]), storage=bh.storage.Int())
+    h = bh.Histogram(bh.axis.IntCategory([1, 2, 3]), storage=bh.storage.Int())
 
     h.fill(1)
     h.fill(2)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -64,10 +64,10 @@ axes_creations = (
     (bh.axis.Regular, (4, 2, 4), {"circular": True}),
     (bh.axis.Variable, ([1, 2, 3, 4],), {}),
     (bh.axis.Integer, (1, 4), {}),
-    (bh.axis.Category, ([1, 2, 3],), {}),
-    (bh.axis.Category, ([1, 2, 3],), {"growth": True}),
-    (bh.axis.Category, (["1", "2", "3"],), {}),
-    (bh.axis.Category, (["1", "2", "3"],), {"growth": True}),
+    (bh.axis.IntCategory, ([1, 2, 3],), {}),
+    (bh.axis.IntCategory, ([1, 2, 3],), {"growth": True}),
+    (bh.axis.StrCategory, (["1", "2", "3"],), {}),
+    (bh.axis.StrCategory, (["1", "2", "3"],), {"growth": True}),
 )
 
 

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -159,7 +159,7 @@ def test_histogram_metadata(copy_fn, metadata):
 
 @pytest.mark.parametrize("copy_fn", copy_fns)
 def test_numpy_edge(copy_fn):
-    ax1 = bh._core.axis.regular_numpy(10, 0, 1)
+    ax1 = bh._core.axis.regular_numpy(10, 0, 1, None)
     ax2 = copy_fn(ax1)
 
     # stop defaults to 0, so this fails if the copy fails


### PR DESCRIPTION
Fixes #215 by splitting Category into IntCategory and StrCategory. You can now make an empty category axis.

Some cleanup of the axis creation, and removing internal docstrings.

~~@HDembinski, would a possible workaround for now (in the bindings) be to create the default constructed axis, then set the metadata manually? Would there be any potential issues? It would be nice to be compatible with Boost 1.72's Histogram for the moment.~~ 

~~(Implemented)~~

@HDembinski already fixed this in Boost.Histogram, so now using that here!
