### PR TITLE
Fix fill issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@
 *~
 *.clangd
 compile_commands.json
+
+# Venvs
+/*venv*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ option(BOOST_HISTOGRAM_ERRORS "Make warnings errors (for CI mostly)")
 
 # Adding warnings
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-    target_compile_options(_core PRIVATE -Wall -Wextra -pedantic-errors -Wconversion -Wsign-conversion)
+    target_compile_options(_core PRIVATE -Wall -Wextra -pedantic-errors -Wconversion -Wsign-conversion -Wsign-compare)
     if(BOOST_HISTOGRAM_ERRORS)
         target_compile_options(_core PRIVATE -Werror)
     endif()
@@ -202,6 +202,3 @@ if(BUILD_TESTING)
         add_test(${TEST_NAME} ${PYTHON_EXECUTABLE} -m pytest "${TEST_FILE}")
     endforeach()
 endif()
-
-
-

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -313,6 +313,8 @@ register_histogram(py::module &m, const char *name, const char *desc) {
                          if(sarray.ndim() != 1)
                              throw std::invalid_argument("Sample array must be 1D");
 
+                         // releasing gil here is safe, we don't manipulate refcounts
+                         py::gil_scoped_release lock;
                          bv2::visit(
                              overload(
                                  [&h, &vargs, &sarray](const bv2::monostate &) {
@@ -326,6 +328,8 @@ register_histogram(py::module &m, const char *name, const char *desc) {
                      [&kwargs, &vargs, &weight](auto &h) {
                          finalize_args(kwargs);
 
+                         // releasing gil here is safe, we don't manipulate refcounts
+                         py::gil_scoped_release lock;
                          bv2::visit(
                              overload([&h, &vargs](
                                           const bv2::monostate &) { h.fill(vargs); },

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -232,14 +232,14 @@ register_histogram(py::module &m, const char *name, const char *desc) {
                      "supported value types are double, int, std::string; new axis was "
                      "added with different value type");
 
-                 // HD: std::vector<std::string> is for passing strings, this very very
-                 // inefficient but works at least I need to change something in
+                 // HD: std::vector<std::string> is for passing strings, this is very
+                 // inefficient but works at least. I need to change something in
                  // boost::histogram to make passing strings from a numpy array
-                 // efficient
-                 using varg_t = boost::variant2::variant<array_int_t,
-                                                         int,
+                 // efficient.
+                 using varg_t = boost::variant2::variant<double,
                                                          array_double_t,
-                                                         double,
+                                                         int,
+                                                         array_int_t,
                                                          std::vector<std::string>,
                                                          std::string>;
                  auto vargs   = bh::detail::make_stack_buffer<varg_t>(

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -260,10 +260,10 @@ register_histogram(py::module &m, const char *name, const char *desc) {
                  // inefficient but works at least. I need to change something in
                  // boost::histogram to make passing strings from a numpy array
                  // efficient.
-                 using varg_t = boost::variant2::variant<double,
-                                                         array_double_t,
-                                                         int,
+                 using varg_t = boost::variant2::variant<array_double_t,
+                                                         double,
                                                          array_int_t,
+                                                         int,
                                                          std::vector<std::string>,
                                                          std::string>;
                  auto vargs   = bh::detail::make_stack_buffer<varg_t>(

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -66,7 +66,11 @@ auto overload(Fs &&... xs) {
 }
 
 template <class T>
-using c_array_t = py::array_t<T, py::array::c_style | py::array::forcecast>;
+struct c_array_t : py::array_t<T, py::array::c_style | py::array::forcecast> {
+    using base_t = py::array_t<T, py::array::c_style | py::array::forcecast>;
+    using base_t::base_t;
+    std::size_t size() const { return static_cast<std::size_t>(base_t::size()); }
+};
 
 } // namespace detail
 

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -267,8 +267,14 @@ register_histogram(py::module &m, const char *name, const char *desc) {
                                  // once the issue in boost::histogram is fixed
                                  v = std::vector<std::string>(1,
                                                               py::cast<std::string>(x));
-                             else
+                             else if(py::isinstance<py::array>(x)) {
+                                 if(py::cast<py::array>(x).ndim() != 1)
+                                     throw std::invalid_argument(
+                                         "All arrays must be 1D");
                                  v = py::cast<std::vector<std::string>>(x);
+                             } else {
+                                 v = py::cast<std::vector<std::string>>(x);
+                             }
                          },
                          [](auto t, varg_t &v, const py::handle &x) {
                              using U = typename decltype(t)::type;

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -65,8 +65,8 @@ bool is_pyiterable(const T &t) {
     return py::isinstance<py::buffer>(t) || py::hasattr(t, "__iter__");
 }
 
-template <class T, class VArg, class Arg>
-void set_varg(boost::mp11::mp_identity<T>, VArg &v, const Arg &x) {
+template <class T, class VArg>
+void set_varg(boost::mp11::mp_identity<T>, VArg &v, const py::handle &x) {
     if(is_pyiterable(x)) {
         auto arr
             = py::cast<py::array_t<T, py::array::c_style | py::array::forcecast>>(x);
@@ -79,8 +79,8 @@ void set_varg(boost::mp11::mp_identity<T>, VArg &v, const Arg &x) {
 
 // specialization for string (HD: this is very inefficient and will be made more
 // efficient in the future)
-template <class VArg, class Arg>
-void set_varg(boost::mp11::mp_identity<std::string>, VArg &v, const Arg &x) {
+template <class VArg>
+void set_varg(boost::mp11::mp_identity<std::string>, VArg &v, const py::handle &x) {
     if(py::isinstance<py::str>(x))
         v = py::cast<std::string>(x);
     else

--- a/include/boost/histogram/python/register_histogram.hpp
+++ b/include/boost/histogram/python/register_histogram.hpp
@@ -32,6 +32,15 @@
 #include <tuple>
 #include <vector>
 
+namespace detail {
+template <class T, class... Us>
+using is_one_of = boost::mp11::mp_contains<boost::mp11::mp_list<Us...>, T>;
+
+template <class T>
+bool is_pyiterable(const T &t) {
+    return py::isinstance<py::buffer>(t) || py::hasattr(t, "__iter__");
+}
+
 template <class...>
 struct overload_t;
 
@@ -56,36 +65,9 @@ auto overload(Fs &&... xs) {
     return overload_t<Fs...>(std::forward<Fs>(xs)...);
 }
 
-namespace detail {
-template <class T, class... Us>
-using is_one_of = boost::mp11::mp_contains<boost::mp11::mp_list<Us...>, T>;
-
 template <class T>
-bool is_pyiterable(const T &t) {
-    return py::isinstance<py::buffer>(t) || py::hasattr(t, "__iter__");
-}
+using c_array_t = py::array_t<T, py::array::c_style | py::array::forcecast>;
 
-template <class T, class VArg>
-void set_varg(boost::mp11::mp_identity<T>, VArg &v, const py::handle &x) {
-    if(is_pyiterable(x)) {
-        auto arr
-            = py::cast<py::array_t<T, py::array::c_style | py::array::forcecast>>(x);
-        if(arr.ndim() != 1)
-            throw std::invalid_argument("All arrays must be 1D");
-        v = arr;
-    } else
-        v = py::cast<T>(x);
-}
-
-// specialization for string (HD: this is very inefficient and will be made more
-// efficient in the future)
-template <class VArg>
-void set_varg(boost::mp11::mp_identity<std::string>, VArg &v, const py::handle &x) {
-    if(py::isinstance<py::str>(x))
-        v = py::cast<std::string>(x);
-    else
-        v = py::cast<std::vector<std::string>>(x);
-}
 } // namespace detail
 
 template <class A, class S>
@@ -239,13 +221,13 @@ register_histogram(py::module &m, const char *name, const char *desc) {
 
         .def("fill",
              [](histogram_t &self, py::args args, py::kwargs kwargs) {
-                 using array_int_t
-                     = py::array_t<int, py::array::c_style | py::array::forcecast>;
-                 using array_double_t
-                     = py::array_t<double, py::array::c_style | py::array::forcecast>;
-
                  if(args.size() != self.rank())
                      throw std::invalid_argument("Wrong number of args");
+
+                 using detail::is_pyiterable;
+                 using detail::is_one_of;
+                 using detail::overload;
+                 using detail::c_array_t;
 
                  namespace bmp = boost::mp11;
                  static_assert(
@@ -260,46 +242,67 @@ register_histogram(py::module &m, const char *name, const char *desc) {
                  // inefficient but works at least. I need to change something in
                  // boost::histogram to make passing strings from a numpy array
                  // efficient.
-                 using varg_t = boost::variant2::variant<array_double_t,
+                 using varg_t = boost::variant2::variant<c_array_t<double>,
                                                          double,
-                                                         array_int_t,
+                                                         c_array_t<int>,
                                                          int,
                                                          std::vector<std::string>,
                                                          std::string>;
-                 auto vargs   = bh::detail::make_stack_buffer<varg_t>(
+
+                 auto vargs = bh::detail::make_stack_buffer<varg_t>(
                      bh::unsafe_access::axes(self));
 
-                 {
-                     auto args_it  = args.begin();
-                     auto vargs_it = vargs.begin();
-                     self.for_each_axis([&args_it, &vargs_it](const auto &ax) {
-                         using T = std::decay_t<decltype(ax.value(0))>;
-                         detail::set_varg(
-                             boost::mp11::mp_identity<T>{}, *vargs_it++, *args_it++);
-                     });
-                 }
+                 self.for_each_axis([args_it  = args.begin(),
+                                     vargs_it = vargs.begin()](const auto &ax) mutable {
+                     using T = bh::axis::traits::value_type<std::decay_t<decltype(ax)>>;
+
+                     overload(
+                         [](bmp::mp_identity<std::string>,
+                            varg_t &v,
+                            const py::handle &x) {
+                             // specialization for string (HD: this is very inefficient
+                             // and will be made more efficient in the future)
+                             if(py::isinstance<py::str>(x))
+                                 // hot-fix, should be `v = py::cast<std::string>(x);`
+                                 // once the issue in boost::histogram is fixed
+                                 v = std::vector<std::string>(1,
+                                                              py::cast<std::string>(x));
+                             else
+                                 v = py::cast<std::vector<std::string>>(x);
+                         },
+                         [](auto t, varg_t &v, const py::handle &x) {
+                             using U = typename decltype(t)::type;
+                             if(is_pyiterable(x)) {
+                                 auto arr = py::cast<c_array_t<U>>(x);
+                                 if(arr.ndim() != 1)
+                                     throw std::invalid_argument(
+                                         "All arrays must be 1D");
+                                 v = arr;
+                             } else
+                                 v = py::cast<U>(x);
+                         })(bmp::mp_identity<T>(), *vargs_it++, *args_it++);
+                 });
 
                  // default constructed as monostate to indicate absence of weight
-                 bv2::variant<bv2::monostate, double, array_double_t> weight;
+                 bv2::variant<bv2::monostate, double, c_array_t<double>> weight;
                  {
                      auto w = optional_arg(kwargs, "weight");
                      if(!w.is_none()) {
-                         if(detail::is_pyiterable(w))
-                             weight = py::cast<array_double_t>(w);
+                         if(is_pyiterable(w))
+                             weight = py::cast<c_array_t<double>>(w);
                          else
                              weight = py::cast<double>(w);
                      }
                  }
 
                  using storage_t = typename histogram_t::storage_type;
-                 bh::detail::static_if<detail::is_one_of<storage_t,
-                                                         storage::mean,
-                                                         storage::weighted_mean>>(
+                 bh::detail::static_if<
+                     is_one_of<storage_t, storage::mean, storage::weighted_mean>>(
                      [&kwargs, &vargs, &weight](auto &h) {
                          auto s = required_arg(kwargs, "sample");
                          finalize_args(kwargs);
 
-                         auto sarray = py::cast<array_double_t>(s);
+                         auto sarray = py::cast<c_array_t<double>>(s);
                          if(sarray.ndim() != 1)
                              throw std::invalid_argument("Sample array must be 1D");
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -795,5 +795,5 @@ def test_fill_with_sequence_2():
 
 ## this segfaults
 # def test_fill_with_sequence_3():
-#     h = bh.Histogram(bh.axis.StrCategory([], growth=True), bh.axis.Regular(20, 0, 1))
-#     h.fill(['a'], np.arange(2))
+#     h = bh.Histogram(bh.axis.StrCategory([], growth=True), bh.axis.Integer(0, 1))
+#     h.fill(["1"], np.arange(2))

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -765,7 +765,7 @@ def test_fill_with_sequence_1():
     assert a[2] == 3
 
 
-def test_fill_with_numpy_array_2():
+def test_fill_with_sequence_2():
     a = bh.Histogram(bh.axis.StrCategory(["A", "B"]))
     a.fill("A")
     a.fill(("A", "B", "C"))
@@ -773,6 +773,12 @@ def test_fill_with_numpy_array_2():
     assert a[0] == 3
     assert a[1] == 1
     assert a[bh.overflow] == 2
+
+    with pytest.raises(ValueError):
+        a.fill(np.array("B"))  # ndim == 0 not allowed
+
+    with pytest.raises(ValueError):
+        a.fill(np.array((("B", "A"), ("C", "A"))))  # ndim == 2 not allowed
 
     b = bh.Histogram(
         bh.axis.Integer(0, 2, underflow=False, overflow=False),
@@ -785,3 +791,9 @@ def test_fill_with_numpy_array_2():
     assert b[1, 1] == 0
     assert b[0, bh.overflow] == 0
     assert b[1, bh.overflow] == 1
+
+
+## this segfaults
+# def test_fill_with_sequence_3():
+#     h = bh.Histogram(bh.axis.StrCategory([], growth=True), bh.axis.Regular(20, 0, 1))
+#     h.fill(['a'], np.arange(2))

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -770,9 +770,7 @@ def test_fill_with_numpy_array_2():
     a.fill("A")
     a.fill(("A", "B", "C"))
     a.fill(np.array(("D", "A"), dtype="S5"))
-    assert a[0] == 2
-    assert a[1] == 1
-    assert a[bh.overflow] == 2
+    assert a.view(true) == (3, 1, 2)
 
     b = bh.Histogram(
         bh.axis.Integer(0, 2, underflow=False, overflow=False),

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -645,7 +645,7 @@ def test_numpy_conversion_5():
     assert a1[2, 1] == 5
 
 
-def test_fill_with_numpy_array_0():
+def test_fill_with_sequence_0():
     def ar(*args):
         return np.array(args, dtype=float)
 
@@ -699,7 +699,7 @@ def test_fill_with_numpy_array_0():
     assert a[2] == 3
 
 
-def test_fill_with_numpy_array_1():
+def test_fill_with_sequence_1():
     def ar(*args):
         return np.array(args, dtype=float)
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -770,7 +770,9 @@ def test_fill_with_numpy_array_2():
     a.fill("A")
     a.fill(("A", "B", "C"))
     a.fill(np.array(("D", "A"), dtype="S5"))
-    assert a.view(true) == (3, 1, 2)
+    assert a[0] == 3
+    assert a[1] == 1
+    assert a[bh.overflow] == 2
 
     b = bh.Histogram(
         bh.axis.Integer(0, 2, underflow=False, overflow=False),

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -767,6 +767,7 @@ def test_fill_with_numpy_array_1():
 
 def test_fill_with_numpy_array_2():
     a = bh.Histogram(bh.axis.StrCategory(["A", "B"]))
+    a.fill("A")
     a.fill(("A", "B", "C"))
     a.fill(np.array(("D", "A"), dtype="S5"))
     assert a[0] == 2


### PR DESCRIPTION
Fixes the issues in #214 reported by @nsmith-
- [x] `h.fill("foo")` must work
- [x] `h.fill(np.array("foo"))` should not work and give a clear error message (ndim==0 not supported)
- [ ] segfault of the following code
```py
h = bh.Histogram(bh.axis.StrCategory([], growth=True), bh.axis.Integer(0, 1))
h.fill(["a"], [1, 2])
```