### PR TITLE
Fix shallow copy, axis staleness, transform pickle

### DIFF
--- a/boost_histogram/_internal/axis.py
+++ b/boost_histogram/_internal/axis.py
@@ -12,12 +12,18 @@ from .axis_transform import AxisTransform
 from .utils import cast, register, set_family, MAIN_FAMILY, CPP_FAMILY, set_module
 
 import warnings
+import copy
 
 
 # Contains common methods and properties to all axes
 @set_module("boost_histogram.axis")
 class Axis(object):
     __slots__ = ("_ax",)
+
+    def __copy__(self):
+        other = self.__class__.__new__(self.__class__)
+        other._ax = copy.copy(self._ax)
+        return other
 
     def index(self, value):
         """

--- a/boost_histogram/_internal/axis_transform.py
+++ b/boost_histogram/_internal/axis_transform.py
@@ -8,10 +8,17 @@ from .utils import register, set_family, CPP_FAMILY, MAIN_FAMILY, set_module
 from .sig_tools import inject_signature
 from .kwargs import KWArgs
 
+import copy
+
 
 @set_module("boost_histogram.axis.transform")
 class AxisTransform(object):
     __slots__ = ("_this",)
+
+    def __copy__(self):
+        other = self.__class__.__new__(self.__class__)
+        other._this = copy.copy(self._this)
+        return other
 
     @classmethod
     def _convert_cpp(cls, this):

--- a/include/transform.hpp
+++ b/include/transform.hpp
@@ -137,3 +137,24 @@ inline const char* axis_suffix(const ::func_transform&) { return "_trans"; }
 } // namespace detail
 } // namespace histogram
 } // namespace boost
+
+/// Simple deep copy for any class *without* a python component
+template <class T>
+T deep_copy(const T& input, py::object) {
+    return T(input);
+}
+
+/// Specialization for the case where Python components are present
+/// (Function transform in this case)
+template <>
+inline func_transform deep_copy<func_transform>(const func_transform& input,
+                                                py::object memo) {
+    py::module copy = py::module::import("copy");
+
+    py::object forward = copy.attr("deepcopy")(input._forward_ob, memo);
+    py::object inverse = copy.attr("deepcopy")(input._inverse_ob, memo);
+    py::object convert = copy.attr("deepcopy")(input._convert_ob, memo);
+    py::str name       = copy.attr("deepcopy")(input._name, memo);
+
+    return func_transform(forward, inverse, convert, name);
+}

--- a/src/register_transforms.cpp
+++ b/src/register_transforms.cpp
@@ -9,6 +9,7 @@
 #include <pybind11/operators.h>
 
 #include "axis.hpp"
+#include "make_pickle.hpp"
 #include "transform.hpp"
 #include <boost/histogram/axis/regular.hpp>
 
@@ -18,6 +19,7 @@ py::class_<T> register_transform(py::module& mod, Args&&... args) {
     transform.def(py::init<T>());
     transform.def("forward", [](const T& self, double v) { return self.forward(v); });
     transform.def("inverse", [](const T& self, double v) { return self.inverse(v); });
+    transform.def(make_pickle<T>());
     return transform;
 }
 

--- a/src/register_transforms.cpp
+++ b/src/register_transforms.cpp
@@ -16,10 +16,18 @@
 template <class T, class... Args>
 py::class_<T> register_transform(py::module& mod, Args&&... args) {
     py::class_<T> transform(mod, std::forward<Args>(args)...);
-    transform.def(py::init<T>());
-    transform.def("forward", [](const T& self, double v) { return self.forward(v); });
-    transform.def("inverse", [](const T& self, double v) { return self.inverse(v); });
-    transform.def(make_pickle<T>());
+
+    transform
+
+        .def(py::init<T>())
+        .def("forward", [](const T& self, double v) { return self.forward(v); })
+        .def("inverse", [](const T& self, double v) { return self.inverse(v); })
+        .def(make_pickle<T>())
+        .def("__copy__", [](const T& self) { return T(self); })
+        .def("__deepcopy__", &deep_copy<T>)
+
+        ;
+
     return transform;
 }
 

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -199,3 +199,38 @@ def test_pickle_transforms(mod, copy_fn):
     assert ax1 == ax2
     assert_array_equal(ax1.centers, ax2.centers)
     assert_array_equal(ax2.centers, ax3.centers)
+
+
+@pytest.mark.parametrize("copy_fn", copy_fns)
+def test_hist_axes_reference(copy_fn):
+    h = bh.Histogram(bh.axis.Regular(10, 0, 1, metadata=1))
+    h.axes[0].metadata = 2
+
+    # Note: copy does not copy the metadata, but we are *replacing*
+    # the metadata here, so it should be distinct even after a shallow copy.
+    h2 = copy_fn(h)
+
+    assert h2._hist is not h._hist
+    assert h2.axes[0] is not h.axes[0]
+
+    assert h2.axes[0].metadata == 2
+
+    h.axes[0].metadata = 3
+    assert h2._axis(0).metadata == 2
+    assert h2.axes[0].metadata == 2
+
+
+@pytest.mark.parametrize("copy_fn", copy_fns)
+def test_axis_wrapped(copy_fn):
+    ax = bh.axis.Regular(10, 0, 2)
+    ax2 = copy_fn(ax)
+
+    assert ax._ax is not ax2._ax
+
+
+@pytest.mark.parametrize("copy_fn", copy_fns)
+def test_trans_wrapped(copy_fn):
+    tr = bh.axis.transform.Pow(2)
+    tr2 = copy_fn(tr)
+
+    assert tr._this is not tr2._this


### PR DESCRIPTION
The wrapped design was not copying anything on a shallow copy, as this now was skipping the `._this`/`._hist`/`._ax` attribute as "deep". (I may rename all of them to `_this` for consistency later).

Fix #220 again; this time after copies.

Pickling transforms was broken due to a missing line, fixed.

TODO:
- [x] Fix copy/deepcopy for transforms (will help Python 2)