### PR TITLE
Move formatting to Github Actions

### DIFF
--- a/.ci/azure-test-pipeline.yml
+++ b/.ci/azure-test-pipeline.yml
@@ -9,22 +9,6 @@ variables:
 
 jobs:
 
-- job: Formatting
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.7'
-        architecture: 'x64'
-    - script: python -m pip install pre-commit
-      displayName: Install pre-commit
-    - script: pre-commit run --all
-      displayName: Run pre-commit
-    - script: git diff --exit-code
-      displayName: Display format changes
-      condition: always()
-
 - job: LinuxSDist
   pool:
     vmImage: 'ubuntu-16.04'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,22 @@
+name: Format
+
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+    - develop
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+    - name: set PY
+      run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - uses: pre-commit/action@v1.0.0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Gitter][gitter-badge]][gitter-link]
 [![Build Status][azure-badge]][azure-link]
+[![Actions Status][actions-badge]][actions-link]
 [![Documentation Status][rtd-badge]][rtd-link]
 [![DOI](https://zenodo.org/badge/148885351.svg)](https://zenodo.org/badge/latestdoi/148885351)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
@@ -180,10 +181,12 @@ Support for this work was provided by the National Science Foundation cooperativ
 
 [gitter-badge]:            https://badges.gitter.im/HSF/PyHEP-histogramming.svg
 [gitter-link]:             https://gitter.im/HSF/PyHEP-histogramming?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
-[azure-badge]:             https://dev.azure.com/scikit-hep/boost-histogram/_apis/build/status/scikit-hep.boost-histogram?branchName=develop
+[azure-badge]:             https://dev.azure.com/scikit-hep/boost-histogram/_apis/build/status/bh-tests?branchName=develop
 [azure-link]:              https://dev.azure.com/scikit-hep/boost-histogram/_build/latest?definitionId=2&branchName=develop
 [rtd-badge]:               https://readthedocs.org/projects/boost-histogram/badge/?version=latest
 [rtd-link]:                https://boost-histogram.readthedocs.io/en/latest/?badge=latest
+[actions-badge]:           https://github.com/scikit-hep/boost-histogram/workflows/Format/badge.svg
+[actions-link]:            https://github.com/scikit-hep/boost-histogram/actions
 
 [Boost::Histogram]:        https://www.boost.org/doc/libs/1_71_0/libs/histogram/doc/html/index.html
 [Boost::Histogram source]: https://github.com/boostorg/histogram


### PR DESCRIPTION
Using GitHub Actions, does not checkout submodules, closes #69. Formatting can complete in 23 seconds instead of 1 minute.

Implemented using https://github.com/pre-commit/action/issues/1.

Sadly, there's still no way to say "Reformat, please" to get it to reformat. But that may happen at some point.