### PR TITLE
Add density to numpy

### DIFF
--- a/boost_histogram/numpy.py
+++ b/boost_histogram/numpy.py
@@ -25,17 +25,19 @@ def histogramdd(
         if bh_warning is not None:
             import warnings
 
-            warnings.warn("bh= has been replaced by bh_object=", FutureWarning)
+            warnings.warn("bh= has been replaced by bh_cls=", FutureWarning)
+            bh_warning = bh.Histogram
         else:
-            bh_warning = False
-        bh_object = k.optional("bh_object", bh_warning)
-        bh_storage = k.optional("bh_storage", _storage.Double())
+            bh_warning = None
+        bh_cls = k.optional("cls", bh_warning)
+        cls = _hist.Histogram if bh_cls is None else bh_cls
+        bh_storage = k.optional("storage", _storage.Double())
 
     if normed is not None:
         raise KeyError(
             "normed=True is not recommended for use in Numpy, and is not supported in boost-histogram; use density=True instead"
         )
-    if density and bh_object:
+    if density and bh_cls is not None:
         raise KeyError(
             "boost-histogram does not support the density keyword when returning a boost-histogram object"
         )
@@ -70,17 +72,14 @@ def histogramdd(
             b[-1] = np.nextafter(b[-1], np.finfo("d").max)
             axs.append(_axis.Variable(b))
 
-    if weights is None:
-        hist = _hist.Histogram(*axs, storage=bh_storage).fill(*a)
-    else:
-        hist = _hist.Histogram(*axis, storage=bh_storage).fill(*a, weight=weights)
+    hist = cls(*axs, storage=bh_storage).fill(*a, weight=weights)
 
     if density:
         areas = np.prod(hist.axes.widths, axis=0)
         density = hist.view() / hist.sum() / areas
         return (density,) + hist.to_numpy()[1:]
 
-    return hist if bh_object else hist.to_numpy()
+    return hist if bh_cls is not None else hist.to_numpy()
 
 
 def histogram2d(
@@ -95,8 +94,8 @@ def histogram(
     np = _np
 
     # numpy 1d histogram returns integers in some cases
-    if "bh_storage" not in kwargs and not (weights or normed or density):
-        kwargs["bh_storage"] = _storage.Int64()
+    if "storage" not in kwargs and not (weights or normed or density):
+        kwargs["storage"] = _storage.Int64()
 
     if isinstance(bins, str):
         if tuple(int(x) for x in np.__version__.split(".")[:2]) < (1, 13):
@@ -116,8 +115,8 @@ for f, n in zip(
     H = """\
     Return a boost-histogram object using the same arguments as numpy's {}.
     This does not support the deprecated normed=True argument. Two extra
-    arguments are added: bh_object=True will enable object based output, and
-    bh_storage=... lets you set the storage used.
+    arguments are added: cls=bh.Histogram will enable object based output, and
+    storage=bh.storage.* lets you set the storage used.
     """
 
     f.__doc__ = H.format(n.__name__) + n.__doc__

--- a/boost_histogram/numpy.py
+++ b/boost_histogram/numpy.py
@@ -25,11 +25,13 @@ def histogramdd(
         if bh_warning is not None:
             import warnings
 
-            warnings.warn("bh= has been replaced by bh_cls=", FutureWarning)
+            warnings.warn(
+                "bh=True has been replaced by histogram=bh.Histogram", FutureWarning
+            )
             bh_warning = bh.Histogram
         else:
             bh_warning = None
-        bh_cls = k.optional("cls", bh_warning)
+        bh_cls = k.optional("histogram", bh_warning)
         cls = _hist.Histogram if bh_cls is None else bh_cls
         bh_storage = k.optional("storage", _storage.Double())
 
@@ -115,8 +117,8 @@ for f, n in zip(
     H = """\
     Return a boost-histogram object using the same arguments as numpy's {}.
     This does not support the deprecated normed=True argument. Two extra
-    arguments are added: cls=bh.Histogram will enable object based output, and
-    storage=bh.storage.* lets you set the storage used.
+    arguments are added: histogram=bh.Histogram will enable object based
+    output, and storage=bh.storage.* lets you set the storage used.
     """
 
     f.__doc__ = H.format(n.__name__) + n.__doc__

--- a/boost_histogram/numpy.py
+++ b/boost_histogram/numpy.py
@@ -21,14 +21,14 @@ def histogramdd(
     np = _np  # Hidden to keep module clean
 
     with _KWArgs(kwargs) as k:
-        boost = k.optional("bh", False)
-        storage = k.optional("bh_storage", _storage.Double())
+        bh_object = k.optional("bh_object", False)
+        bh_storage = k.optional("bh_storage", _storage.Double())
 
     if normed is not None:
         raise KeyError(
             "normed=True is not recommended for use in Numpy, and is not supported in boost-histogram; use density=True instead"
         )
-    if density and boost:
+    if density and bh_object:
         raise KeyError(
             "boost-histogram does not support the density keyword when returning a boost-histogram object"
         )
@@ -64,16 +64,16 @@ def histogramdd(
             axs.append(_axis.Variable(b))
 
     if weights is None:
-        hist = _hist.Histogram(*axs, storage=storage).fill(*a)
+        hist = _hist.Histogram(*axs, storage=bh_storage).fill(*a)
     else:
-        hist = _hist.Histogram(*axis, storage=storage).fill(*a, weight=weights)
+        hist = _hist.Histogram(*axis, storage=bh_storage).fill(*a, weight=weights)
 
     if density:
         areas = np.prod(hist.axes.widths, axis=0)
         density = hist.view() / hist.sum() / areas
         return (density,) + hist.to_numpy()[1:]
 
-    return hist if boost else hist.to_numpy()
+    return hist if bh_object else hist.to_numpy()
 
 
 def histogram2d(
@@ -109,7 +109,7 @@ for f, n in zip(
     H = """\
     Return a boost-histogram object using the same arguments as numpy's {}.
     This does not support the deprecated normed=True argument. Two extra
-    arguments are added: bh=True will enable object based output, and
+    arguments are added: bh_object=True will enable object based output, and
     bh_storage=... lets you set the storage used.
     """
 

--- a/boost_histogram/numpy.py
+++ b/boost_histogram/numpy.py
@@ -21,7 +21,14 @@ def histogramdd(
     np = _np  # Hidden to keep module clean
 
     with _KWArgs(kwargs) as k:
-        bh_object = k.optional("bh_object", False)
+        bh_warning = k.optional("bh")
+        if bh_warning is not None:
+            import warnings
+
+            warnings.warn("bh= has been replaced by bh_object=", FutureWarning)
+        else:
+            bh_warning = False
+        bh_object = k.optional("bh_object", bh_warning)
         bh_storage = k.optional("bh_storage", _storage.Double())
 
     if normed is not None:

--- a/tests/test_numpy_interface.py
+++ b/tests/test_numpy_interface.py
@@ -3,11 +3,7 @@ import pytest
 import boost_histogram as bh
 import numpy as np
 
-import warnings
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    import boost_histogram.numpy as bhnp
+import copy
 
 np113 = tuple(int(x) for x in np.__version__.split(".")[:2]) >= (1, 13)
 
@@ -45,11 +41,21 @@ np113 = tuple(int(x) for x in np.__version__.split(".")[:2]) >= (1, 13)
 )
 def test_histogram1d(a, opt):
     v = np.array(a)
+
     h1, e1 = np.histogram(v, **opt)
-    h2, e2 = bhnp.histogram(v, **opt)
+    h2, e2 = bh.numpy.histogram(v, **opt)
 
     np.testing.assert_array_almost_equal(e1, e2)
     np.testing.assert_array_equal(h1, h2)
+
+    opt = copy.deepcopy(opt)
+    opt["density"] = True
+
+    h1, e1 = np.histogram(v, **opt)
+    h2, e2 = bh.numpy.histogram(v, **opt)
+
+    np.testing.assert_array_almost_equal(e1, e2)
+    np.testing.assert_array_almost_equal(h1, h2)
 
 
 def test_histogram2d():
@@ -57,8 +63,15 @@ def test_histogram2d():
     y = np.array([0.4, 0.5, 0.22, 0.65, 0.32, 0.01, 0.23, 1.98])
 
     h1, e1x, e1y = np.histogram2d(x, y)
-    h2, e2x, e2y = bhnp.histogram2d(x, y)
+    h2, e2x, e2y = bh.numpy.histogram2d(x, y)
 
     np.testing.assert_array_almost_equal(e1x, e2x)
     np.testing.assert_array_almost_equal(e1y, e2y)
     np.testing.assert_array_equal(h1, h2)
+
+    h1, e1x, e1y = np.histogram2d(x, y, density=True)
+    h2, e2x, e2y = bh.numpy.histogram2d(x, y, density=True)
+
+    np.testing.assert_array_almost_equal(e1x, e2x)
+    np.testing.assert_array_almost_equal(e1y, e2y)
+    np.testing.assert_array_almost_equal(h1, h2)

--- a/tests/test_numpy_interface.py
+++ b/tests/test_numpy_interface.py
@@ -59,7 +59,7 @@ def test_histogram1d(a, opt):
 @pytest.mark.parametrize("opt", opts)
 def test_histogram1d_object(a, opt):
     bh_opt = copy.deepcopy(opt)
-    bh_opt["bh_object"] = True
+    bh_opt["cls"] = bh.Histogram
 
     v = np.array(a)
 
@@ -104,7 +104,7 @@ def test_histogram2d_object():
     y = np.array([0.4, 0.5, 0.22, 0.65, 0.32, 0.01, 0.23, 1.98])
 
     h1, e1x, e1y = np.histogram2d(x, y)
-    bh_h2 = bh.numpy.histogram2d(x, y, bh_object=True)
+    bh_h2 = bh.numpy.histogram2d(x, y, cls=bh.Histogram)
     h2, e2x, e2y = bh_h2.to_numpy()
 
     np.testing.assert_array_almost_equal(e1x, e2x)
@@ -112,4 +112,4 @@ def test_histogram2d_object():
     np.testing.assert_array_equal(h1, h2)
 
     with pytest.raises(KeyError):
-        bh_h2 = bh.numpy.histogram2d(x, y, density=True, bh_object=True)
+        bh_h2 = bh.numpy.histogram2d(x, y, density=True, cls=bh.Histogram)

--- a/tests/test_numpy_interface.py
+++ b/tests/test_numpy_interface.py
@@ -59,7 +59,7 @@ def test_histogram1d(a, opt):
 @pytest.mark.parametrize("opt", opts)
 def test_histogram1d_object(a, opt):
     bh_opt = copy.deepcopy(opt)
-    bh_opt["cls"] = bh.Histogram
+    bh_opt["histogram"] = bh.Histogram
 
     v = np.array(a)
 
@@ -104,7 +104,7 @@ def test_histogram2d_object():
     y = np.array([0.4, 0.5, 0.22, 0.65, 0.32, 0.01, 0.23, 1.98])
 
     h1, e1x, e1y = np.histogram2d(x, y)
-    bh_h2 = bh.numpy.histogram2d(x, y, cls=bh.Histogram)
+    bh_h2 = bh.numpy.histogram2d(x, y, histogram=bh.Histogram)
     h2, e2x, e2y = bh_h2.to_numpy()
 
     np.testing.assert_array_almost_equal(e1x, e2x)
@@ -112,4 +112,4 @@ def test_histogram2d_object():
     np.testing.assert_array_equal(h1, h2)
 
     with pytest.raises(KeyError):
-        bh_h2 = bh.numpy.histogram2d(x, y, density=True, cls=bh.Histogram)
+        bh_h2 = bh.numpy.histogram2d(x, y, density=True, histogram=bh.Histogram)

--- a/tests/test_numpy_interface.py
+++ b/tests/test_numpy_interface.py
@@ -7,38 +7,35 @@ import copy
 
 np113 = tuple(int(x) for x in np.__version__.split(".")[:2]) >= (1, 13)
 
+inputs_1d = (
+    [1, 2, 3, 4, 3, 4, 5, 10, 9, 11, 21, -2],
+    [
+        0.27237556,
+        0.72020987,
+        0.75204098,
+        -0.29265003,
+        -2.67332888,
+        0.68420365,
+        -0.60629843,
+        -0.6375687,
+        -1.00017927,
+        -0.07707552,
+    ],
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+)
+opts = (
+    {},
+    {"bins": 10},
+    {"bins": "auto" if np113 else 20},
+    {"range": (0, 5), "bins": 30},
+    {"bins": [0, 1, 1.2, 1.3, 4, 21]},
+)
 
-@pytest.mark.parametrize(
-    "a",
-    (
-        [1, 2, 3, 4, 3, 4, 5, 10, 9, 11, 21, -2],
-        [
-            0.27237556,
-            0.72020987,
-            0.75204098,
-            -0.29265003,
-            -2.67332888,
-            0.68420365,
-            -0.60629843,
-            -0.6375687,
-            -1.00017927,
-            -0.07707552,
-        ],
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-    ),
-)
-@pytest.mark.parametrize(
-    "opt",
-    (
-        {},
-        {"bins": 10},
-        {"bins": "auto" if np113 else 20},
-        {"range": (0, 5), "bins": 30},
-        {"bins": [0, 1, 1.2, 1.3, 4, 21]},
-    ),
-)
+
+@pytest.mark.parametrize("a", inputs_1d)
+@pytest.mark.parametrize("opt", opts)
 def test_histogram1d(a, opt):
     v = np.array(a)
 
@@ -58,6 +55,31 @@ def test_histogram1d(a, opt):
     np.testing.assert_array_almost_equal(h1, h2)
 
 
+@pytest.mark.parametrize("a", inputs_1d)
+@pytest.mark.parametrize("opt", opts)
+def test_histogram1d_object(a, opt):
+    bh_opt = copy.deepcopy(opt)
+    bh_opt["bh_object"] = True
+
+    v = np.array(a)
+
+    h1, e1 = np.histogram(v, **opt)
+    bh_h2 = bh.numpy.histogram(v, **bh_opt)
+    h2, e2 = bh_h2.to_numpy()
+
+    np.testing.assert_array_almost_equal(e1, e2)
+    np.testing.assert_array_equal(h1, h2)
+
+    opt = copy.deepcopy(opt)
+    opt["density"] = True
+
+    bh_opt = copy.deepcopy(bh_opt)
+    bh_opt["density"] = True
+
+    with pytest.raises(KeyError):
+        bh_h2 = bh.numpy.histogram(v, **bh_opt)
+
+
 def test_histogram2d():
     x = np.array([0.3, 0.3, 0.1, 0.8, 0.34, 0.03, 0.32, 0.65])
     y = np.array([0.4, 0.5, 0.22, 0.65, 0.32, 0.01, 0.23, 1.98])
@@ -75,3 +97,19 @@ def test_histogram2d():
     np.testing.assert_array_almost_equal(e1x, e2x)
     np.testing.assert_array_almost_equal(e1y, e2y)
     np.testing.assert_array_almost_equal(h1, h2)
+
+
+def test_histogram2d_object():
+    x = np.array([0.3, 0.3, 0.1, 0.8, 0.34, 0.03, 0.32, 0.65])
+    y = np.array([0.4, 0.5, 0.22, 0.65, 0.32, 0.01, 0.23, 1.98])
+
+    h1, e1x, e1y = np.histogram2d(x, y)
+    bh_h2 = bh.numpy.histogram2d(x, y, bh_object=True)
+    h2, e2x, e2y = bh_h2.to_numpy()
+
+    np.testing.assert_array_almost_equal(e1x, e2x)
+    np.testing.assert_array_almost_equal(e1y, e2y)
+    np.testing.assert_array_equal(h1, h2)
+
+    with pytest.raises(KeyError):
+        bh_h2 = bh.numpy.histogram2d(x, y, density=True, bh_object=True)


### PR DESCRIPTION
Numpy interface was missing density, now it's easy to calculate, so adding it back in. Also fixed a bug where the requested storage type was being ignored.