### PR TITLE
Pickle touchup

### DIFF
--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -269,6 +269,15 @@ class Histogram(BaseHistogram):
         other.axes = AxesTuple(other._axis(i) for i in range(other.rank))
         return other
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state["axes"]  # Don't save the cashe
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.axes = AxesTuple(self._axis(i) for i in range(self.rank))
+
     def __repr__(self):
         ret = "{self.__class__.__name__}(\n  ".format(self=self)
         ret += ",\n  ".join(repr(ax) for ax in self.axes)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -139,6 +139,7 @@ def test_metadata_any(axis, args, opts, copy_fn):
     assert new == orig
 
 
+@pytest.mark.benchmark(group="histogram-pickling")
 @pytest.mark.parametrize("copy_fn", copy_fns)
 @pytest.mark.parametrize(
     "storage, extra",
@@ -153,8 +154,8 @@ def test_metadata_any(axis, args, opts, copy_fn):
         (bh.storage.WeightedMean, {"weight", "sample"}),
     ),
 )
-def test_storage(copy_fn, storage, extra):
-    n = 10000  # make large enough so that slow pickling becomes noticable
+def test_storage(benchmark, copy_fn, storage, extra):
+    n = 10000  # Make large enough so that slow pickling becomes noticable
     hist = bh.Histogram(bh.axis.Integer(0, n), storage=storage())
     x = np.arange(2 * (n + 2)) % (n + 2) - 1
     if extra == {}:
@@ -166,7 +167,7 @@ def test_storage(copy_fn, storage, extra):
     else:
         hist.fill(x, weight=np.arange(2 * n + 4) + 1, sample=np.arange(2 * n + 4) + 1)
 
-    new = copy_fn(hist)
+    new = benchmark(copy_fn, hist)
     assert_array_equal(hist.view(True), new.view(True))
     assert new == hist
 

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -155,7 +155,7 @@ def test_metadata_any(axis, args, opts, copy_fn):
     ),
 )
 def test_storage(benchmark, copy_fn, storage, extra):
-    n = 10000  # Make large enough so that slow pickling becomes noticable
+    n = 1000
     hist = bh.Histogram(bh.axis.Integer(0, n), storage=storage())
     x = np.arange(2 * (n + 2)) % (n + 2) - 1
     if extra == {}:


### PR DESCRIPTION
The tests added in #237 measure performance, so this adds benchmarks to handle the slow-pickle testing. Also simplifies the histogram pickle by not repickling the cached axes.

Run with:

```bash
python3 -m pytest --benchmark-enable --benchmark-sort fullname ../tests/test_pickle.py
```

Current result (I reduced the number from 10000 to 1000 for these runs accidentally, similar results x 10 if you use the current length):

```
---------------------------------------------------------------------------------------------------------- benchmark '1d-fills': 32 tests ----------------------------------------------------------------------------------------------------------
Name (time in us)                                                            Min                   Max                Mean             StdDev              Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_storage[AtomicInt64-extra0-copy]                                    25.0150 (1.10)       166.3780 (1.26)      26.8740 (1.09)      5.6740 (1.42)      25.4790 (1.10)      0.2860 (1.42)    1084;3717       37.2107 (0.91)      21596           1
test_storage[AtomicInt64-extra0-deepcopy]                                29.0420 (1.28)       132.7360 (1.01)      31.0798 (1.27)      6.1544 (1.54)      29.5460 (1.27)      0.3280 (1.62)    1026;3008       32.1752 (0.79)      19977           1
test_storage[AtomicInt64-extra0-pickle_roundtrip_protocol_2]             79.7780 (3.51)       191.6130 (1.46)      83.9384 (3.42)      8.3356 (2.08)      81.4310 (3.51)      1.1640 (5.76)      372;675       11.9135 (0.29)       4406           1
test_storage[AtomicInt64-extra0-pickle_roundtrip_protocol_highest]       71.5610 (3.15)       202.3310 (1.54)      75.8416 (3.09)      8.7116 (2.17)      73.1525 (3.15)      1.0970 (5.43)     557;1504       13.1854 (0.32)       9124           1
test_storage[Double-extra4-copy]                                         23.2380 (1.02)       132.3800 (1.01)      25.0402 (1.02)      5.2595 (1.31)      23.7910 (1.02)      0.2630 (1.30)    1292;3782       39.9359 (0.98)      25243           1
test_storage[Double-extra4-deepcopy]                                     27.0910 (1.19)       202.5830 (1.54)      30.2239 (1.23)      7.6599 (1.91)      27.9430 (1.20)      2.7855 (13.79)   1227;1528       33.0864 (0.81)      18984           1
test_storage[Double-extra4-pickle_roundtrip_protocol_2]                  94.8500 (4.17)       278.2330 (2.11)     107.1392 (4.36)     19.3209 (4.82)      98.5595 (4.25)     14.2970 (70.78)     468;403        9.3336 (0.23)       4482           1
test_storage[Double-extra4-pickle_roundtrip_protocol_highest]            66.9440 (2.94)       249.2090 (1.89)      72.2903 (2.94)     11.3043 (2.82)      68.6020 (2.96)      2.3320 (11.54)    506;1475       13.8331 (0.34)       7514           1
test_storage[Int64-extra1-copy]                                          23.3550 (1.03)       131.5960 (1.0)       24.5650 (1.0)       4.0054 (1.0)       23.7060 (1.02)      0.2020 (1.0)      848;2671       40.7083 (1.0)       22720           1
test_storage[Int64-extra1-deepcopy]                                      27.2820 (1.20)       137.4020 (1.04)      28.8675 (1.18)      4.6787 (1.17)      27.7940 (1.20)      0.2920 (1.45)     863;2302       34.6410 (0.85)      18578           1
test_storage[Int64-extra1-pickle_roundtrip_protocol_2]                   74.3680 (3.27)     1,004.3380 (7.63)      81.9240 (3.33)     26.0432 (6.50)      76.3675 (3.29)      1.5770 (7.81)     293;1395       12.2064 (0.30)       7014           1
test_storage[Int64-extra1-pickle_roundtrip_protocol_highest]             66.7410 (2.94)       487.3630 (3.70)      71.9518 (2.93)     11.6153 (2.90)      68.4270 (2.95)      1.6980 (8.41)     611;1705       13.8982 (0.34)       9118           1
test_storage[Mean-extra6-copy]                                           24.1420 (1.06)     1,186.6930 (9.02)      26.8937 (1.09)     12.4259 (3.10)      24.6070 (1.06)      1.0518 (5.21)    1070;5713       37.1834 (0.91)      24647           1
test_storage[Mean-extra6-deepcopy]                                       28.2180 (1.24)       459.9490 (3.50)      30.7127 (1.25)      7.6343 (1.91)      28.6810 (1.24)      0.4830 (2.39)    1290;3659       32.5598 (0.80)      19341           1
test_storage[Mean-extra6-pickle_roundtrip_protocol_2]                   130.7650 (5.75)       317.4850 (2.41)     139.7894 (5.69)     16.0046 (4.00)     133.6800 (5.76)      2.9378 (14.54)     412;725        7.1536 (0.18)       3567           1
test_storage[Mean-extra6-pickle_roundtrip_protocol_highest]              73.5560 (3.23)       250.1640 (1.90)      81.2012 (3.31)     11.2561 (2.81)      76.4535 (3.29)      9.8070 (48.55)     454;329       12.3151 (0.30)       6378           1
test_storage[Unlimited-extra2-copy]                                      22.7380 (1.0)        163.6450 (1.24)      24.6652 (1.00)      5.6616 (1.41)      23.2140 (1.0)       0.3820 (1.89)    1280;4652       40.5429 (1.00)      26057           1
test_storage[Unlimited-extra2-deepcopy]                                  26.8260 (1.18)       138.0650 (1.05)      28.4146 (1.16)      4.6855 (1.17)      27.3460 (1.18)      0.2350 (1.16)     918;2427       35.1932 (0.86)      20600           1
test_storage[Unlimited-extra2-pickle_roundtrip_protocol_2]               71.3060 (3.14)       203.7100 (1.55)      76.1452 (3.10)      9.8008 (2.45)      73.0110 (3.15)      1.4190 (7.02)     498;1192       13.1328 (0.32)       6767           1
test_storage[Unlimited-extra2-pickle_roundtrip_protocol_highest]         64.1530 (2.82)       218.6620 (1.66)      67.4801 (2.75)      7.7989 (1.95)      65.4585 (2.82)      0.7490 (3.71)     625;1305       14.8192 (0.36)       9920           1
test_storage[Unlimited-extra3-copy]                                      23.1560 (1.02)       147.3520 (1.12)      25.1464 (1.02)      5.9820 (1.49)      23.5960 (1.02)      0.2720 (1.35)    1405;4723       39.7672 (0.98)      25300           1
test_storage[Unlimited-extra3-deepcopy]                                  27.2840 (1.20)       200.4320 (1.52)      29.1268 (1.19)      5.5651 (1.39)      27.8420 (1.20)      0.3060 (1.51)    1028;2916       34.3327 (0.84)      20548           1
test_storage[Unlimited-extra3-pickle_roundtrip_protocol_2]               94.1210 (4.14)       298.1620 (2.27)     101.9726 (4.15)     15.2326 (3.80)      96.2630 (4.15)      3.1085 (15.39)    666;1103        9.8066 (0.24)       5620           1
test_storage[Unlimited-extra3-pickle_roundtrip_protocol_highest]         66.7410 (2.94)       220.5550 (1.68)      72.5396 (2.95)     11.5792 (2.89)      68.7920 (2.96)      1.9302 (9.56)     703;1855       13.7856 (0.34)       9509           1
test_storage[Weight-extra5-copy]                                         24.0410 (1.06)       203.4220 (1.55)      25.8032 (1.05)      4.9748 (1.24)      24.5330 (1.06)      0.3478 (1.72)    1350;3958       38.7549 (0.95)      24859           1
test_storage[Weight-extra5-deepcopy]                                     28.1640 (1.24)       151.9400 (1.15)      29.7233 (1.21)      4.0086 (1.00)      28.9740 (1.25)      0.4973 (2.46)     733;1888       33.6436 (0.83)      19961           1
test_storage[Weight-extra5-pickle_roundtrip_protocol_2]                 141.7560 (6.23)       355.7580 (2.70)     167.6429 (6.82)     33.2957 (8.31)     162.1510 (6.99)     31.0962 (153.94)      41;25        5.9651 (0.15)        399           1
test_storage[Weight-extra5-pickle_roundtrip_protocol_highest]            69.7490 (3.07)       262.8730 (2.00)      78.3945 (3.19)     15.6554 (3.91)      72.3460 (3.12)      8.8025 (43.58)     862;878       12.7560 (0.31)       9417           1
test_storage[WeightedMean-extra7-copy]                                   24.5020 (1.08)       207.7210 (1.58)      26.8281 (1.09)      7.3343 (1.83)      24.9690 (1.08)      0.4100 (2.03)    1311;4380       37.2743 (0.92)      22709           1
test_storage[WeightedMean-extra7-deepcopy]                               28.6690 (1.26)       171.9270 (1.31)      30.7721 (1.25)      6.7084 (1.67)      29.1610 (1.26)      0.2970 (1.47)    1090;2618       32.4970 (0.80)      19441           1
test_storage[WeightedMean-extra7-pickle_roundtrip_protocol_2]           321.6530 (14.15)      656.0140 (4.99)     346.1372 (14.09)    36.5918 (9.14)     330.1370 (14.22)    17.0840 (84.57)     242;411        2.8890 (0.07)       2414           1
test_storage[WeightedMean-extra7-pickle_roundtrip_protocol_highest]      76.9180 (3.38)     2,872.9320 (21.83)     87.3151 (3.55)     44.6904 (11.16)     79.0840 (3.41)      8.1995 (40.59)     289;948       11.4528 (0.28)       8621           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Classic (pre #237 result):

```
---------------------------------------------------------------------------------------------------------------- benchmark '1d-fills': 32 tests ---------------------------------------------------------------------------------------------------------------
Name (time in us)                                                               Min                    Max                   Mean              StdDev                 Median                 IQR            Outliers          OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_storage[AtomicInt64-extra0-copy]                                       24.8300 (1.10)        129.4890 (1.27)         26.6865 (1.08)       5.1722 (1.23)         25.2870 (1.10)       0.3300 (1.69)    1412;4502  37,472.1640 (0.92)      24714           1
test_storage[AtomicInt64-extra0-deepcopy]                                   28.7770 (1.27)        165.5650 (1.63)         30.7210 (1.25)       5.5847 (1.33)         29.2970 (1.27)       0.2750 (1.41)    1090;3420  32,551.0450 (0.80)      19715           1
test_storage[AtomicInt64-extra0-pickle_roundtrip_protocol_2]             4,095.0790 (181.27)    4,897.5910 (48.11)     4,319.3547 (175.60)   164.6072 (39.28)     4,301.1980 (186.98)   293.7630 (>1000.0)      97;0     231.5161 (0.01)        232           1
test_storage[AtomicInt64-extra0-pickle_roundtrip_protocol_highest]       4,097.4310 (181.37)    5,066.7800 (49.77)     4,355.0354 (177.05)   205.4093 (49.02)     4,311.5840 (187.44)   343.8625 (>1000.0)      79;1     229.6193 (0.01)        227           1
test_storage[Double-extra4-copy]                                            22.9170 (1.01)        296.9370 (2.92)         25.2773 (1.03)       6.4161 (1.53)         23.6430 (1.03)       1.3500 (6.92)    1605;2054  39,561.1282 (0.97)      26063           1
test_storage[Double-extra4-deepcopy]                                        26.8090 (1.19)        159.4470 (1.57)         28.8961 (1.17)       6.1045 (1.46)         27.5390 (1.20)       0.3470 (1.78)     886;2174  34,606.7286 (0.85)      18807           1
test_storage[Double-extra4-pickle_roundtrip_protocol_2]                     92.3150 (4.09)        340.1080 (3.34)        104.7923 (4.26)      21.5598 (5.14)         94.8330 (4.12)      14.1115 (72.37)     681;623   9,542.6832 (0.23)       6048           1
test_storage[Double-extra4-pickle_roundtrip_protocol_highest]               65.4830 (2.90)        965.2130 (9.48)         74.5441 (3.03)      22.6057 (5.39)         67.2940 (2.93)       8.1503 (41.80)    696;1144  13,414.8749 (0.33)       9909           1
test_storage[Int64-extra1-copy]                                             22.9300 (1.02)     13,658.6310 (134.18)       27.5721 (1.12)      85.4250 (20.38)        23.6230 (1.03)       2.7200 (13.95)     88;2683  36,268.5581 (0.89)      26236           1
test_storage[Int64-extra1-deepcopy]                                         27.0150 (1.20)      1,186.5990 (11.66)        31.3695 (1.28)      16.1561 (3.86)         27.7450 (1.21)       3.3410 (17.13)    915;1808  31,878.0904 (0.78)      17951           1
test_storage[Int64-extra1-pickle_roundtrip_protocol_2]                      73.5330 (3.25)        214.2070 (2.10)         79.3331 (3.23)      12.9979 (3.10)         75.0720 (3.26)       1.3997 (7.18)     449;1232  12,605.0803 (0.31)       6359           1
test_storage[Int64-extra1-pickle_roundtrip_protocol_highest]                65.5170 (2.90)        310.0080 (3.05)         74.4338 (3.03)      15.5492 (3.71)         67.9595 (2.95)       9.7050 (49.77)     808;769  13,434.7543 (0.33)       9734           1
test_storage[Mean-extra6-copy]                                              23.8310 (1.05)        188.0700 (1.85)         26.2193 (1.07)       7.9340 (1.89)         24.2580 (1.05)       0.2430 (1.25)    1509;3549  38,139.8518 (0.94)      25707           1
test_storage[Mean-extra6-deepcopy]                                          28.0710 (1.24)        139.0530 (1.37)         29.9146 (1.22)       5.6299 (1.34)         28.7080 (1.25)       0.3100 (1.59)     414;1330  33,428.5048 (0.82)       9859           1
test_storage[Mean-extra6-pickle_roundtrip_protocol_2]                   18,246.2650 (807.68)   19,362.9490 (190.21)   18,820.0443 (765.12)   271.6853 (64.83)    18,814.2520 (817.90)   321.3495 (>1000.0)      19;0      53.1348 (0.00)         53           1
test_storage[Mean-extra6-pickle_roundtrip_protocol_highest]             18,387.6870 (813.94)   21,493.8480 (211.14)   18,924.0360 (769.34)   463.1576 (110.52)   18,946.6030 (823.66)   378.9138 (>1000.0)       8;2      52.8429 (0.00)         53           1
test_storage[Unlimited-extra2-copy]                                         22.5910 (1.0)         145.9050 (1.43)         24.5976 (1.0)        5.8981 (1.41)         23.0030 (1.0)        0.4550 (2.33)    1646;5096  40,654.2942 (1.0)       26624           1
test_storage[Unlimited-extra2-deepcopy]                                     26.4830 (1.17)        274.4700 (2.70)         29.4100 (1.20)       8.2474 (1.97)         27.0720 (1.18)       1.1120 (5.70)    1348;4946  34,002.0181 (0.84)      21303           1
test_storage[Unlimited-extra2-pickle_roundtrip_protocol_2]                  70.1530 (3.11)      1,016.5160 (9.99)         82.6569 (3.36)      25.7664 (6.15)         73.6190 (3.20)      11.8517 (60.78)     536;660  12,098.2060 (0.30)       6843           1
test_storage[Unlimited-extra2-pickle_roundtrip_protocol_highest]            62.9980 (2.79)        361.8140 (3.55)         68.9116 (2.80)      14.1989 (3.39)         64.4770 (2.80)       1.8495 (9.48)     564;1617  14,511.3508 (0.36)       8107           1
test_storage[Unlimited-extra3-copy]                                         22.9630 (1.02)        194.8810 (1.91)         24.9365 (1.01)       5.5452 (1.32)         23.5160 (1.02)       0.3140 (1.61)    1564;4232  40,101.8080 (0.99)      25674           1
test_storage[Unlimited-extra3-deepcopy]                                     26.9160 (1.19)        136.0090 (1.34)         28.7417 (1.17)       5.0441 (1.20)         27.5480 (1.20)       0.2840 (1.46)    1093;3248  34,792.6687 (0.86)      20462           1
test_storage[Unlimited-extra3-pickle_roundtrip_protocol_2]                  92.8520 (4.11)        317.9600 (3.12)        105.2593 (4.28)      19.7149 (4.70)         95.9660 (4.17)      14.6005 (74.87)     675;433   9,500.3520 (0.23)       5308           1
test_storage[Unlimited-extra3-pickle_roundtrip_protocol_highest]            65.9960 (2.92)      2,210.9460 (21.72)        79.1096 (3.22)      40.2546 (9.61)         69.4410 (3.02)      10.2895 (52.77)     343;776  12,640.6974 (0.31)       7131           1
test_storage[Weight-extra5-copy]                                            23.7790 (1.05)        101.7970 (1.0)          25.3304 (1.03)       5.2212 (1.25)         24.1440 (1.05)       0.1950 (1.0)     1197;3221  39,478.2778 (0.97)      25499           1
test_storage[Weight-extra5-deepcopy]                                        27.8680 (1.23)        164.6770 (1.62)         29.8567 (1.21)       6.0801 (1.45)         28.4390 (1.24)       0.3790 (1.94)     979;2428  33,493.3017 (0.82)      18779           1
test_storage[Weight-extra5-pickle_roundtrip_protocol_2]                  9,788.1180 (433.28)   11,286.0730 (110.87)   10,180.5661 (413.88)   227.2512 (54.23)    10,160.1250 (441.69)   221.9615 (>1000.0)      17;3      98.2264 (0.00)         81           1
test_storage[Weight-extra5-pickle_roundtrip_protocol_highest]            9,809.9680 (434.24)   11,518.1980 (113.15)   10,337.1681 (420.25)   322.1126 (76.86)    10,316.1885 (448.47)   337.0070 (>1000.0)      25;7      96.7383 (0.00)         98           1
test_storage[WeightedMean-extra7-copy]                                      24.3250 (1.08)        121.7920 (1.20)         25.6397 (1.04)       4.1907 (1.0)          24.7310 (1.08)       0.2070 (1.06)    1086;3042  39,001.9835 (0.96)      25381           1
test_storage[WeightedMean-extra7-deepcopy]                                  28.4040 (1.26)        102.7510 (1.01)         29.9631 (1.22)       4.3883 (1.05)         28.9140 (1.26)       0.3570 (1.83)     882;2402  33,374.4236 (0.82)      20281           1
test_storage[WeightedMean-extra7-pickle_roundtrip_protocol_2]           30,007.6890 (>1000.0)  32,596.4770 (320.21)   30,777.2085 (>1000.0)  655.2783 (156.37)   30,561.5350 (>1000.0)  773.9440 (>1000.0)       8;2      32.4916 (0.00)         33           1
test_storage[WeightedMean-extra7-pickle_roundtrip_protocol_highest]     30,053.5460 (>1000.0)  31,733.0440 (311.73)   30,491.8352 (>1000.0)  316.5412 (75.53)    30,479.2700 (>1000.0)  372.0755 (>1000.0)       5;1      32.7957 (0.00)         32           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```