### PR TITLE
Adds `__str__` which generates a text rendering

### DIFF
--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -201,7 +201,14 @@ class BaseHistogram(object):
         A rendering of the histogram is made using ASCII or unicode characters (whatever is supported by the terminal). What exactly is displayed is still experimental. Do not rely on any particular rendering.
         """
         # TODO check the terminal width and adjust the presentation
-        return str(self._hist).strip()
+        # only use for 1D, fall back to repr for ND
+        if self._hist.rank() == 1:
+            s = str(self._hist)
+            # get rid of first line and last character
+            s = s[s.index("\n") + 1 : -1]
+        else:
+            s = repr(self)
+        return s
 
     def _axis(self, i):
         """

--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -221,6 +221,9 @@ class histogram(BaseHistogram):
     def __repr__(self):
         return repr(self._hist)
 
+    def __str__(self):
+        return str(self._hist)
+
     # Call uses fill since it supports strings,
     # runtime argument list, etc.
     @inject_signature("self, *args, weight=None, sample=None")
@@ -290,6 +293,21 @@ class Histogram(BaseHistogram):
             if inner != outer:
                 ret += " ({0} with flow)".format(outer)
         return ret
+
+    def __str__(self):
+        """
+        This calls show().
+        """
+        return self.show()
+
+    def show(self):
+        """
+        Prints the histogram on the current terminal.
+        
+        A rendering of the histogram is made using ASCII or unicode characters (whatever is supported by the terminal). What exactly is displayed is still experimental. Do not rely on any particular rendering.
+        """
+        # TODO check the terminal width and just the presentation
+        return str(self._hist)
 
     def _compute_commonindex(self, index, expand_ellipsis):
         # Shorten the computations with direct access to raw object

--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -296,17 +296,9 @@ class Histogram(BaseHistogram):
 
     def __str__(self):
         """
-        This calls show().
-        """
-        return self.show()
-
-    def show(self):
-        """
-        Prints the histogram on the current terminal.
-        
         A rendering of the histogram is made using ASCII or unicode characters (whatever is supported by the terminal). What exactly is displayed is still experimental. Do not rely on any particular rendering.
         """
-        # TODO check the terminal width and just the presentation
+        # TODO check the terminal width and adjust the presentation
         return str(self._hist)
 
     def _compute_commonindex(self, index, expand_ellipsis):

--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -183,6 +183,26 @@ class BaseHistogram(object):
         self._hist.fill(*args, **kwargs)
         return self
 
+    def __repr__(self):
+        ret = "{self.__class__.__name__}(\n  ".format(self=self)
+        ret += ",\n  ".join(repr(self._axis(i)) for i in range(self._hist.rank()))
+        ret += ",\n  storage={0}".format(self._storage_type())
+        ret += ")"
+        outer = self._hist.sum(flow=True)
+        if outer:
+            inner = self._hist.sum(flow=False)
+            ret += " # Sum: {0}".format(inner)
+            if inner != outer:
+                ret += " ({0} with flow)".format(outer)
+        return ret
+
+    def __str__(self):
+        """
+        A rendering of the histogram is made using ASCII or unicode characters (whatever is supported by the terminal). What exactly is displayed is still experimental. Do not rely on any particular rendering.
+        """
+        # TODO check the terminal width and adjust the presentation
+        return str(self._hist).strip()
+
     def _axis(self, i):
         """
         Get N-th axis.
@@ -217,12 +237,6 @@ class histogram(BaseHistogram):
         Select a contents given indices. -1 is the underflow bin, N is the overflow bin.
         """
         return self._hist.at(*indexes)
-
-    def __repr__(self):
-        return repr(self._hist)
-
-    def __str__(self):
-        return str(self._hist)
 
     # Call uses fill since it supports strings,
     # runtime argument list, etc.
@@ -293,13 +307,6 @@ class Histogram(BaseHistogram):
             if inner != outer:
                 ret += " ({0} with flow)".format(outer)
         return ret
-
-    def __str__(self):
-        """
-        A rendering of the histogram is made using ASCII or unicode characters (whatever is supported by the terminal). What exactly is displayed is still experimental. Do not rely on any particular rendering.
-        """
-        # TODO check the terminal width and adjust the presentation
-        return str(self._hist)
 
     def _compute_commonindex(self, index, expand_ellipsis):
         # Shorten the computations with direct access to raw object

--- a/tests/test_cpp_interface.py
+++ b/tests/test_cpp_interface.py
@@ -30,14 +30,12 @@ def test_convert_bh():
     assert hasattr(h, "axes")
 
 
-def test_reprs():
+def test_str():
     # Mixing bh/bhc is fine; histogram correctly always returns matching axis,
     # axis returns matching transform, etc.
     h = bhc.histogram(bh.axis.Regular(4, 0, 4))
-    assert (
-        repr(h)
-        == """\
-histogram(regular(4, 0, 4, metadata="None", options=underflow | overflow))
+    assert repr(str(h)) == repr(
+        """histogram(regular(4, 0, 4, metadata="None", options=underflow | overflow))
               +--------------------------------------------------------------+
 [-inf,   0) 0 |                                                              |
 [   0,   1) 0 |                                                              |
@@ -45,13 +43,17 @@ histogram(regular(4, 0, 4, metadata="None", options=underflow | overflow))
 [   2,   3) 0 |                                                              |
 [   3,   4) 0 |                                                              |
 [   4, inf) 0 |                                                              |
-              +--------------------------------------------------------------+
-"""
+              +--------------------------------------------------------------+"""
     )
 
+
+def test_repr():
+    h = bhc.histogram(bh.axis.Regular(4, 0, 4))
     assert (
-        repr(h.axis(0))
-        == 'regular(4, 0, 4, metadata="None", options=underflow | overflow)'
+        repr(h)
+        == """histogram(
+  regular(4, 0, 4, metadata="None", options=underflow | overflow),
+  storage=double())"""
     )
 
 

--- a/tests/test_cpp_interface.py
+++ b/tests/test_cpp_interface.py
@@ -35,8 +35,7 @@ def test_str():
     # axis returns matching transform, etc.
     h = bhc.histogram(bh.axis.Regular(4, 0, 4))
     assert repr(str(h)) == repr(
-        """histogram(regular(4, 0, 4, metadata="None", options=underflow | overflow))
-              +--------------------------------------------------------------+
+        """              +--------------------------------------------------------------+
 [-inf,   0) 0 |                                                              |
 [   0,   1) 0 |                                                              |
 [   1,   2) 0 |                                                              |

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -333,10 +333,8 @@ def test_repr():
 def test_str():
     h1 = bh.Histogram(bh.axis.Regular(3, 0, 1))
     h1.view(True)[...] = [0, 1, 3, 2, 1]
-    print(h1)
     assert repr(str(h1)) == repr(
-        """histogram(regular(3, 0, 1, metadata="None", options=underflow | overflow))
-                   +---------------------------------------------------------+
+        """                   +---------------------------------------------------------+
 [  -inf,      0) 0 |                                                         |
 [     0, 0.3333) 1 |===================                                      |
 [0.3333, 0.6667) 3 |======================================================== |
@@ -346,16 +344,7 @@ def test_str():
     )
 
     h2 = bh.Histogram(bh.axis.Regular(3, 0, 1), bh.axis.Integer(0, 1))
-    print(h2)
-    assert repr(str(h2)) == repr(
-        """histogram(
-  regular(3, 0, 1, metadata="None", options=underflow | overflow)
-  integer(0, 1, metadata="None", options=underflow | overflow)
-  (-1 -1): 0 ( 0 -1): 0 ( 1 -1): 0 ( 2 -1): 0 ( 3 -1): 0
-  (-1  0): 0 ( 0  0): 0 ( 1  0): 0 ( 2  0): 0 ( 3  0): 0
-  (-1  1): 0 ( 0  1): 0 ( 1  1): 0 ( 2  1): 0 ( 3  1): 0
-)"""
-    )
+    assert repr(str(h2)) == repr(repr(h2))
 
 
 def test_axis():

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -330,6 +330,34 @@ def test_repr():
     assert repr(h) == hrepr
 
 
+def test_str():
+    h1 = bh.Histogram(bh.axis.Regular(3, 0, 1))
+    h1.view(True)[...] = [0, 1, 3, 2, 1]
+    print(h1)
+    assert repr(str(h1)) == repr(
+        """histogram(regular(3, 0, 1, metadata="None", options=underflow | overflow))
+                   +---------------------------------------------------------+
+[  -inf,      0) 0 |                                                         |
+[     0, 0.3333) 1 |===================                                      |
+[0.3333, 0.6667) 3 |======================================================== |
+[0.6667,      1) 2 |=====================================                    |
+[     1,    inf) 1 |===================                                      |
+                   +---------------------------------------------------------+"""
+    )
+
+    h2 = bh.Histogram(bh.axis.Regular(3, 0, 1), bh.axis.Integer(0, 1))
+    print(h2)
+    assert repr(str(h2)) == repr(
+        """histogram(
+  regular(3, 0, 1, metadata="None", options=underflow | overflow)
+  integer(0, 1, metadata="None", options=underflow | overflow)
+  (-1 -1): 0 ( 0 -1): 0 ( 1 -1): 0 ( 2 -1): 0 ( 3 -1): 0
+  (-1  0): 0 ( 0  0): 0 ( 1  0): 0 ( 2  0): 0 ( 3  0): 0
+  (-1  1): 0 ( 0  1): 0 ( 1  1): 0 ( 2  1): 0 ( 3  1): 0
+)"""
+    )
+
+
 def test_axis():
     axes = (bh.axis.Regular(10, 0, 1), bh.axis.Integer(0, 1))
     h = bh.Histogram(*axes)


### PR DESCRIPTION
The original idea was to add `.show()` to generate the text rendering, with possibly some options on how to render. Then `.__str__(self)` would call `.show()`. However, this does not work well in the REPL, unless `.show()` returns a special string class that has a modified `__repr__(self)`:
```
In [8]: h.show()
Out[8]: 'histogram(regular(10, 0, 1, metadata="None", options=underflow | overflow))\n              +--------------------------------------------------------------+\n[-inf,   0) 0 |                                                              |\n[   0, 0.1) 0 |                                                              |\n[ 0.1, 0.2) 0 |                                                              |\n[ 0.2, 0.3) 0 |                                                              |\n[ 0.3, 0.4) 0 |                                                              |\n[ 0.4, 0.5) 0 |                                                              |\n[ 0.5, 0.6) 0 |                                                              |\n[ 0.6, 0.7) 0 |                                                              |\n[ 0.7, 0.8) 0 |                                                              |\n[ 0.8, 0.9) 0 |                                                              |\n[ 0.9,   1) 0 |                                                              |\n[   1, inf) 4 |============================================================= |\n              +--------------------------------------------------------------+\n'
```

All that can be done, but I think this is overengineering. It is ok if the lowest layer just does something simple. I don't think we should even make it configurable. Upper layers will most likely override the display anyway with something custom.