### PR TITLE
Fix repr for 1 and 0d

### DIFF
--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -279,9 +279,21 @@ class Histogram(BaseHistogram):
         self.axes = AxesTuple(self._axis(i) for i in range(self.rank))
 
     def __repr__(self):
-        ret = "{self.__class__.__name__}(\n  ".format(self=self)
-        ret += ",\n  ".join(repr(ax) for ax in self.axes)
-        ret += ",\n  storage={0}".format(self._storage_type())
+        newline = "\n  "
+        sep = "," if len(self.axes) > 0 else ""
+        ret = "{self.__class__.__name__}({newline}".format(
+            self=self, newline=newline if len(self.axes) > 1 else ""
+        )
+        ret += ",{newline}".format(newline=newline).join(repr(ax) for ax in self.axes)
+        ret += "{comma}{newline}storage={storage}".format(
+            storage=self._storage_type(),
+            newline=newline
+            if len(self.axes) > 1
+            else " "
+            if len(self.axes) > 0
+            else "",
+            comma="," if len(self.axes) > 0 else "",
+        )
         ret += ")"
         outer = self.sum(flow=True)
         if outer:

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -330,6 +330,18 @@ def test_repr():
     assert repr(h) == hrepr
 
 
+def test_1d_repr():
+    hrepr = """Histogram(Regular(4, 1, 2), storage=Double())"""
+    h = bh.Histogram(bh.axis.Regular(4, 1, 2))
+    assert repr(h) == hrepr
+
+
+def test_empty_repr():
+    hrepr = """Histogram(storage=Double())"""
+    h = bh.Histogram()
+    assert repr(h) == hrepr
+
+
 def test_axis():
     axes = (bh.axis.Regular(10, 0, 1), bh.axis.Integer(0, 1))
     h = bh.Histogram(*axes)


### PR DESCRIPTION
This fixes half of #263, the Histogram part. Follows the original Boost.Histogram design with single line repr for 1D, and prints properly for 0D (and added tests). May need to need to be merged with changes in #262.