### PR TITLE
Fixing bug in view property access

### DIFF
--- a/boost_histogram/_internal/view.py
+++ b/boost_histogram/_internal/view.py
@@ -36,6 +36,16 @@ class View(np.ndarray):
         )
 
 
+def make_getitem_property(name):
+    def fget(self):
+        return self[name]
+
+    def fset(self, value):
+        self[name] = value
+
+    return property(fget, fset)
+
+
 def fields(*names):
     """
     This decorator adds the name to the _FIELDS
@@ -60,15 +70,9 @@ def fields(*names):
         fields = []
         for name in names:
             fields.append(name)
-
-            def fget(self):
-                return self[name]
-
-            def fset(self, value):
-                self[name] = value
-
-            setattr(cls, name, property(fget, fset))
+            setattr(cls, name, make_getitem_property(name))
             cls._FIELDS = tuple(fields)
+
         return cls
 
     return injector

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -58,6 +58,9 @@ def test_setting_weight():
     assert b["value"][0] == a["value"][0]
     assert b["variance"][0] == a["variance"][0]
 
+    assert_array_equal(a.view().value, b.view()["value"])
+    assert_array_equal(a.view().variance, b.view()["variance"])
+
 
 def test_setting_profile():
     h = bh.Histogram(bh.axis.Regular(10, 0, 10), storage=bh.storage.Mean())
@@ -98,6 +101,12 @@ def test_setting_profile():
     assert b[0]["value"] == a["value"][0]
     assert b[0]["count"] == a["count"][0]
     assert b[0]["sum_of_deltas_squared"] == a["sum_of_deltas_squared"][0]
+
+    assert_array_equal(a.view().value, b.view()["value"])
+    assert_array_equal(a.view().count, b.view()["count"])
+    assert_array_equal(
+        a.view().sum_of_deltas_squared, b.view()["sum_of_deltas_squared"]
+    )
 
 
 def test_setting_weighted_profile():
@@ -159,4 +168,14 @@ def test_setting_weighted_profile():
     assert b[0]["sum_of_weights_squared"] == a["sum_of_weights_squared"][0]
     assert (
         b[0]["sum_of_weighted_deltas_squared"] == a["sum_of_weighted_deltas_squared"][0]
+    )
+
+    assert_array_equal(a.view().value, b.view()["value"])
+    assert_array_equal(a.view().sum_of_weights, b.view()["sum_of_weights"])
+    assert_array_equal(
+        a.view().sum_of_weights_squared, b.view()["sum_of_weights_squared"]
+    )
+    assert_array_equal(
+        a.view().sum_of_weighted_deltas_squared,
+        b.view()["sum_of_weighted_deltas_squared"],
     )


### PR DESCRIPTION
Very irritating bug due to late binding (which I thought I'd fixed/checked, but apparently not). All non-computed properties on views for accumulators return the same set of values. So `h.view().value` is not the value, but the final property, etc.