### PR TITLE
Allow single value (fix several setting bugs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
+### Version 0.6.1
+
+#### User changes
+
+* Slices and single values can be mixed in indexing [#279][]
+
+#### Bug fixes
+
+* Properties on accumulator views now resolve correctly [#273][]
+* Division of a histogram by a number is supported again [#278][]
+* Setting a histogram with length one slice fixed [#279][]
+
+[#273]: https://github.com/scikit-hep/boost-histogram/pull/273
+[#278]: https://github.com/scikit-hep/boost-histogram/pull/278
+[#279]: https://github.com/scikit-hep/boost-histogram/pull/279
+
+
+
 ## Version 0.6
+
 
 This version fills out most of the remaining features missing from the 0.5.x
 series.  You can now use all the storages without the original caveats; even

--- a/docs/usage/indexing.rst
+++ b/docs/usage/indexing.rst
@@ -36,6 +36,7 @@ Slicing:
    h2 = h[::sum]         # Projection operations # (name may change)
    h2 = h[a:b:sum]       # Adding endpoints to projection operations
    h2 = h[0:len:sum]     #   removes under or overflow from the calculation
+   h2 = h[v, a:b]        #   A single value v is like v:v+1:sum
    h2 = h[a:b, ...]      # Ellipsis work just like normal numpy
 
 Setting
@@ -58,7 +59,7 @@ allowed. These all return histograms, so flow bins are always preserved
 - the one exception is projection; since this removes an axis, the only
 use for the slice edges is to be explicit on what part you are
 interested for the projection. So an explicit (non-empty) slice here
-will case the relevant flow bin to be excluded (not currently supported).
+will case the relevant flow bin to be excluded.
 
 ``loc``, ``project``, and ``rebin`` all live inside the histogramming
 package (like boost-histogram), but are completely general and can be created by a
@@ -77,7 +78,8 @@ are slices, and follow the rules listed above. This looks like:
     h[{7: slice(0, 2, bh.rebin(4))}]       # slice and rebin axis 7
 
 
-If you don't like manually building slices, you can use the `Slicer()` utility to recover the original slicing syntax inside the dict:
+If you don't like manually building slices, you can use the `Slicer()` utility
+to recover the original slicing syntax inside the dict:
 
 .. code:: python
 
@@ -94,7 +96,6 @@ Invalid syntax:
 
 .. code:: python
 
-   h[v, a:b] # You cannot mix slices and bin contents access (h is an integer)
    h[1.0] # Floats are not allowed, just like numpy
    h[::2] # Skipping is not (currently) supported
    h[..., None] # None == np.newaxis is not supported
@@ -127,8 +128,10 @@ here <https://gist.github.com/henryiii/d545a673ea2b3225cb985c9c02ac958b>`__.
 `Extra doc
 here <https://docs.google.com/document/d/1bJKA7Y0QXf46w53UFizJ4bnZlVIkb4aCqx6m2hoN0HM/edit#heading=h.jvegm6z8f387>`__.
 
-Note that the API comes in two forms; the ``__call__``/``__new__`` operator form is more powerful, slower, optional, and is currently not supported by boost-histogram.
-A fully conforming UHI implementation must allow the tag form without the operators.
+Note that the API comes in two forms; the ``__call__``/``__new__`` operator
+form is more powerful, slower, optional, and is currently not supported by
+boost-histogram.  A fully conforming UHI implementation must allow the tag form
+without the operators.
 
 Basic implementation (WIP):
 
@@ -163,7 +166,11 @@ Basic implementation (WIP):
 
 
    class rebin:
-       "When used in the step of a Histogram's slice, rebin(n) combines bins, scaling their widths by a factor of n. If the number of bins is not divisible by n, the remainder is added to the overflow bin."
+       """
+       When used in the step of a Histogram's slice, rebin(n) combines bins,
+       scaling their widths by a factor of n. If the number of bins is not
+       divisible by n, the remainder is added to the overflow bin.
+       """
        projection = False
        def __init__(self, factor):
            self.factor = factor

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -1,5 +1,6 @@
 import boost_histogram as bh
 import numpy as np
+from numpy.testing import assert_array_equal
 
 import pytest
 
@@ -137,6 +138,48 @@ def test_slicing_projection():
 
     h3 = h2[:, 5 : 7 : bh.sum]
     assert h3[1] == 6
+
+    # Select one bin
+    assert h1[2, :: bh.sum, :: bh.sum] == 12 * 12
+
+    # Select one bin
+    assert h1[2, 7, :: bh.sum] == 12
+
+
+def test_mix_value_with_slice():
+    h = bh.Histogram(
+        bh.axis.Regular(10, 0, 10), bh.axis.Regular(10, 0, 10), bh.axis.Integer(0, 2)
+    )
+
+    vals = np.arange(100).reshape(10, 10, 1)
+    h[:, :, 1:2] = vals
+
+    print(h.view()[:3, :3, :])
+
+    assert h[0, 1, True] == 1
+    assert h[1, 0, True] == 10
+    assert h[1, 1, True] == 11
+    assert h[3, 4, False] == 0
+
+    assert_array_equal(h[:, :, True].view(), vals[:, :, 0])
+    assert_array_equal(h[:, :, False].view(), 0)
+
+
+def test_mix_value_with_slice_2():
+    h = bh.Histogram(
+        bh.axis.Regular(10, 0, 10), bh.axis.Regular(10, 0, 10), bh.axis.Integer(0, 2)
+    )
+
+    vals = np.arange(100).reshape(10, 10)
+    h[:, :, True] = vals
+
+    assert h[0, 1, True] == 1
+    assert h[1, 0, True] == 10
+    assert h[1, 1, True] == 11
+    assert h[3, 4, False] == 0
+
+    assert_array_equal(h[:, :, True].view(), vals)
+    assert_array_equal(h[:, :, False].view(), 0)
 
 
 def test_repr():


### PR DESCRIPTION
This allows single values in indexing expressions, allowing:

```python
hist[a:b, c]
```

as a replacement for

```python
hist[a:b, c:c+1:bh.sum]
```

(Basically it works just like Numpy). It also fixes a bug related to setting with a length 1 slice. Also, the following now works as it should:

```python
h[:, 3] = a_1d_array
```

(Was buggy before)