### PR TITLE
Add single-element UHI to axis

### DIFF
--- a/boost_histogram/_internal/axis.py
+++ b/boost_histogram/_internal/axis.py
@@ -140,10 +140,16 @@ class MainAxisMixin(object):
         """
         Access a bin, using normal Python syntax for wraparound.
         """
-        if i < 0:
-            i += self._ax.size
-        if i >= self._ax.size:
-            raise IndexError("Out of range access")
+        # UHI support
+        if callable(i):
+            i = i(self)
+        else:
+            if i < 0:
+                i += self._ax.size
+            if i >= self._ax.size:
+                raise IndexError(
+                    "Out of range access, {0} is more than {1}".format(i, self._ax.size)
+                )
         return self.bin(i)
 
     @property

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -225,6 +225,9 @@ class TestRegular(Axis):
         assert a.bin(-1)[0] == -np.inf
         assert a.bin(2)[1] == np.inf
 
+        assert_allclose(a[bh.underflow], a.bin(-1))
+        assert_allclose(a[bh.overflow], a.bin(2))
+
         with pytest.raises(IndexError):
             a.bin(-2)
         with pytest.raises(IndexError):
@@ -377,6 +380,11 @@ class TestCircular(Axis):
         with pytest.raises(IndexError):
             a[2]
 
+        with pytest.raises(IndexError):
+            a[bh.underflow]
+
+        assert_allclose(a[bh.overflow], a.bin(2))
+
         assert a.bin(2)[0] == approx(1 + 2 * np.pi)
         assert a.bin(2)[1] == approx(1 + 3 * np.pi)
 
@@ -482,6 +490,9 @@ class TestVariable(Axis):
         assert a[-1] == a[1]
         with pytest.raises(IndexError):
             a[2]
+
+        assert_allclose(a[bh.underflow], a.bin(-1))
+        assert_allclose(a[bh.overflow], a.bin(2))
 
         assert a.bin(-1)[0] == -np.inf
         assert a.bin(-1)[1] == ref[0]
@@ -607,6 +618,9 @@ class TestInteger:
             assert a[i] == r
         assert a.bin(-1) == -2
         assert a.bin(4) == 3
+
+        assert_allclose(a[bh.underflow], a.bin(-1))
+        assert_allclose(a[bh.overflow], a.bin(4))
 
     def test_iter(self):
         a = bh.axis.Integer(-1, 3)


### PR DESCRIPTION
Single item UHI should work on axes indexing.

(Working on examples and docs)

(Slices as a way to slice axes would be very useful too, but should be a 0.7 feature)