### PR TITLE
Fixing numpy failure for numpy int with bins

### DIFF
--- a/boost_histogram/numpy.py
+++ b/boost_histogram/numpy.py
@@ -62,7 +62,7 @@ def histogramdd(
 
     axs = []
     for n, (b, r) in enumerate(zip(bins, range)):
-        if isinstance(b, int):
+        if np.issubdtype(type(b), np.integer):
             if r is None:
                 # Nextafter may affect bin edges slightly
                 r = (np.min(a[n]), np.max(a[n]))

--- a/tests/test_numpy_interface.py
+++ b/tests/test_numpy_interface.py
@@ -30,6 +30,9 @@ opts = (
     {"bins": 10},
     {"bins": "auto" if np113 else 20},
     {"range": (0, 5), "bins": 30},
+    {"range": np.array((0, 5), dtype=np.float), "bins": np.int32(30)},
+    {"range": np.array((0, 3), dtype=np.double), "bins": np.uint32(10)},
+    {"range": np.array((0, 10), dtype=np.int), "bins": np.int8(30)},
     {"bins": [0, 1, 1.2, 1.3, 4, 21]},
 )
 


### PR DESCRIPTION
The Numpy adaptor will fail if a Numpy int instead of a python int is used for bins. This fixes that check.