### PR TITLE
Fix missing inplace add, nicer inplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,22 @@
 #### User changes
 
 * Slices and single values can be mixed in indexing [#279][]
+* UHI locators supported on axes [#280][]
 
 #### Bug fixes
 
 * Properties on accumulator views now resolve correctly [#273][]
 * Division of a histogram by a number is supported again [#278][]
 * Setting a histogram with length one slice fixed [#279][]
+* Numpy functions now work with Numpy ints in `bins=` [#282][]
+* In-place addition avoids a copy [#284][]
 
 [#273]: https://github.com/scikit-hep/boost-histogram/pull/273
 [#278]: https://github.com/scikit-hep/boost-histogram/pull/278
 [#279]: https://github.com/scikit-hep/boost-histogram/pull/279
+[#280]: https://github.com/scikit-hep/boost-histogram/pull/280
+[#282]: https://github.com/scikit-hep/boost-histogram/pull/282
+[#284]: https://github.com/scikit-hep/boost-histogram/pull/284
 
 
 

--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -25,6 +25,10 @@ _histograms = (
 )
 
 
+def _hist_or_val(other):
+    return other._hist if hasattr(other, "_hist") else other
+
+
 def _arg_shortcut(item):
     msg = "Developer shortcut: will be removed in a future version"
     if isinstance(item, tuple) and len(item) == 3:
@@ -129,7 +133,11 @@ class BaseHistogram(object):
         return _to_view(self._hist.view(False))
 
     def __add__(self, other):
-        return self.__class__(self._hist + other._hist)
+        return self.__class__(self._hist.__add__(other._hist))
+
+    def __iadd__(self, other):
+        self._hist.__iadd__(other._hist)
+        return self
 
     def __eq__(self, other):
         return self._hist == other._hist
@@ -139,40 +147,28 @@ class BaseHistogram(object):
 
     # If these fail, the underlying object throws the correct error
     def __mul__(self, other):
-        if isinstance(other, BaseHistogram):
-            return self.__class__(self._hist * other._hist)
-        else:
-            return self.__class__(self._hist * other)
+        return self.__class__(self._hist.__mul__(other))
 
     def __rmul__(self, other):
         return self * other
 
     def __imul__(self, other):
-        return self.__class__(self._hist.__imul__(other))
+        self._hist.__imul__(_hist_or_val(other))
+        return self
 
     def __truediv__(self, other):
-        if isinstance(other, BaseHistogram):
-            return self.__class__(self._hist.__truediv__(other._hist))
-        else:
-            return self.__class__(self._hist.__truediv__(other))
+        return self.__class__(self._hist.__truediv__(_hist_or_val(other)))
 
     def __div__(self, other):
-        if isinstance(other, BaseHistogram):
-            return self.__class__(self._hist.__div__(other._hist))
-        else:
-            return self.__class__(self._hist.__div__(other))
+        return self.__class__(self._hist.__div__(_hist_or_val(other)))
 
     def __itruediv__(self, other):
-        if isinstance(other, BaseHistogram):
-            return self.__class__(self._hist.__itruediv__(other._hist))
-        else:
-            return self.__class__(self._hist.__itruediv__(other))
+        self._hist.__itruediv__(_hist_or_val(other))
+        return self
 
     def __idiv__(self, other):
-        if isinstance(other, BaseHistogram):
-            return self.__class__(self._hist.__idiv__(other._hist))
-        else:
-            return self.__class__(self._hist.__idiv__(other))
+        self._hist.__idiv__(_hist_or_val(other))
+        return self
 
     def __copy__(self):
         other = self.__class__.__new__(self.__class__)

--- a/include/register_histogram.hpp
+++ b/include/register_histogram.hpp
@@ -60,6 +60,9 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
              })
 
         .def(py::self + py::self)
+        // .def(py::self + value_type())
+        .def(py::self += py::self)
+        // .def(py::self += value_type())
 
         .def(py::self == py::self)
         .def(py::self != py::self)

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -404,11 +404,14 @@ def test_out_of_range():
 def test_operators():
     h = bh.Histogram(bh.axis.Integer(0, 2))
     h.fill(0)
+    h_orig = h
     h += h
+    assert h is h_orig
     assert h[0] == 2
     assert h[1] == 0
 
     h *= 2
+    assert h is h_orig
     assert h[0] == 4
     assert h[1] == 0
 
@@ -416,6 +419,7 @@ def test_operators():
     assert (h + h)[0] == (2 * h)[0]
 
     h /= 2
+    assert h is h_orig
     assert h[0] == 2
     assert h[1] == 0
 


### PR DESCRIPTION
Inplace add was simply falling back to out-of-place add; the binding for inplace add was missing.

Also improved the inplace operations to not change the python object ID either.