### PR TITLE
WIP: Use integer weights for integer storages

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -44,7 +44,7 @@ _histograms = (
 
 def _fill_cast(value, inner=False):
     """
-    Convert to NumPy arrays. Some buffer objects do not get converted by forcecast.
+    Convert to NumPy arrays; must be c-order dense arrays to work.
     If not called by itself (inner=False), then will work through one level of tuple/list.
     """
     if value is None or isinstance(value, string_types + (bytes,)):
@@ -340,9 +340,9 @@ class Histogram(object):
         ----------
         *args : Union[Array[float], Array[int], Array[str], float, int, str]
             Provide one value or array per dimension.
-        weight : List[Union[Array[float], Array[int], Array[str], float, int, str]]]
-            Provide weights (only if the histogram storage supports it)
-        sample : List[Union[Array[float], Array[int], Array[str], float, int, str]]]
+        weight : List[Union[Array[float], Array[int], float, int]]]
+            Provide weights (float only if the histogram storage supports it)
+        sample : List[Union[Array[float], Array[int], float, int]]]
             Provide samples (only if the histogram storage supports it)
         threads : Optional[int]
             Fill with threads. Defaults to None, which does not activate

--- a/src/boost_histogram/_internal/sig_tools.py
+++ b/src/boost_histogram/_internal/sig_tools.py
@@ -15,6 +15,7 @@ if sys.version_info < (3, 0):
         # type: (str, Optional[Dict[str, Any]]) -> Any
         def wrap(f):
             return f
+
         return wrap
 
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -73,6 +73,12 @@ def test_copy():
     assert id(b) != id(c)
 
 
+def test_fill_int_storage_with_floats():
+    h = bh.Histogram(bh.axis.Regular(10,-1,1), storage=bh.storage.Int64())
+    h.fill([.3,.4,.5], weight=[1, 3, 2])
+    h.fill([.3,.4,.5], weight=[.1, .3, .2])
+
+
 def test_fill_int_1d():
 
     h = bh.Histogram(bh.axis.Integer(-1, 2))

--- a/tests/test_numpy_interface.py
+++ b/tests/test_numpy_interface.py
@@ -31,9 +31,9 @@ opts = (
     {"bins": 10},
     {"bins": "auto" if np113 else 20},
     {"range": (0, 5), "bins": 30},
-    {"range": np.array((0, 5), dtype=np.float), "bins": np.int32(30)},
+    {"range": np.array((0, 5), dtype=float), "bins": np.int32(30)},
     {"range": np.array((0, 3), dtype=np.double), "bins": np.uint32(10)},
-    {"range": np.array((0, 10), dtype=np.int), "bins": np.int8(30)},
+    {"range": np.array((0, 10), dtype=int), "bins": np.int8(30)},
     {"bins": [0, 1, 1.2, 1.3, 4, 21]},
 )
 


### PR DESCRIPTION
Basic work toward #289. Going to be tricker than expected, since PyBind11 converts float arrays to int arrays without complaint if you use cast.