### PR TITLE
Fixing category indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ Documentation update. Now using development branch of Boost.Histogram again.
 
 #### Bug fixes
 
-* Allow slicing on flowless axes [#288][]
-* Sum repr fixed [#293][]
+* Fix sum over category axes in indexing [#298][]
+* Allow single category item selection [#298][]
+* Allow slicing on axes without flow bins [#288][]
+* Sum repr no longer throws error [#293][]
 
 #### Developer changes
 
@@ -14,6 +16,7 @@ Documentation update. Now using development branch of Boost.Histogram again.
 [#288]: https://github.com/scikit-hep/boost-histogram/pull/288
 [#292]: https://github.com/scikit-hep/boost-histogram/pull/292
 [#293]: https://github.com/scikit-hep/boost-histogram/pull/293
+[#298]: https://github.com/scikit-hep/boost-histogram/pull/298
 
 ### Version 0.6.1
 

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -218,3 +218,47 @@ def test_noflow_slicing():
 
     assert_array_equal(h[:, :, True].view(), vals)
     assert_array_equal(h[:, :, False].view(), 0)
+
+
+def test_pick_str_category():
+    noflow = dict(underflow=False, overflow=False)
+
+    h = bh.Histogram(
+        bh.axis.Regular(10, 0, 10),
+        bh.axis.Regular(10, 0, 10, **noflow),
+        bh.axis.StrCategory(["on", "off", "maybe"]),
+    )
+
+    vals = np.arange(100).reshape(10, 10)
+    h[:, :, bh.loc("on")] = vals
+
+    assert h[0, 1, bh.loc("on")] == 1
+    assert h[1, 0, bh.loc("on")] == 10
+    assert h[1, 1, bh.loc("on")] == 11
+    assert h[3, 4, bh.loc("maybe")] == 0
+
+    assert_array_equal(h[:, :, bh.loc("on")].view(), vals)
+    assert_array_equal(h[:, :, bh.loc("off")].view(), 0)
+
+
+def test_pick_int_category():
+    noflow = dict(underflow=False, overflow=False)
+
+    h = bh.Histogram(
+        bh.axis.Regular(10, 0, 10),
+        bh.axis.Regular(10, 0, 10, **noflow),
+        bh.axis.IntCategory([3, 5, 7]),
+    )
+
+    vals = np.arange(100).reshape(10, 10)
+    h[:, :, bh.loc(3)] = vals
+    h[:, :, bh.loc(5)] = vals + 1
+
+    assert h[0, 1, bh.loc(3)] == 1
+    assert h[1, 0, bh.loc(5)] == 10 + 1
+    assert h[1, 1, bh.loc(5)] == 11 + 1
+    assert h[3, 4, bh.loc(7)] == 0
+
+    assert_array_equal(h[:, :, bh.loc(3)].view(), vals)
+    assert_array_equal(h[:, :, bh.loc(5)].view(), vals + 1)
+    assert_array_equal(h[:, :, bh.loc(7)].view(), 0)


### PR DESCRIPTION
Fix issues with indexing and summing category axes. You can now sum over a category axes again (regression in 0.6.0), and you can select a single item from a category axes just like you can from other axes types.

Fixes #297, improves #296 (single item selection now works on a category axis).

This may be improved upstream in Boost.Histogram later, in which case this can be simplified eventually.