### PR TITLE
Use slices again for single item selection

### DIFF
--- a/boost_histogram/_internal/hist.py
+++ b/boost_histogram/_internal/hist.py
@@ -550,7 +550,7 @@ class Histogram(BaseHistogram):
                 if self.axes[i].options.underflow:
                     reduced._hist._reset_row(i, -1)
             for i in zeroes_stop:
-                if self.axes[i].options.underflow:
+                if self.axes[i].options.overflow:
                     reduced._hist._reset_row(i, reduced.axes[i].size)
 
             result = (

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -220,6 +220,23 @@ def test_noflow_slicing():
     assert_array_equal(h[:, :, False].view(), 0)
 
 
+def test_singleflow_slicing():
+    h = bh.Histogram(
+        bh.axis.Integer(0, 4, underflow=False), bh.axis.Integer(0, 4, overflow=False)
+    )
+
+    vals = np.arange(4 * 4).reshape(4, 4)
+    h[:, :] = vals
+
+    assert h[0, 0] == 0
+    assert h[0, 1] == 1
+    assert h[1, 0] == 4
+    assert h[1, 1] == 5
+
+    assert_array_equal(h[:, 1 : 3 : bh.sum], vals[:, 1:3].sum(axis=1))
+    assert_array_equal(h[1 : 3 : bh.sum, :], vals[1:3, :].sum(axis=0))
+
+
 def test_pick_str_category():
     noflow = dict(underflow=False, overflow=False)
 
@@ -247,17 +264,19 @@ def test_pick_int_category():
     h = bh.Histogram(
         bh.axis.Regular(10, 0, 10),
         bh.axis.Regular(10, 0, 10, **noflow),
-        bh.axis.IntCategory([3, 5, 7]),
+        bh.axis.IntCategory([3, 5, 7, 12, 13]),
     )
 
     vals = np.arange(100).reshape(10, 10)
     h[:, :, bh.loc(3)] = vals
     h[:, :, bh.loc(5)] = vals + 1
+    h[:, :, 3] = vals + 100
 
     assert h[0, 1, bh.loc(3)] == 1
     assert h[1, 0, bh.loc(5)] == 10 + 1
     assert h[1, 1, bh.loc(5)] == 11 + 1
     assert h[3, 4, bh.loc(7)] == 0
+    assert h[3, 4, bh.loc(12)] == 134
 
     assert_array_equal(h[:, :, bh.loc(3)].view(), vals)
     assert_array_equal(h[:, :, bh.loc(5)].view(), vals + 1)


### PR DESCRIPTION
Fix typo that causes the *upper* bound of the range to not be respected if the underflow bin is off.

This does not affect 0.6.1 because summation over anything with flow turned off was broken.