### PR TITLE
Allow metadata to be set on AxesTuple

### DIFF
--- a/boost_histogram/_internal/axistuple.py
+++ b/boost_histogram/_internal/axistuple.py
@@ -19,6 +19,11 @@ class AxesTuple(tuple):
     def metadata(self):
         return tuple(s.metadata for s in self)
 
+    @metadata.setter
+    def metadata(self, values):
+        for s, v in zip(self, values):
+            s.metadata = v
+
     @property
     def extent(self):
         return tuple(s.extent for s in self)

--- a/tests/test_axes_object.py
+++ b/tests/test_axes_object.py
@@ -20,6 +20,10 @@ def test_axes_all_at_once():
     assert h.axes.extent == (12, 7, 3)
     assert h.axes.metadata == (2, "hi", None)
 
+    h.axes.metadata = None, 3, "bye"
+
+    assert h.axes.metadata == (None, 3, "bye")
+
     centers = h.axes.centers
     answers = np.ogrid[0.5:10, 0.5:5, 0.5:2]
 


### PR DESCRIPTION
Just noticed that this was not available, but it should be.