### PR TITLE
Cleanup and preparation for 0.7.0

### DIFF
--- a/.ci/azure-build-pipeline.yml
+++ b/.ci/azure-build-pipeline.yml
@@ -27,6 +27,7 @@ variables:
   dev_requirements_file: dev-requirements.txt
   test_requirements_file: dev-requirements.txt
   NPY_NUM_BUILD_JOBS: 4
+  MACOSX_DEPLOYMENT_TARGET: 10.9
 
 
 jobs:

--- a/.ci/azure-test-pipeline.yml
+++ b/.ci/azure-test-pipeline.yml
@@ -9,6 +9,7 @@ variables:
   dev_requirements_file: dev-requirements.txt
   test_requirements_file: dev-requirements.txt
   NPY_NUM_BUILD_JOBS: 4
+  MACOSX_DEPLOYMENT_TARGET: 10.9
 
 jobs:
 

--- a/.ci/azure-wheel-helpers/README.md
+++ b/.ci/azure-wheel-helpers/README.md
@@ -1,8 +1,15 @@
 ## Azure Wheel Helpers
 
-This repository holds a collection of wheel helpers designed by the [Scikit-HEP][] project to build Python Wheels on [Azure DevOps][]. This is designed for packages that require building; if you have a pure-Python project, producing a universal wheel is trivial without this helper collection. This collection assumes some standard paths and procedures, though *some* of them can be customized.
+This repository holds a collection of wheel helpers designed by the
+[Scikit-HEP][] project to build Python Wheels on [Azure DevOps][]. This is
+designed for packages that require building; if you have a pure-Python project,
+producing a universal wheel is trivial without this helper collection. This
+collection assumes some standard paths and procedures, though *some* of them
+can be customized.
 
-Azure provides manual pipeline triggering and release pipelines, making it slighly better suited for this than GitHub Actions, though otherwise they are *very* similar.
+Azure provides manual pipeline triggering and release pipelines, making it
+slighly better suited for this than GitHub Actions, though otherwise they are
+*very* similar.
 
 ### Supported platforms and caveats
 
@@ -17,10 +24,22 @@ TLDR: Python 2.7, 3.6, 3.7, and 3.8  on all platforms, along with 3.5 on Linux.
 | Windows | 64 & 32-bit | 2.7, 3.6, 3.7, 3.8 |
 
 * Linux: Python 3.4 is not supported because Numpy does not support it either.
-* manylinux1: Optional support for GCC 9.1 using docker image; should work but can't be called directly other compiled extensions unless they do the same thing (think that's the main caveat). Supporting 32 bits because it's there for Numpy and PPA for now.
-* manylinux2010: Requires pip 10+ and a version of Linux newer than 2010. This is very new technology. 64-bit only. Eventually this will become the preferred (and then only) way to produce Linux wheels. Optional modern GCC image available.
-* MacOS: Uses the dedicated 64 bit 10.9+ Python.org builds. We are not supporting 3.5 because those no longer provide binaries (could use 32+64 fat 10.6+ but really force to 10.9+, but will not be added unless there is a need for it).
-* Windows: PyBind11 requires compilation with a newer copy of Visual Studio than Python 2.7's Visual Studio 2008; you need to have the [Visual Studio 2015 distributable][msvc2015] installed (the dll is included in 2017 and 2019, as well).
+* manylinux1: Optional support for GCC 9.1 using docker image; should work but
+  can't be called directly other compiled extensions unless they do the same
+  thing (think that's the main caveat). Supporting 32 bits because it's there
+  for Numpy and PPA for now.
+* manylinux2010: Requires pip 10+ and a version of Linux newer than 2010. This
+  is very new technology. 64-bit only. Eventually this will become the
+  preferred (and then only) way to produce Linux wheels. Optional modern GCC
+  image available.
+* MacOS: Uses the dedicated 64 bit 10.9+ Python.org builds. We are not
+  supporting 3.5 because those no longer provide binaries (could use 32+64 fat
+  10.6+ but really force to 10.9+, but will not be added unless there is a need
+  for it).
+* Windows: PyBind11 requires compilation with a newer copy of Visual Studio
+  than Python 2.7's Visual Studio 2008; you need to have the [Visual Studio
+  2015 distributable][msvc2015] installed (the dll is included in 2017 and
+  2019, as well).
 
 [msvc2017]: https://www.microsoft.com/en-us/download/details.aspx?id=48145
 
@@ -50,9 +69,13 @@ variables:
   many_linux_base: "quay.io/pypa/manylinux1_" # Could also be "skhep/manylinuxgcc-"
   dev_requirements_file: .ci/azure-wheel-helpers/empty-requirements.txt
   test_requirements_file: .ci/azure-wheel-helpers/empty-requirements.txt
+  MACOSX_DEPLOYMENT_TARGET: 10.9
 ```
 
-You can adjust the rest of the template as needed. If you need a non-standard procedure, you can change the target of the `template` inputs to a local file. You must have a `test_requirments` file, as the manylinux wheel install test does not pull requirements when testing, and at least pytest is required.
+You can adjust the rest of the template as needed. If you need a non-standard
+procedure, you can change the target of the `template` inputs to a local file.
+You must have a `test_requirments` file, as the manylinux wheel install test
+does not pull requirements when testing, and at least pytest is required.
 
 
 #### Updates
@@ -63,25 +86,42 @@ To update, run:
 git subtree pull --prefix .ci/azure-wheel-helpers git@github.com:scikit-hep/azure-wheel-helpers.git master --squash
 ```
 
+If you make changes inside the folder and want to contribute back, run:
+
+```bash
+git subtree push --prefix=.ci/azure-wheel-helpers git@github.com:scikit-hep/azure-wheel-helpers.git my_fixup_branch
+```
+
+As always, you can make a remote to shorten these commands.
+
+
 ### Common needs
 
 #### Using numpy with Cython
 
-If you build with Cython, you will need to require an older version of Numpy. Either place this in your  `dev_requirements_file` (classic builds) or your `pyproject.toml` (PEP 517 builds):
+If you build with Cython, you will need to require an older version of Numpy.
+Either place this in your  `dev_requirements_file` (classic builds) or your
+`pyproject.toml` (PEP 517 builds):
 
 ```
 numpy==1.11.3; python_version<="3.5"
 numpy==1.12.1; python_version=="3.6"
-numpy==1.14.5; python_version=='3.7'
-numpy==1.17.3; python_version>='3.8'
+numpy==1.14.5; python_version=="3.7"
+numpy==1.17.3; python_version>="3.8"
 ```
 
-(Note: most of Scikit-HEP officially requires 1.13.3+, so you can simplify this with a single `<='3.6'`)
+(Note: most of Scikit-HEP officially requires 1.13.3+, so you can simplify this
+with a single `<='3.6'`)
 
 #### Using PEP 517 builds
 
-For PEP 517 builds, you need to have a pyproject.toml file. Then, for PIP > 10, the build happens in a
-custom environment that has *only* the packages you request. It replaces the deprecated and mostly non-functional `setup_requires` in setup.py, and even lets you select a build system other than setuptools. If you just use it as a replacement for `setup_requires`, you can still support pip < 10; users will just have to manually install the requirements (usually Numpy) beforehand. Here's an example of a Cython PEP 517 build:
+For PEP 517 builds, you need to have a pyproject.toml file. Then, for PIP > 10,
+the build happens in a custom environment that has *only* the packages you
+request. It replaces the deprecated and mostly non-functional `setup_requires`
+in setup.py, and even lets you select a build system other than setuptools. If
+you just use it as a replacement for `setup_requires`, you can still support
+pip < 10; users will just have to manually install the requirements (usually
+Numpy) beforehand. Here's an example of a Cython PEP 517 build:
 
 ```toml
 [build-system]
@@ -95,7 +135,8 @@ requires = [
 ]
 ```
 
-Now, in `setup.py`, just `import numpy` and use it, no need to check to see if it there, etc.
+Now, in `setup.py`, just `import numpy` and use it, no need to check to see if
+it there, etc.
 
 #### Using Numpy parallel compile
 
@@ -110,7 +151,8 @@ distutils.ccompiler.CCompiler.compile = CCompiler_compile
 
 #### Using Cython + Setuptools
 
-Since `setuptools>=18.0`, you can now pass `.pyx` files directly as sources to `Extension`, and they get Cythonized for you! You just need Cython installed. 
+Since `setuptools>=18.0`, you can now pass `.pyx` files directly as sources to
+`Extension`, and they get Cythonized for you! You just need Cython installed. 
 
 ### License
 

--- a/.ci/azure-wheel-helpers/azure-pipeline-build.yml
+++ b/.ci/azure-wheel-helpers/azure-pipeline-build.yml
@@ -29,6 +29,7 @@ variables:
   many_linux_base: quay.io/pypa/manylinux1_
   dev_requirements_file: .ci/azure-wheel-helpers/empty-requirements.txt
   test_requirements_file: .ci/azure-wheel-helpers/empty-requirements.txt
+  MACOSX_DEPLOYMENT_TARGET: 10.9
 
 
 jobs:

--- a/.ci/azure-wheel-helpers/azure-steps.yml
+++ b/.ci/azure-wheel-helpers/azure-steps.yml
@@ -9,12 +9,12 @@ steps:
     call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" $(python.architecture)
     set MSSdk=1
     set DISTUTILS_USE_SDK=1
-    python -m pip wheel . -w wheelhouse/
+    python -m pip wheel -v . -w wheelhouse/
   displayName: 'Build wheel (Windows Python 2.7)'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['python.version'], '2.7')) 
 
 - script: |
-    python -m pip wheel . -w wheelhouse/
+    python -m pip wheel -v . -w wheelhouse/
   displayName: 'Build wheel'
   condition: and(succeeded(), not(and(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['python.version'], '2.7'))))
 

--- a/.ci/azure-wheel-helpers/azure-tests.yml
+++ b/.ci/azure-wheel-helpers/azure-tests.yml
@@ -5,7 +5,7 @@
 
 steps:
 - script: |
-    python -m pip install -U pytest pytest-cov pytest-azurepipelines
+    python -m pip install -U pytest pytest-cov pytest-azurepipelines "coverage>=5.0"
   displayName: Install Azure testing requirements
 
 - script: |

--- a/.ci/azure-wheel-helpers/build-wheels.sh
+++ b/.ci/azure-wheel-helpers/build-wheels.sh
@@ -26,7 +26,7 @@ echo "Using Pythons: ${pys[@]}"
 # Compile wheels
 for PYBIN in "${pys[@]}"; do
     "${PYBIN}/pip" install -r /io/$dev_requirements_file
-    "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+    "${PYBIN}/pip" wheel -v /io/ -w wheelhouse/
 done
 
 # Bundle external shared libraries into the wheels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## Version 0.7.0 (in progress)
+
+#### User changes
+
+* Added `threads=` keyword to `.fill` and numpy functions; 0 for automatic, default is 1 [#325][]
+* `.metadata` is now settable directly from the AxesTuple [#303][]
+* Deprecated items from 0.5.x now dropped [#301][]
+* `cpp` mode updates and fixes [#317][]
+
+#### Bug fixes
+
+* Dict indexing is now identical to positional indexing, fixes "picking" axes in dict [#320][]
+* Passing `samples=None` is now always allowed in `.fill` [#325][]
+
+#### Developer changes
+
+* Build system update, higher requirements for developers (only) [#314][]
+    * Version is now obtained from `setuptools_scm`, no longer stored in repo
+* Removed `futures` requirement for Python 2 tests
+* Updated Boost.Histogram, cleaner code with fewer workarounds
+
+[#301]: https://github.com/scikit-hep/boost-histogram/pull/301
+[#303]: https://github.com/scikit-hep/boost-histogram/pull/303
+[#314]: https://github.com/scikit-hep/boost-histogram/pull/314
+[#317]: https://github.com/scikit-hep/boost-histogram/pull/317
+[#320]: https://github.com/scikit-hep/boost-histogram/pull/320
+[#325]: https://github.com/scikit-hep/boost-histogram/pull/325
+
 ### Version 0.6.2
 
 Common analysis tasks are now better supported. Much more complete

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,9 +46,6 @@ exclude =
     tests
     extern
 
-[aliases]
-test = pytest
-
 [tool:pytest]
 addopts = --benchmark-disable
 testpaths =

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ exclude =
     extern
 
 [tool:pytest]
+junit_family=xunit2
 addopts = --benchmark-disable
 testpaths =
     tests

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,6 @@ import sys
 import os
 
 
-# Official trick to avoid pytest-runner as requirement if not needed
-needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
-pytest_runner = ["pytest-runner"] if needs_pytest else []
-
 # Use -j N or set the environment variable NPY_NUM_BUILD_JOBS
 try:
     from numpy.distutils.ccompiler import CCompiler_compile
@@ -114,9 +110,6 @@ extras["all"] = sum(extras.values(), [])
 setup(
     ext_modules=ext_modules,
     cmdclass={"build_ext": BuildExt},
-    test_suite="tests",
     install_requires=["numpy"],
-    tests_require=extras["test"],
-    setup_requires=[] + pytest_runner,
     extras_require=extras,
 )


### PR DESCRIPTION
This drops the deprecated `setup.py test` syntax, updates the changelog, and attempts to fix #169. ~~If the fix works, this will need 793c3dd pushed up to the subtree (I haven't done that before, so might have to work on that for a bit).~~ Pushed to Azure-wheel-helpers, and updated the README with instructions.

(Note: merging this does *not* mean 0.7.0 is released, there are at least two more issues to be addressed, the readme banner needs to be removed.)