### PR TITLE
Remove unncessary print statement

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -198,7 +198,6 @@ class BaseHistogram(object):
             if threads == 0:
                 threads = os.cpu_count()
 
-            print(self._hist._storage_type)
             if (
                 self._hist._storage_type is _core.storage.mean
                 or self._hist._storage_type is _core.storage.weighted_mean


### PR DESCRIPTION
I was playing with the `bh.numpy` API and I noticed this print statement is always reached when `threads` is not `None`. I'm assuming printing an object any time a particular argument is present is not desired behavior