### PR TITLE
Test cpp sum

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -125,8 +125,14 @@ class BaseHistogram(object):
 
         raise TypeError("Unsupported storage")
 
+    def view(self, flow=False):
+        """
+        Return a view into the data, optionally with overflow turned on.
+        """
+        return _to_view(self._hist.view(flow))
+
     def __array__(self):
-        return _to_view(self._hist.view(False))
+        return self.view(False)
 
     def __add__(self, other):
         return self.__class__(self._hist.__add__(other._hist))
@@ -466,12 +472,6 @@ class Histogram(BaseHistogram):
             return copy.deepcopy(self)
         else:
             return copy.copy(self)
-
-    def view(self, flow=False):
-        """
-        Return a view into the data, optionally with overflow turned on.
-        """
-        return _to_view(self._hist.view(flow))
 
     def reset(self):
         """

--- a/tests/test_cpp_interface.py
+++ b/tests/test_cpp_interface.py
@@ -83,7 +83,7 @@ def test_shrink():
     from boost_histogram.cpp.algorithm import reduce, shrink
 
     h = bhc.histogram(bhc.axis.regular(4, 1, 5))
-    np.asarray(h)[:] = 1
+    h.view()[:] = 1
 
     hs = reduce(h, shrink(0, 2, 3))
     assert hs.axis(0) == bhc.axis.regular(1, 2, 3)
@@ -99,7 +99,7 @@ def test_crop():
     from boost_histogram.cpp.algorithm import reduce, crop
 
     h = bhc.histogram(bhc.axis.regular(4, 1, 5))
-    np.asarray(h)[:] = 1
+    h.view()[:] = 1
 
     hs = reduce(h, crop(0, 2, 3))
     assert hs.axis(0) == bhc.axis.regular(1, 2, 3)
@@ -116,7 +116,7 @@ def test_slice(mode):
     from boost_histogram.cpp.algorithm import reduce, slice
 
     h = bhc.histogram(bhc.axis.regular(4, 1, 5))
-    np.asarray(h)[:] = 1
+    h.view()[:] = 1
     assert_array_equal(h, [1, 1, 1, 1])
 
     hs = reduce(h, slice(0, 1, 2, mode=mode))
@@ -133,7 +133,7 @@ def test_rebin():
     from boost_histogram.cpp.algorithm import reduce, rebin
 
     h = bhc.histogram(bhc.axis.regular(4, 1, 5))
-    np.asarray(h)[:] = 1
+    h.view()[:] = 1
     assert_array_equal(h, [1, 1, 1, 1])
 
     hs = reduce(h, rebin(0, 4))
@@ -148,7 +148,7 @@ def test_shrink_and_rebin():
     from boost_histogram.cpp.algorithm import reduce, shrink_and_rebin
 
     h = bhc.histogram(bhc.axis.regular(5, 0, 5))
-    np.asarray(h)[:] = 1
+    h.view()[:] = 1
     hs = reduce(h, shrink_and_rebin(0, 1, 3, 2))
     assert hs.axis(0) == bhc.axis.regular(1, 1, 3)
     assert_array_equal(hs, [2])
@@ -160,7 +160,7 @@ def test_crop_and_rebin():
     from boost_histogram.cpp.algorithm import reduce, crop_and_rebin
 
     h = bhc.histogram(bhc.axis.regular(5, 0, 5))
-    np.asarray(h)[:] = 1
+    h.view()[:] = 1
     hs = reduce(h, crop_and_rebin(0, 1, 3, 2))
     assert hs.axis(0) == bhc.axis.regular(1, 1, 3)
     assert_array_equal(hs, [2])
@@ -172,9 +172,19 @@ def test_slice_and_rebin():
     from boost_histogram.cpp.algorithm import reduce, slice_and_rebin
 
     h = bhc.histogram(bhc.axis.regular(5, 0, 5))
-    np.asarray(h)[:] = 1
+    h.view()[:] = 1
     hs = reduce(h, slice_and_rebin(0, 1, 3, 2))
     assert hs.axis(0) == bhc.axis.regular(1, 1, 3)
     assert_array_equal(hs, [2])
     hs2 = reduce(h, slice_and_rebin(1, 3, 2))
     assert hs == hs2
+
+
+def test_sum():
+    from boost_histogram.cpp.algorithm import sum
+
+    h = bhc.histogram(bhc.axis.integer(1, 5))
+    h.view(True)[:] = 1
+    assert sum(h) == 6  # C++ behavior is to include flow bins by default
+    assert sum(h, False) == 4
+    assert sum(h, True) == 6


### PR DESCRIPTION
Note: As part of this patch, I moved the `.view` from the main interface into the base interface, so that the cpp interface can also use it.

This adds a test for the cpp-style `sum` to check that the default behavior is as in C++.