### PR TITLE
Allow cloudpickle to work on histograms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ extras = {
         "sphinx_copybutton",
     ],
     "examples": ["matplotlib", "xarray", "xhistogram", "netCDF4", "numba"],
-    "dev": ["pytest-sugar", "ipykernel"],
+    "dev": ["pytest-sugar", "ipykernel", "cloudpickle"],
 }
 extras["all"] = sum(extras.values(), [])
 

--- a/src/boost_histogram/__init__.py
+++ b/src/boost_histogram/__init__.py
@@ -28,6 +28,15 @@ except ImportError as err:
         err.msg += "\nDid you forget to compile? Use CMake or Setuptools to build, see the readme"
     raise err
 
+# Support cloudpickle - pybind11 submodules do not have __file__ attributes
+# And setting this in C++ causes a segfault
+_core.accumulators.__file__ = _core.__file__
+_core.algorithm.__file__ = _core.__file__
+_core.axis.__file__ = _core.__file__
+_core.axis.transform.__file__ = _core.__file__
+_core.hist.__file__ = _core.__file__
+_core.storage.__file__ = _core.__file__
+
 
 from ._internal.hist import Histogram
 from . import axis, storage, accumulators, utils, numpy

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -258,3 +258,14 @@ def test_trans_wrapped(copy_fn):
     tr2 = copy_fn(tr)
 
     assert tr._this is not tr2._this
+
+
+# Testing #342
+def test_cloudpickle():
+    cloudpickle = pytest.importorskip("cloudpickle")
+    h = bh.Histogram(bh.axis.Regular(50, 0, 20))
+    h.fill([1, 2, 3, 4, 5])
+    h2 = loads(cloudpickle.dumps(h))
+
+    assert h == h2
+    assert h is not h2


### PR DESCRIPTION
This is a bit hacky, a better fix should come from cloudpickle or pybind11. Fixes #342.

This is correctly fixed in https://github.com/cloudpipe/cloudpickle/pull/357 - when that is merged and released, this can simply become a test with a new version of cloudpickle.