### PR TITLE
feat: Adding addition of 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,5 @@ compile_commands.json
 # Testing
 /.benchmarks/*
 
-# IDEs
-/.idea
+# PyCharm
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ message(STATUS "boost-histogram ${BOOST_HISTOGRAM_VERSION}")
 
 if(BUILD_TESTING)
 
-    python_import(numpy pytest pytest-benchmark six typing)
+    python_import(numpy pytest pytest-benchmark typing)
 
     # Support for running from build directory
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/pytest.ini"

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -155,12 +155,25 @@ class BaseHistogram(object):
         return self.view(False)
 
     def __add__(self, other):
-        return self.__class__(self._hist.__add__(other._hist))
+        if hasattr(other, "_hist"):
+            return self.__class__(self._hist.__add__(other._hist))
+        else:
+            retval = self.copy()
+            retval += other
+            return retval
 
     def __iadd__(self, other):
-        self._hist.__iadd__(other._hist)
-        self.axes = self._generate_axes_()
-        return self
+        if isinstance(other, (int, float)) and other == 0:
+            return self
+        if hasattr(other, "_hist"):
+            self._hist.__iadd__(other._hist)
+            # Addition may change category axes
+            self.axes = self._generate_axes_()
+            return self
+        return NotImplemented
+
+    def __radd__(self, other):
+        return self + other
 
     def __eq__(self, other):
         return self._hist == other._hist

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -283,6 +283,47 @@ def test_fill_2d(flow):
 
 
 def test_add_2d(flow):
+    h0 = bh.Histogram(
+        bh.axis.Integer(-1, 2, underflow=flow, overflow=flow),
+        bh.axis.Regular(4, -2, 2, underflow=flow, overflow=flow),
+    )
+    assert isinstance(h0, bh.Histogram)
+
+    h0.fill(-1, -2)
+    h0.fill(-1, -1)
+    h0.fill(0, 0)
+    h0.fill(0, 1)
+    h0.fill(1, 0)
+    h0.fill(3, -1)
+    h0.fill(0, -3)
+
+    m = [
+        [1, 1, 0, 0, 0, 0],
+        [0, 0, 1, 1, 0, 1],
+        [0, 0, 1, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0],
+    ]
+
+    h = h0.copy()
+    h += h
+    for i in range(-flow, h.axes[0].size + flow):
+        for j in range(-flow, h.axes[1].size + flow):
+            assert h[bh.tag.at(i), bh.tag.at(j)] == 2 * m[i][j]
+
+    h = sum([h0, h0])
+    for i in range(-flow, h.axes[0].size + flow):
+        for j in range(-flow, h.axes[1].size + flow):
+            assert h[bh.tag.at(i), bh.tag.at(j)] == 2 * m[i][j]
+
+    h = 0 + h0 + h0
+    for i in range(-flow, h.axes[0].size + flow):
+        for j in range(-flow, h.axes[1].size + flow):
+            assert h[bh.tag.at(i), bh.tag.at(j)] == 2 * m[i][j]
+
+
+@pytest.mark.parametrize("flow", [True, False])
+def test_add_2d_fancy(flow):
     h = bh.Histogram(
         bh.axis.Integer(-1, 2, underflow=flow, overflow=flow),
         bh.axis.Regular(4, -2, 2, underflow=flow, overflow=flow),


### PR DESCRIPTION
Adding with a false-like, such as 0 or None, is now supported. This allows syntax like `sum(histogram_list)` without answering the hard question of what it means to add a constant to a histogram with flow bins and unevenly sized bins. That can be done much more clearly using the view or `[...] =` syntax.

Closes #261.