### PR TITLE
fix: extra Python wrapper removed

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -571,7 +571,7 @@ class Histogram(BaseHistogram):
 
                 slices.append(_core.algorithm.slice_and_rebin(i, start, stop, merge))
 
-        reduced = self._reduce(*slices)
+        reduced = self._hist.reduce(*slices)
 
         if not integrations:
             return self.__class__(reduced)


### PR DESCRIPTION
TODO: Could add a test; static typing would have caught this too. Maybe consider normalizing all the hidden method return types?

Discovered in https://github.com/scikit-hep/hist/pull/22