### PR TITLE
fix: Type safety for string index

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ testpaths =
 
 [flake8]
 max-line-length = 80
-max-complexity = 12
+max-complexity = 13
 select = C, E, F, W, B, B9
 ignore = E203, E231, E501, E722, W503, B950
 

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -17,7 +17,7 @@ def _isstr(value):
     """
     Check to see if this is a stringlike or a (nested) iterable of stringlikes
     """
-    str_types = (type(""), type(""))
+    str_types = (type(""), type(u""))
 
     if isinstance(value, str_types):
         return True
@@ -100,15 +100,7 @@ class Axis(object):
         """
 
         def _process_internal(item, default):
-            return (
-                default
-                if item is None
-                else item(self)
-                if callable(item)
-                else self.index(item)
-                if isinstance(item, str)
-                else item
-            )
+            return default if item is None else item(self) if callable(item) else item
 
         begin = _process_internal(start, -1 if self._ax.options.underflow else 0)
         end = _process_internal(
@@ -583,7 +575,7 @@ class BaseStrCategory(Axis):
 
         # We need to make sure we support Python 2 for now :(
         # henryiii: This shortcut possibly should be removed
-        if isinstance(categories, (type(""), type(""))):
+        if isinstance(categories, (type(""), type(u""))):
             categories = list(categories)
 
         if options == {"growth"}:

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -434,10 +434,7 @@ class Histogram(BaseHistogram):
 
         # Allow [bh.loc(...)] to work
         for i in range(len(indexes)):
-            # Shortcut: strings directly work on string axes
-            if isinstance(indexes[i], str):
-                indexes[i] = self.axes[i].index(indexes[i])
-            elif callable(indexes[i]):
+            if callable(indexes[i]):
                 indexes[i] = indexes[i](self.axes[i])
             elif hasattr(indexes[i], "flow"):
                 if indexes[i].flow == 1:

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -434,8 +434,11 @@ class Histogram(BaseHistogram):
 
         # Allow [bh.loc(...)] to work
         for i in range(len(indexes)):
-            if callable(indexes[i]):
-                indexes[i] = indexes[i](cast(self, hist.axis(i), Axis))
+            # Shortcut: strings directly work on string axes
+            if isinstance(indexes[i], str):
+                indexes[i] = self.axes[i].index(indexes[i])
+            elif callable(indexes[i]):
+                indexes[i] = indexes[i](self.axes[i])
             elif hasattr(indexes[i], "flow"):
                 if indexes[i].flow == 1:
                     indexes[i] = hist.axis(i).size

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+
+@pytest.fixture(params=(False, True), ids=("nogrowth", "growth"))
+def growth(request):
+    return request.param

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -698,7 +698,6 @@ class TestCategory(Axis):
         assert bh.axis.StrCategory(["A", "B"]) != bh.axis.StrCategory("BA")
 
     @pytest.mark.parametrize("ref", ([1, 2, 3], "ABC"))
-    @pytest.mark.parametrize("growth", (False, True))
     def test_len(self, ref, growth):
         Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
         a = Cat(ref, growth=growth)
@@ -721,7 +720,6 @@ class TestCategory(Axis):
             assert repr(ax) == "StrCategory([u'A', u'B', u'C'], metadata='foo')"
 
     @pytest.mark.parametrize("ref", ([1, 2, 3], "ABC"))
-    @pytest.mark.parametrize("growth", (False, True))
     def test_getitem(self, ref, growth):
         Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
 
@@ -745,14 +743,14 @@ class TestCategory(Axis):
             assert a.bin(3) is None
 
     @pytest.mark.parametrize("ref", ([1, 2, 3], ("A", "B", "C")))
-    @pytest.mark.parametrize("growth", (False, True))
     def test_iter(self, ref, growth):
         Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
         a = Cat(ref, growth=growth)
         assert_array_equal(a, ref)
 
-    @pytest.mark.parametrize("ref", ([1, 2, 3, 4], ("A", "B", "C", "D")))
-    @pytest.mark.parametrize("growth", (False, True))
+    @pytest.mark.parametrize(
+        "ref", ([1, 2, 3, 4], ("A", "B", "C", "D")), ids=("int", "str")
+    )
     def test_index(self, ref, growth):
         Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
         a = Cat(ref[:-1], growth=growth)
@@ -762,7 +760,6 @@ class TestCategory(Axis):
         assert_array_equal(a.index(np.reshape(ref, (2, 2))), [[0, 1], [2, 3]])
 
     @pytest.mark.parametrize("ref", ([1, 2, 3], ("A", "B", "C")))
-    @pytest.mark.parametrize("growth", (False, True))
     def test_value(self, ref, growth):
         Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
         a = Cat(ref, growth=growth)
@@ -779,7 +776,6 @@ class TestCategory(Axis):
             a.value([[2], [2]])
 
     @pytest.mark.parametrize("ref", ([1, 2, 3], "ABC"))
-    @pytest.mark.parametrize("growth", (False, True))
     def test_edges_centers_widths(self, ref, growth):
         Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
         a = Cat(ref, growth=growth)

--- a/tests/test_benchmark_category_axis.py
+++ b/tests/test_benchmark_category_axis.py
@@ -5,7 +5,6 @@ import numpy as np
 
 
 @pytest.mark.benchmark(group="IntCategory")
-@pytest.mark.parametrize("growth", (False, True))
 @pytest.mark.parametrize("dtype", ("i", tuple))
 def test_IntCategory(benchmark, growth, dtype):
     np.random.seed(42)
@@ -22,7 +21,6 @@ def test_IntCategory(benchmark, growth, dtype):
 
 
 @pytest.mark.benchmark(group="StrCategory")
-@pytest.mark.parametrize("growth", (False, True))
 @pytest.mark.parametrize("dtype", ("S", "U", "O", tuple))
 def test_StrCategory(benchmark, growth, dtype):
     np.random.seed(42)

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -268,6 +268,28 @@ def test_pick_str_category():
     assert_array_equal(h[:, :, bh.loc("off")].view(), 0)
 
 
+def test_string_shortcut():
+    h = bh.Histogram(
+        bh.axis.Integer(0, 10),
+        bh.axis.StrCategory(["1", "a", "hello"]),
+        storage=bh.storage.Int64(),
+    )
+    h[...] = np.arange(30).reshape([10, 3])
+
+    assert h[3, "a"] == 10
+    assert h[4, "1"] == 12
+    assert h[5, "hello"]
+
+    with pytest.raises(TypeError):
+        h[bh.loc("1"), 1]
+
+    with pytest.raises(TypeError):
+        h["1", 1]
+
+    with pytest.raises(TypeError):
+        h["1", "1"]
+
+
 def test_pick_int_category():
     noflow = dict(underflow=False, overflow=False)
 

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -268,26 +268,23 @@ def test_pick_str_category():
     assert_array_equal(h[:, :, bh.loc("off")].view(), 0)
 
 
-def test_string_shortcut():
+def test_string_requirement():
     h = bh.Histogram(
         bh.axis.Integer(0, 10),
         bh.axis.StrCategory(["1", "a", "hello"]),
         storage=bh.storage.Int64(),
     )
-    h[...] = np.arange(30).reshape([10, 3])
-
-    assert h[3, "a"] == 10
-    assert h[4, "1"] == 12
-    assert h[5, "hello"]
 
     with pytest.raises(TypeError):
-        h[bh.loc("1"), 1]
+        h[bh.loc("1"), bh.loc(1)]
 
     with pytest.raises(TypeError):
-        h["1", 1]
+        h[bh.loc(1), bh.loc(1)]
 
     with pytest.raises(TypeError):
-        h["1", "1"]
+        h[bh.loc("1"), bh.loc("1")]
+
+    assert h[bh.loc(1), bh.loc("1")] == 0
 
 
 def test_pick_int_category():


### PR DESCRIPTION
This fixes a type safety issue where types could be mismatched; for example ints could be used in locators for StrCategory, when really only strings make sense.

Simplify testing a bit with a parametrized fixture (see [nice article here](https://levelup.gitconnected.com/advanced-pytest-techniques-i-learned-while-contributing-to-pandas-7ba1465b65eb)). This could probably be used elsewhere. Also improves testing output with IDs for growth.

@HDembinski, what do you think?