### PR TITLE
feat: Add Boolean axes from Boost.Histogram

### DIFF
--- a/include/bh_python/axis.hpp
+++ b/include/bh_python/axis.hpp
@@ -108,6 +108,9 @@ using category_str_growth
 BHP_SPECIALIZE_NAME(category_str)
 BHP_SPECIALIZE_NAME(category_str_growth)
 
+using boolean = bh::axis::boolean<metadata_t>;
+BHP_SPECIALIZE_NAME(boolean)
+
 // Axis defined elsewhere
 BHP_SPECIALIZE_NAME(regular_numpy)
 
@@ -275,7 +278,8 @@ using axis_variant = bh::axis::variant<axis::regular_uoflow,
                                        axis::category_int,
                                        axis::category_int_growth,
                                        axis::category_str,
-                                       axis::category_str_growth>;
+                                       axis::category_str_growth,
+                                       axis::boolean>;
 
 // This saves a little typing
 using vector_axis_variant = std::vector<axis_variant>;

--- a/include/bh_python/axis.hpp
+++ b/include/bh_python/axis.hpp
@@ -181,14 +181,15 @@ decltype(auto) unchecked_bin(const A& ax, bh::axis::index_type i) {
 template <class A>
 py::array_t<double> edges(const A& ax, bool flow = false, bool numpy_upper = false) {
     auto continuous = [flow, numpy_upper](const auto& ax) {
-        using index_type = std::conditional_t<
-            bh::axis::traits::is_continuous<std::decay_t<decltype(ax)>>::value,
-            bh::axis::real_index_type,
-            bh::axis::index_type>;
+        using AX = std::decay_t<decltype(ax)>;
+        using index_type
+            = std::conditional_t<bh::axis::traits::is_continuous<AX>::value,
+                                 bh::axis::real_index_type,
+                                 bh::axis::index_type>;
         const index_type underflow
-            = flow && (bh::axis::traits::options(ax) & option::underflow);
+            = flow && (bh::axis::traits::get_options<AX>::test(option::underflow));
         const index_type overflow
-            = flow && (bh::axis::traits::options(ax) & option::overflow);
+            = flow && (bh::axis::traits::get_options<AX>::test(option::overflow));
 
         py::array_t<double> edges(
             static_cast<std::size_t>(ax.size() + 1 + overflow + underflow));
@@ -207,11 +208,12 @@ py::array_t<double> edges(const A& ax, bool flow = false, bool numpy_upper = fal
     return select(
         continuous,
         [flow](const auto& ax) {
-            static_assert(!(std::decay_t<decltype(ax)>::options() & option::underflow),
+            using AX = std::decay_t<decltype(ax)>;
+            static_assert(!bh::axis::traits::get_options<AX>::test(option::underflow),
                           "discrete axis never has underflow");
 
             const bh::axis::index_type overflow
-                = flow && (bh::axis::traits::options(ax) & option::overflow);
+                = flow && bh::axis::traits::get_options<AX>::test(option::overflow);
 
             py::array_t<double> edges(
                 static_cast<std::size_t>(ax.size() + 1 + overflow));

--- a/include/bh_python/fill.hpp
+++ b/include/bh_python/fill.hpp
@@ -32,8 +32,8 @@ namespace variant = boost::variant2;
 static_assert(
     mp11::mp_empty<mp11::mp_set_difference<
         mp11::mp_unique<mp11::mp_transform<bh::axis::traits::value_type, axis_variant>>,
-        mp11::mp_list<double, int, std::string>>>::value,
-    "supported value types are double, int, std::string; "
+        mp11::mp_list<double, int, std::string, bool>>>::value,
+    "supported value types are double, int, std::string, bool; "
     "new axis was added with different value type");
 
 template <class T>
@@ -60,7 +60,7 @@ struct c_array_t<std::string> : std::vector<std::string> {
     }
 };
 
-// for int, double
+// for int, double, bool
 template <class T>
 bool is_value(py::handle h) {
     if(py::isinstance<py::array>(h) && py::cast<py::array>(h).ndim() > 0)
@@ -99,6 +99,8 @@ using arg_t = variant::variant<c_array_t<double>,
                                double,
                                c_array_t<int>,
                                int,
+                               c_array_t<bool>,
+                               bool,
                                c_array_t<std::string>,
                                std::string>;
 
@@ -114,7 +116,7 @@ inline auto get_vargs(const vector_axis_variant& axes, const py::args& args) {
         axes,
         [args_it = args.begin(), vargs_it = vargs.begin()](const auto& ax) mutable {
             using T = bh::axis::traits::value_type<std::decay_t<decltype(ax)>>;
-            // T is one of: int, double, std::string
+            // T is one of: int, double, std::string, bool
 
             const auto& x = *args_it++;
             auto& v       = *vargs_it++;

--- a/include/bh_python/register_axis.hpp
+++ b/include/bh_python/register_axis.hpp
@@ -116,9 +116,7 @@ py::class_<A> register_axis(py::module& m, Args&&... args) {
 
         .def_property_readonly(
             "options",
-            [](const A& self) {
-                return options{static_cast<unsigned>(self.options())};
-            },
+            [](const A&) { return options{bh::axis::traits::get_options<A>::value}; },
             "Return the options associated to the axis")
 
         .def_property(
@@ -150,13 +148,12 @@ py::class_<A> register_axis(py::module& m, Args&&... args) {
             "bin",
             [](const A& ax, int i) {
                 const bh::axis::index_type begin
-                    = bh::axis::traits::static_options<A>::test(
+                    = bh::axis::traits::get_options<A>::test(
                           bh::axis::option::underflow)
                           ? -1
                           : 0;
                 const bh::axis::index_type end
-                    = bh::axis::traits::static_options<A>::test(
-                          bh::axis::option::overflow)
+                    = bh::axis::traits::get_options<A>::test(bh::axis::option::overflow)
                           ? ax.size() + 1
                           : ax.size();
                 if(begin <= i && i < end)

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -378,6 +378,48 @@ class regular(BaseRegular, CppAxisMixin):
         return None
 
 
+# Contains all common methods and properties for the boolean axis
+@register({ca.boolean})
+class BaseBoolean(Axis):
+    __slots__ = ()
+
+    @inject_signature("self, *, metadata=None")
+    def __init__(self, **kwargs):
+        """
+        Make an axis for boolean values.
+
+        Parameters
+        ----------
+        metadata : object
+            Any Python object to attach to the axis, like a label.
+        """
+        with KWArgs(kwargs) as k:
+            metadata = k.optional("metadata")
+
+        self._ax = ca.boolean(metadata)
+
+
+@set_family(MAIN_FAMILY)
+@set_module("boost_histogram.axis")
+class Boolean(BaseBoolean, MainAxisMixin):
+    __slots__ = ()
+
+    def _repr_args(self):
+        "Return inner part of signature for use in repr"
+        return ""
+
+    def _repr_kwargs(self):
+        """
+        Return options for use in repr. Metadata is last,
+        just in case it spans multiple lines.
+        """
+
+        if self.metadata is not None:
+            return "metadata={0!r}".format(self.metadata)
+        else:
+            return ""
+
+
 @register(
     {
         ca.variable_none,

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -378,48 +378,6 @@ class regular(BaseRegular, CppAxisMixin):
         return None
 
 
-# Contains all common methods and properties for the boolean axis
-@register({ca.boolean})
-class BaseBoolean(Axis):
-    __slots__ = ()
-
-    @inject_signature("self, *, metadata=None")
-    def __init__(self, **kwargs):
-        """
-        Make an axis for boolean values.
-
-        Parameters
-        ----------
-        metadata : object
-            Any Python object to attach to the axis, like a label.
-        """
-        with KWArgs(kwargs) as k:
-            metadata = k.optional("metadata")
-
-        self._ax = ca.boolean(metadata)
-
-
-@set_family(MAIN_FAMILY)
-@set_module("boost_histogram.axis")
-class Boolean(BaseBoolean, MainAxisMixin):
-    __slots__ = ()
-
-    def _repr_args(self):
-        "Return inner part of signature for use in repr"
-        return ""
-
-    def _repr_kwargs(self):
-        """
-        Return options for use in repr. Metadata is last,
-        just in case it spans multiple lines.
-        """
-
-        if self.metadata is not None:
-            return "metadata={0!r}".format(self.metadata)
-        else:
-            return ""
-
-
 @register(
     {
         ca.variable_none,
@@ -729,3 +687,45 @@ class int_category(BaseIntCategory, CppAxisMixin):
 @set_module("boost_histogram.cpp.axis")
 class str_category(BaseStrCategory, CppAxisMixin):
     __slots__ = ()
+
+
+# Contains all common methods and properties for the boolean axis
+@register({ca.boolean})
+class BaseBoolean(Axis):
+    __slots__ = ()
+
+    @inject_signature("self, *, metadata=None")
+    def __init__(self, **kwargs):
+        """
+        Make an axis for boolean values.
+
+        Parameters
+        ----------
+        metadata : object
+            Any Python object to attach to the axis, like a label.
+        """
+        with KWArgs(kwargs) as k:
+            metadata = k.optional("metadata")
+
+        self._ax = ca.boolean(metadata)
+
+
+@set_family(MAIN_FAMILY)
+@set_module("boost_histogram.axis")
+class Boolean(BaseBoolean, MainAxisMixin):
+    __slots__ = ()
+
+    def _repr_args(self):
+        "Return inner part of signature for use in repr"
+        return ""
+
+    def _repr_kwargs(self):
+        """
+        Return options for use in repr. Metadata is last,
+        just in case it spans multiple lines.
+        """
+
+        if self.metadata is not None:
+            return "metadata={0!r}".format(self.metadata)
+        else:
+            return ""

--- a/src/boost_histogram/axis/__init__.py
+++ b/src/boost_histogram/axis/__init__.py
@@ -2,7 +2,14 @@
 from __future__ import absolute_import, division, print_function
 
 from .._internal.axis import Axis
-from .._internal.axis import Regular, Variable, Integer, IntCategory, StrCategory
+from .._internal.axis import (
+    Regular,
+    Variable,
+    Integer,
+    IntCategory,
+    StrCategory,
+    Boolean,
+)
 from .._core.axis import options
 from . import transform
 
@@ -14,6 +21,7 @@ __all__ = (
     "Integer",
     "IntCategory",
     "StrCategory",
+    "Boolean",
     "Axis",
     "options",
     "transform",

--- a/src/register_axis.cpp
+++ b/src/register_axis.cpp
@@ -153,5 +153,9 @@ void register_axes(py::module& mod) {
                "metadata"_a);
     });
 
+    register_axis<axis::boolean>(mod, "boolean")
+        .def(py::init<>())
+        .def(py::init<metadata_t>(), "metadata"_a);
+
     ;
 }

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -532,6 +532,69 @@ class TestVariable(Axis):
         assert_allclose(a.widths, [1, 2])
 
 
+class TestBoolean:
+    def test_init(self):
+        bh.axis.Boolean()
+        bh.axis.Boolean(metadata="foo")
+
+        with pytest.raises(TypeError):
+            bh.axis.Boolean(1)
+
+        ax = bh.axis.Boolean()
+        assert isinstance(ax, bh.axis.Boolean)
+        assert ax.options == bh.axis.options()
+
+    def test_equal(self):
+        assert bh.axis.Boolean() == bh.axis.Boolean()
+        assert bh.axis.Boolean(metadata="hi") == bh.axis.Boolean(metadata="hi")
+        assert bh.axis.Boolean(metadata="hi") != bh.axis.Boolean()
+        assert bh.axis.Boolean(metadata="hi") != bh.axis.Boolean(metadata="ho")
+
+    def test_len(self):
+        a = bh.axis.Boolean()
+        assert len(a) == 2
+        assert a.size == 2
+        assert a.extent == 2
+
+    def test_repr(self):
+        a = bh.axis.Boolean()
+        assert repr(a) == "Boolean()"
+
+        a = bh.axis.Boolean(metadata="hi")
+        assert repr(a) == "Boolean(metadata='hi')"
+
+    def test_label(self):
+        a = bh.axis.Boolean(metadata="foo")
+        assert a.metadata == "foo"
+        a.metadata = "bar"
+        assert a.metadata == "bar"
+
+    def test_getitem(self):
+        a = bh.axis.Boolean()
+        ref = [False, True]
+        for i, r in enumerate(ref):
+            assert a.bin(i) == r
+            assert a[i] == r
+        assert a.bin(0) == 0
+        assert a.bin(1) == 1
+
+    def test_iter(self):
+        a = bh.axis.Boolean()
+        ref = (False, True)
+        assert_array_equal(a, ref)
+
+    def test_index(self):
+        a = bh.axis.Boolean()
+        assert a.index(False) == 0
+        assert a.index(True) == 1
+
+    def test_edges_centers_widths(self):
+        a = bh.axis.Boolean()
+        assert_allclose(a.edges, [0.0, 1.0, 2.0])
+        assert_allclose(a.centers, [0.5, 1.5])
+        assert_allclose(a.widths, [1, 1])
+
+
 class TestInteger:
     def test_init(self):
         bh.axis.Integer(-1, 2)

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -532,69 +532,6 @@ class TestVariable(Axis):
         assert_allclose(a.widths, [1, 2])
 
 
-class TestBoolean:
-    def test_init(self):
-        bh.axis.Boolean()
-        bh.axis.Boolean(metadata="foo")
-
-        with pytest.raises(TypeError):
-            bh.axis.Boolean(1)
-
-        ax = bh.axis.Boolean()
-        assert isinstance(ax, bh.axis.Boolean)
-        assert ax.options == bh.axis.options()
-
-    def test_equal(self):
-        assert bh.axis.Boolean() == bh.axis.Boolean()
-        assert bh.axis.Boolean(metadata="hi") == bh.axis.Boolean(metadata="hi")
-        assert bh.axis.Boolean(metadata="hi") != bh.axis.Boolean()
-        assert bh.axis.Boolean(metadata="hi") != bh.axis.Boolean(metadata="ho")
-
-    def test_len(self):
-        a = bh.axis.Boolean()
-        assert len(a) == 2
-        assert a.size == 2
-        assert a.extent == 2
-
-    def test_repr(self):
-        a = bh.axis.Boolean()
-        assert repr(a) == "Boolean()"
-
-        a = bh.axis.Boolean(metadata="hi")
-        assert repr(a) == "Boolean(metadata='hi')"
-
-    def test_label(self):
-        a = bh.axis.Boolean(metadata="foo")
-        assert a.metadata == "foo"
-        a.metadata = "bar"
-        assert a.metadata == "bar"
-
-    def test_getitem(self):
-        a = bh.axis.Boolean()
-        ref = [False, True]
-        for i, r in enumerate(ref):
-            assert a.bin(i) == r
-            assert a[i] == r
-        assert a.bin(0) == 0
-        assert a.bin(1) == 1
-
-    def test_iter(self):
-        a = bh.axis.Boolean()
-        ref = (False, True)
-        assert_array_equal(a, ref)
-
-    def test_index(self):
-        a = bh.axis.Boolean()
-        assert a.index(False) == 0
-        assert a.index(True) == 1
-
-    def test_edges_centers_widths(self):
-        a = bh.axis.Boolean()
-        assert_allclose(a.edges, [0.0, 1.0, 2.0])
-        assert_allclose(a.centers, [0.5, 1.5])
-        assert_allclose(a.widths, [1, 1])
-
-
 class TestInteger:
     def test_init(self):
         bh.axis.Integer(-1, 2)
@@ -845,3 +782,66 @@ class TestCategory(Axis):
         assert_allclose(a.edges, [0, 1, 2, 3])
         assert_allclose(a.centers, [0.5, 1.5, 2.5])
         assert_allclose(a.widths, [1, 1, 1])
+
+
+class TestBoolean:
+    def test_init(self):
+        bh.axis.Boolean()
+        bh.axis.Boolean(metadata="foo")
+
+        with pytest.raises(TypeError):
+            bh.axis.Boolean(1)
+
+        ax = bh.axis.Boolean()
+        assert isinstance(ax, bh.axis.Boolean)
+        assert ax.options == bh.axis.options()
+
+    def test_equal(self):
+        assert bh.axis.Boolean() == bh.axis.Boolean()
+        assert bh.axis.Boolean(metadata="hi") == bh.axis.Boolean(metadata="hi")
+        assert bh.axis.Boolean(metadata="hi") != bh.axis.Boolean()
+        assert bh.axis.Boolean(metadata="hi") != bh.axis.Boolean(metadata="ho")
+
+    def test_len(self):
+        a = bh.axis.Boolean()
+        assert len(a) == 2
+        assert a.size == 2
+        assert a.extent == 2
+
+    def test_repr(self):
+        a = bh.axis.Boolean()
+        assert repr(a) == "Boolean()"
+
+        a = bh.axis.Boolean(metadata="hi")
+        assert repr(a) == "Boolean(metadata='hi')"
+
+    def test_label(self):
+        a = bh.axis.Boolean(metadata="foo")
+        assert a.metadata == "foo"
+        a.metadata = "bar"
+        assert a.metadata == "bar"
+
+    def test_getitem(self):
+        a = bh.axis.Boolean()
+        ref = [False, True]
+        for i, r in enumerate(ref):
+            assert a.bin(i) == r
+            assert a[i] == r
+        assert a.bin(0) == 0
+        assert a.bin(1) == 1
+
+    def test_iter(self):
+        a = bh.axis.Boolean()
+        ref = (False, True)
+        assert_array_equal(a, ref)
+
+    def test_index(self):
+        a = bh.axis.Boolean()
+        assert a.index(False) == 0
+        assert a.index(True) == 1
+
+    def test_edges_centers_widths(self):
+        a = bh.axis.Boolean()
+        assert_allclose(a.edges, [0.0, 1.0, 2.0])
+        assert_allclose(a.centers, [0.5, 1.5])
+        assert_allclose(a.widths, [1, 1])

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -608,6 +608,34 @@ def test_pickle_1():
     assert a == b
 
 
+def test_pickle_bool():
+    a = bh.Histogram(bh.axis.Boolean(), bh.axis.Boolean(metadata={"one": 1}))
+    assert isinstance(a, bh.Histogram)
+
+    a.fill([True, True, False, False], [True, False, True, True])
+    a.fill([True, True, True], True)
+
+    assert a[True, True] == 4
+    assert a[True, False] == 1
+    assert a[False, True] == 2
+    assert a[False, False] == 0
+
+    io = BytesIO()
+    pickle.dump(a, io, protocol=-1)
+    io.seek(0)
+    b = pickle.load(io)
+
+    assert id(a) != id(b)
+    assert a.ndim == b.ndim
+    assert a.axes[0] == b.axes[0]
+    assert a.axes[1] == b.axes[1]
+    assert a.sum() == b.sum()
+    assert repr(a) == repr(b)
+    assert str(a) == str(b)
+    assert a == b
+    assert_array_equal(a.view(), b.view())
+
+
 # Numpy tests
 
 


### PR DESCRIPTION
~~This will not work without https://github.com/boostorg/histogram/pull/283.~~ Edit, at @HDembinski's suggestion, converted to using axis traits everywhere and now it works without updating to latest develop.

TODO:
* [x] Add at least one test with a binary axes in a histogram
* [x] Sort additions so boolean is always last (to match the variant and be consistent)

Boolean has not been added to cpp. (warning added to master)