### PR TITLE
CPP warn, update, cleanup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         python-version: '3.7'
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.4.2 twine
+      run: python -m pip install cibuildwheel==1.5.1 twine
 
     - name: Build wheel
       run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -74,12 +74,12 @@ jobs:
         python-version: '3.7'
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.4.2
+      run: python -m pip install cibuildwheel==1.5.1
 
     - name: Build wheel
       run: python -m cibuildwheel --output-dir wheelhouse
       env:
-        CIBW_SKIP: pp* cp27-win* cp35-win*
+        CIBW_SKIP: pp* cp27-win*
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.CIBW_MANYLINUX_X86_64_IMAGE }}
 
@@ -108,7 +108,7 @@ jobs:
         python-version: '3.7'
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.4.2
+      run: python -m pip install cibuildwheel==1.5.1
 
     - uses: ilammy/msvc-dev-cmd@v1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
     # beta - Doesn't always work. Wait till Travis fixes.
 
 install:
-  - python3 -m pip install cibuildwheel==1.4.2
+  - python3 -m pip install cibuildwheel==1.5.1
 
 script:
   - sed -i '/numpy/d' pyproject.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@
 * Weighted views can be summed and added [#368][]
 * Sum is now identical to the built-in sum function [#365][]
 * Adding growing axis is better supported [#358][]
+* Slicing an AxesTuple now keeps the type [#384][]
+* `ndim` replaces `rank` for NumPy compatibility [#385][]
 * More deprecated functionality removed
 
 #### Bug fixes
 * Support older versions of [CloudPickle][] (issue properly fixed upstream soon) [#343][]
 * Drop extra printout [#338][]
+* Throw an error instead of returning an incorrect result in more places [#386][]
 
-#### Developer change
+#### Developer changes
 
 * Update Boost to 1.73 [#359][], PyBind11 to 2.5.0 [#351][]
 * Cropping no longer uses workaround [#373][]
@@ -25,18 +28,21 @@
 [`cibuildwheel`]: https://cibuildwheel.readthedocs.io/en/stable
 [`pre-commit`]: https://pre-commit.com
 
-[#375]: https://github.com/scikit-hep/boost-histogram/pull/375
-[#368]: https://github.com/scikit-hep/boost-histogram/pull/368
-[#365]: https://github.com/scikit-hep/boost-histogram/pull/365
-[#358]: https://github.com/scikit-hep/boost-histogram/pull/358
-[#343]: https://github.com/scikit-hep/boost-histogram/pull/343
 [#338]: https://github.com/scikit-hep/boost-histogram/pull/338
-[#359]: https://github.com/scikit-hep/boost-histogram/pull/359
-[#351]: https://github.com/scikit-hep/boost-histogram/pull/351
-[#373]: https://github.com/scikit-hep/boost-histogram/pull/373
-[#366]: https://github.com/scikit-hep/boost-histogram/pull/366
 [#340]: https://github.com/scikit-hep/boost-histogram/pull/340
+[#343]: https://github.com/scikit-hep/boost-histogram/pull/343
+[#351]: https://github.com/scikit-hep/boost-histogram/pull/351
+[#358]: https://github.com/scikit-hep/boost-histogram/pull/358
+[#359]: https://github.com/scikit-hep/boost-histogram/pull/359
 [#361]: https://github.com/scikit-hep/boost-histogram/pull/361
+[#365]: https://github.com/scikit-hep/boost-histogram/pull/365
+[#366]: https://github.com/scikit-hep/boost-histogram/pull/366
+[#368]: https://github.com/scikit-hep/boost-histogram/pull/368
+[#373]: https://github.com/scikit-hep/boost-histogram/pull/373
+[#375]: https://github.com/scikit-hep/boost-histogram/pull/375
+[#384]: https://github.com/scikit-hep/boost-histogram/pull/384
+[#385]: https://github.com/scikit-hep/boost-histogram/pull/385
+[#386]: https://github.com/scikit-hep/boost-histogram/pull/386
 
 
 ## Version 0.7.0

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -573,15 +573,13 @@ class BaseStrCategory(Axis):
             metadata = k.optional("metadata")
             options = k.options(growth=False)
 
-        # We need to make sure we support Python 2 for now :(
-        # henryiii: This shortcut possibly should be removed
-        if isinstance(categories, (type(""), type(u""))):
-            categories = list(categories)
+        # henryiii: We currently expand "abc" to "a", "b", "c" - some
+        # Python interfaces protect against that
 
         if options == {"growth"}:
-            self._ax = ca.category_str_growth(categories, metadata)
+            self._ax = ca.category_str_growth(tuple(categories), metadata)
         elif options == set():
-            self._ax = ca.category_str(categories, metadata)
+            self._ax = ca.category_str(tuple(categories), metadata)
         else:
             raise KeyError("Unsupported collection of options")
 
@@ -625,9 +623,9 @@ class BaseIntCategory(Axis):
             options = k.options(growth=False)
 
         if options == {"growth"}:
-            self._ax = ca.category_int_growth(categories, metadata)
+            self._ax = ca.category_int_growth(tuple(categories), metadata)
         elif options == set():
-            self._ax = ca.category_int(categories, metadata)
+            self._ax = ca.category_int(tuple(categories), metadata)
         else:
             raise KeyError("Unsupported collection of options")
 

--- a/src/boost_histogram/cpp/__init__.py
+++ b/src/boost_histogram/cpp/__init__.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 from .._internal.hist import histogram
 
 from . import axis, storage, accumulators, algorithm
 from .. import __version__
 
 del absolute_import, division, print_function
+
+msg = "The cpp module has been deprecated, and will be removed after 0.8.0"
+warnings.warn(msg, FutureWarning)
 
 __all__ = ("histogram", "axis", "storage", "accumulators", "algorithm", "__version__")

--- a/src/register_axis.cpp
+++ b/src/register_axis.cpp
@@ -145,14 +145,12 @@ void register_axes(py::module& mod) {
 
     register_axis_each<axis::category_int, axis::category_int_growth>(mod, [](auto ax) {
         ax.def(py::init<std::vector<int>, metadata_t>(), "categories"_a, "metadata"_a);
-        ax.def(py::init<>());
     });
 
     register_axis_each<axis::category_str, axis::category_str_growth>(mod, [](auto ax) {
         ax.def(py::init<std::vector<std::string>, metadata_t>(),
                "categories"_a,
                "metadata"_a);
-        ax.def(py::init<>());
     });
 
     ;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,29 @@
 import pytest
 
 
-@pytest.fixture(params=(False, True), ids=("nogrowth", "growth"))
+@pytest.fixture(params=(False, True), ids=("no_growth", "growth"))
 def growth(request):
+    return request.param
+
+
+@pytest.fixture(params=(False, True), ids=("no_overflow", "overflow"))
+def overflow(request):
+    return request.param
+
+
+@pytest.fixture(params=(False, True), ids=("no_underflow", "underflow"))
+def underflow(request):
+    return request.param
+
+
+@pytest.fixture(params=(False, True), ids=("no_flow", "flow"))
+def flow(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=(None, "str", 1, {"a": 1}),
+    ids=("no_metadata", "str_metadata", "int_metadata", "dict_metadata"),
+)
+def metadata(request):
     return request.param

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -580,8 +580,6 @@ class TestInteger:
             -1, 2, underflow=False
         )
 
-    @pytest.mark.parametrize("underflow", [0, 1])
-    @pytest.mark.parametrize("overflow", [0, 1])
     def test_len(self, underflow, overflow):
         a = bh.axis.Integer(-1, 3, underflow=underflow, overflow=overflow)
         assert len(a) == 4

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -647,8 +647,10 @@ class TestCategory(Axis):
     def test_init(self):
         # should not raise
         bh.axis.IntCategory([1, 2])
+        bh.axis.IntCategory({1, 2})
         bh.axis.IntCategory((1, 2), metadata="foo")
         bh.axis.StrCategory(["A", "B"])
+        bh.axis.StrCategory({"A", "B"})
         bh.axis.StrCategory("AB")
         bh.axis.StrCategory("AB", metadata="foo")
 

--- a/tests/test_benchmark_1d.py
+++ b/tests/test_benchmark_1d.py
@@ -39,7 +39,6 @@ def make_and_run_hist(flow, storage, vals):
 
 
 @pytest.mark.benchmark(group="1d-fills")
-@pytest.mark.parametrize("flow", (True, False), ids=["flow", "noflow"])
 @pytest.mark.parametrize("dtype", vals)
 @pytest.mark.parametrize("storage", STORAGES)
 def test_boost_1d(benchmark, flow, storage, dtype):

--- a/tests/test_benchmark_2d.py
+++ b/tests/test_benchmark_2d.py
@@ -45,7 +45,6 @@ def make_and_run_hist(flow, storage, vals):
 
 
 @pytest.mark.benchmark(group="2d-fills")
-@pytest.mark.parametrize("flow", (True, False), ids=["flow", "noflow"])
 @pytest.mark.parametrize("dtype", vals)
 @pytest.mark.parametrize("storage", STORAGES)
 def test_2d(benchmark, flow, storage, dtype):

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -120,7 +120,6 @@ def test_fill_int_1d():
         h[-3]
 
 
-@pytest.mark.parametrize("flow", [True, False])
 def test_fill_1d(flow):
     h = bh.Histogram(bh.axis.Regular(3, -1, 2, underflow=flow, overflow=flow))
     with pytest.raises(ValueError):
@@ -250,7 +249,6 @@ def test_grow_and_add():
     assert h3[bh.loc(2), bh.loc("ho")] == 2.0
 
 
-@pytest.mark.parametrize("flow", [True, False])
 def test_fill_2d(flow):
     h = bh.Histogram(
         bh.axis.Integer(-1, 2, underflow=flow, overflow=flow),
@@ -284,7 +282,6 @@ def test_fill_2d(flow):
                 assert get(h, i, j) == m[i][j]
 
 
-@pytest.mark.parametrize("flow", [True, False])
 def test_add_2d(flow):
     h = bh.Histogram(
         bh.axis.Integer(-1, 2, underflow=flow, overflow=flow),
@@ -323,7 +320,6 @@ def test_add_2d_bad():
         a += b
 
 
-@pytest.mark.parametrize("flow", [True, False])
 def test_add_2d_w(flow):
     h = bh.Histogram(
         bh.axis.Integer(-1, 2, underflow=flow, overflow=flow),

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -106,7 +106,6 @@ def test_metadata_str(axis, args, opts, copy_fn):
 
 
 # Special test: Deepcopy should change metadata id, copy should not
-@pytest.mark.parametrize("metadata", ({1: 2}, [1, 2, 3]))
 def test_compare_copy_axis(metadata):
     orig = bh.axis.Regular(4, 0, 2, metadata=metadata)
     new = copy.copy(orig)
@@ -114,11 +113,11 @@ def test_compare_copy_axis(metadata):
 
     assert orig.metadata is new.metadata
     assert orig.metadata == dnew.metadata
-    assert orig.metadata is not dnew.metadata
+    if metadata is not copy.copy(metadata):
+        assert orig.metadata is not dnew.metadata
 
 
 # Special test: Deepcopy should change metadata id, copy should not
-@pytest.mark.parametrize("metadata", ({1: 2}, [1, 2, 3]))
 def test_compare_copy_hist(metadata):
     orig = bh.Histogram(bh.axis.Regular(4, 0, 2, metadata=metadata))
     new = copy.copy(orig)
@@ -126,7 +125,8 @@ def test_compare_copy_hist(metadata):
 
     assert orig.axes[0].metadata is new.axes[0].metadata
     assert orig.axes[0].metadata == dnew.axes[0].metadata
-    assert orig.axes[0].metadata is not dnew.axes[0].metadata
+    if metadata is not copy.copy(metadata):
+        assert orig.axes[0].metadata is not dnew.axes[0].metadata
 
 
 @pytest.mark.parametrize("axis,args,opts", axes_creations)
@@ -189,7 +189,6 @@ def test_histogram_fancy(copy_fn):
 
 
 @pytest.mark.parametrize("copy_fn", copy_fns)
-@pytest.mark.parametrize("metadata", ("This", (1, 2, 3)))
 def test_histogram_metadata(copy_fn, metadata):
 
     hist = bh.Histogram(bh.axis.Regular(4, 1, 2, metadata=metadata))


### PR DESCRIPTION
* CPP import now produces a warning.
* Tests use more fixtures
* Changelog updates
* Cibuildwheel update
* Partial response to #380 - categories accept all iterables. 