### PR TITLE
feat: Support hist/hist division if view supports it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ on Boost.Histogram's C++ tools for actions like cropping.
 * Slicing an AxesTuple now keeps the type [#384][]
 * `ndim` replaces `rank` for NumPy compatibility [#385][]
 * Any array-like supported in fill [#391][], any iterable can be used for Categories [#392][]
+* Added Boolean axes, from Boost.Histogram 1.74 [#390][]
+* Division between histograms is supported [#393][]
 * More deprecated functionality removed
 
 #### Bug fixes
@@ -25,7 +27,7 @@ on Boost.Histogram's C++ tools for actions like cropping.
 
 #### Developer changes
 
-* Update Boost to 1.73 [#359][], PyBind11 to 2.5.0 [#351][]
+* Update Boost to 1.73 [#359][], PyBind11 to 2.5.0 [#351][], Boost.Histogram to pre-1.74 [#388][]
 * Cropping no longer uses workaround [#373][]
 * Many more checks added to [`pre-commit`][] [#366][]
 * Deprecating `cpp` interface [#391][]
@@ -50,8 +52,11 @@ on Boost.Histogram's C++ tools for actions like cropping.
 [#384]: https://github.com/scikit-hep/boost-histogram/pull/384
 [#385]: https://github.com/scikit-hep/boost-histogram/pull/385
 [#386]: https://github.com/scikit-hep/boost-histogram/pull/386
+[#388]: https://github.com/scikit-hep/boost-histogram/pull/388
+[#390]: https://github.com/scikit-hep/boost-histogram/pull/390
 [#391]: https://github.com/scikit-hep/boost-histogram/pull/391
 [#392]: https://github.com/scikit-hep/boost-histogram/pull/392
+[#393]: https://github.com/scikit-hep/boost-histogram/pull/393
 
 
 ## Version 0.7.0

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -172,17 +172,35 @@ class BaseHistogram(object):
         return self
 
     def __truediv__(self, other):
-        return self.__class__(self._hist.__truediv__(_hist_or_val(other)))
+        if isinstance(other, BaseHistogram):
+            result = self.copy()
+            result.__itruediv__(other)
+            return result
+        else:
+            return self.__class__(self._hist.__truediv__(_hist_or_val(other)))
 
     def __div__(self, other):
-        return self.__class__(self._hist.__div__(_hist_or_val(other)))
+        if isinstance(other, BaseHistogram):
+            result = self.copy()
+            result.__idiv__(other)
+            return result
+        else:
+            return self.__class__(self._hist.__div__(_hist_or_val(other)))
 
     def __itruediv__(self, other):
-        self._hist.__itruediv__(_hist_or_val(other))
+        if isinstance(other, BaseHistogram):
+            view = self.view(flow=True)
+            view.__itruediv__(other.view(flow=True))
+        else:
+            self._hist.__itruediv__(_hist_or_val(other))
         return self
 
     def __idiv__(self, other):
-        self._hist.__idiv__(_hist_or_val(other))
+        if isinstance(other, BaseHistogram):
+            view = self.view(flow=True)
+            view.__idiv__(other.view(flow=True))
+        else:
+            self._hist.__idiv__(_hist_or_val(other))
         return self
 
     def __copy__(self):

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -473,6 +473,24 @@ def test_operators():
         h + h2
 
 
+def test_hist_hist_div():
+    h1 = bh.Histogram(bh.axis.Boolean())
+    h2 = bh.Histogram(bh.axis.Boolean())
+
+    h1[:] = (8, 6)
+    h2[:] = (2, 3)
+
+    h3 = h1 / h2
+
+    assert h3[False] == 4
+    assert h3[True] == 2
+
+    h1 /= h2
+
+    assert h1[False] == 4
+    assert h1[True] == 2
+
+
 def test_project():
     h = bh.Histogram(bh.axis.Integer(0, 2), bh.axis.Integer(1, 4))
     h.fill(0, 1)


### PR DESCRIPTION
Closes #302 - Histogram/histogram division is supported using the trick recommended by @HDembinski - the work of division is passed to the view. There are two items that need to be addressed: Accumulator views should support division if that makes sense for them, and if Unlimited is upgraded so that a view does not convert it instantly to double, then this will likely need special handling (probably triggering that conversion in this case, actually). Those are beyond the scope of this PR.

After this, we will start the process for the 0.8.0 release - the SciPy Video has already gone live.