### PR TITLE
ci: Travis timeout increase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,11 @@ branches:
   only:
     - master
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
-    - henryiii/gha-test
 
 env:
   global:
     - TWINE_USERNAME=__token__
     # Set TWINE_PASSWORD in Travis UI
-    - CIBW_BUILD_VERBOSITY=1
 
 jobs:
   include:
@@ -27,7 +25,7 @@ install:
 
 script:
   - sed -i '/numpy/d' pyproject.toml
-  - travis_wait python3 -m cibuildwheel --output-dir dist
+  - CIBW_BUILD_VERBOSITY=1 python3 -m cibuildwheel --output-dir dist
 
 
 deploy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,8 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "numpy==1.13.3; python_version<='3.6'",
-    "numpy==1.14.5; python_version=='3.7'",
-    "numpy==1.17.3; python_version>='3.8'",
-    "setuptools_scm[toml]>=3.4,!=4.0.0"
+    "numpy",
+    "setuptools_scm[toml]>=4.1.2"
 ]
 
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixes a wheel build issue (we don't use NumPy's binary interface, since this is PyBind11 and not Cython, so just dropping the minimal requirement). Proper fix being worked on in https://github.com/joerick/cibuildwheel/pull/398 . Also, the timeout on Travis for ARM/PowerPC was because of the environment variable for cibuildwheel's verbose not being set, so the addition of bool fills caused this to pass 10 minutes, timing out Travis for lack of output. Now there's output while building, so it doesn't time out.