### PR TITLE
fix: warnings with NumPy 1.19

### DIFF
--- a/examples/simple_density.py
+++ b/examples/simple_density.py
@@ -4,6 +4,8 @@
 import numpy as np
 import boost_histogram as bh
 import matplotlib.pyplot as plt
+import functools
+import operator
 
 # Make a 2D histogram
 hist = bh.Histogram(bh.axis.Regular(50, -3, 3), bh.axis.Regular(50, -3, 3))
@@ -12,7 +14,7 @@ hist = bh.Histogram(bh.axis.Regular(50, -3, 3), bh.axis.Regular(50, -3, 3))
 hist.fill(np.random.normal(size=1_000_000), np.random.normal(size=1_000_000))
 
 # Compute the areas of each bin
-areas = np.prod(hist.axes.widths, axis=0)
+areas = functools.reduce(operator.mul, hist.axes.widths)
 
 # Compute the density
 density = hist.view() / hist.sum() / areas

--- a/notebooks/BoostHistogramHandsOn.ipynb
+++ b/notebooks/BoostHistogramHandsOn.ipynb
@@ -17,7 +17,9 @@
    "source": [
     "import boost_histogram as bh\n",
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "import functools\n",
+    "import operator"
    ]
   },
   {
@@ -1013,7 +1015,7 @@
     "hist7 = bh.numpy.histogram(data1 - 3.5, bins=bins, histogram=bh.Histogram)\n",
     "\n",
     "widths = hist7.axes.widths\n",
-    "area = np.prod(widths, axis=0)\n",
+    "area = functools.reduce(operator.mul, hist7.axes.widths)\n",
     "\n",
     "area"
    ]

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ extras = {
     "dev": ["ipykernel", "cloudpickle"],
 }
 extras["all"] = sum(extras.values(), [])
+extras["dev"] += extras["test"]
 
 setup(
     ext_modules=ext_modules,

--- a/src/boost_histogram/numpy.py
+++ b/src/boost_histogram/numpy.py
@@ -9,6 +9,8 @@ from . import storage as _storage
 
 from ._internal.kwargs import KWArgs as _KWArgs
 from ._internal.sig_tools import inject_signature as _inject_signature
+from functools import reduce as _reduce
+from operator import mul as _mul
 
 import numpy as _np
 
@@ -74,7 +76,7 @@ def histogramdd(
     hist = cls(*axs, storage=bh_storage).fill(*a, weight=weights, threads=threads)
 
     if density:
-        areas = np.prod(hist.axes.widths, axis=0)
+        areas = _reduce(_mul, hist.axes.widths)
         density = hist.view() / hist.sum() / areas
         return (density,) + hist.to_numpy()[1:]
 


### PR DESCRIPTION
NumPy warns now if something gets converted to an object array implicitly, which happens on things like prod with a list. So using the Python method here (better, anyway). Does change a common idiom shown in talks...

Also fixes `[dev]` extra missing `pytest`.