### PR TITLE
feat: allow quick transpose of all results

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,19 @@ it yourself (even without installing the hooks) using:
 pre-commit run --all-files
 ```
 
+We do not check `check-manifest` every time locally, since it is slow. You can trigger
+this manual check with:
+
+```
+pre-commit run --all-files --hook-stage manual check-manifest
+```
+
+Developers should update the pre-commit dependencies once in a while, you can
+do this automatically with:
+
+```bash
+pre-commit autoupdate
+```
 
 ## Common tasks
 
@@ -169,7 +182,7 @@ fish shell.
 for f in *
     cd $f
     git fetch
-    git checkout boost-1.72.0 || echo "Not found"
+    git checkout boost-1.74.0 || echo "Not found"
     cd ..
 end
 ```
@@ -180,17 +193,17 @@ end
 
 - Finish merging open PRs that you want in the new version
 - Add most recent changes to the `docs/CHANGELOG.md`
-- Sync master with develop using `git merge develop --ff-only`
-- Make sure the full wheel build runs on master without issues
+- Sync master with develop using `git merge develop --ff-only` and push
+- Make sure the full wheel build runs on master without issues (will happen
+  automatically on push to master)
 - Make the GitHub release in the GitHub UI. Copy the changelog entries and
   links for that version; this has to be done as part of the release and tag
-  procedure for archival tools (Zenodo) to pick them up correctly. Titles
-  should be roughly consistent. I like to give a little descriptive title after
-  the version, though this was a massive release that touched almost every
-  area.
+  procedure for archival tools (Zenodo) to pick them up correctly.
+    - Title should be `"Version <version number>"`
     - Version tag should be `"v" + major + "." + minor + "." + patch`.
 - GHA will build and send to PyPI for you when you release.
-- Conda-forge will automatically make a PR to update a few hours later.
+- Conda-forge will automatically make a PR to update within an hour or so, and
+  it will merge automatically if it passes.
 
 
 </details>

--- a/examples/simple_density.py
+++ b/examples/simple_density.py
@@ -19,11 +19,8 @@ areas = functools.reduce(operator.mul, hist.axes.widths)
 # Compute the density
 density = hist.view() / hist.sum() / areas
 
-# Get the edges
-X, Y = hist.axes.edges
-
 # Make the plot
 fig, ax = plt.subplots()
-mesh = ax.pcolormesh(X.T, Y.T, density.T)
+mesh = ax.pcolormesh(*hist.axes.edges.T, density.T)
 fig.colorbar(mesh)
 plt.savefig("simple_density.png")

--- a/notebooks/BoostHistogramHandsOn.ipynb
+++ b/notebooks/BoostHistogramHandsOn.ipynb
@@ -450,21 +450,14 @@
    "outputs": [],
    "source": [
     "def plothist2d(h):\n",
-    "    X, Y = h.axes.edges\n",
-    "    return plt.pcolormesh(X.T, Y.T, h.view().T)"
+    "    return plt.pcolormesh(*h.axes.edges.T, h.view().T)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is transposed because it is ij indexed instead of xy. You can also do:\n",
-    "\n",
-    "```python\n",
-    "X, Y = h.axes.edges\n",
-    "X, Y = np.broadcast_arrays(X, Y)\n",
-    "return plt.pcolormesh(X, Y, h)\n",
-    "```"
+    "This is transposed because pcolormesh requires ij indexing instead of xy."
    ]
   },
   {

--- a/notebooks/BoostHistogramHandsOn.ipynb
+++ b/notebooks/BoostHistogramHandsOn.ipynb
@@ -457,7 +457,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is transposed because pcolormesh requires ij indexing instead of xy."
+    "This is transposed because [`pcolormesh` expects it](https://matplotlib.org/3.2.2/api/_as_gen/matplotlib.pyplot.pcolormesh.html#axes-pcolormesh-grid-orientation)."
    ]
   },
   {

--- a/src/boost_histogram/_internal/axistuple.py
+++ b/src/boost_histogram/_internal/axistuple.py
@@ -8,12 +8,17 @@ import numpy as np
 del absolute_import, division, print_function
 
 
-class AxesArrayTuple(tuple):
+class ArrayTuple(tuple):
     __slots__ = ()
 
-    @property
-    def T(self):
-        return self.__class__(a.T for a in self)
+    def __getattr__(self, name):
+        return self.__class__(getattr(a, name) for a in self)
+
+    def __dir__(self):
+        return sorted(dir(self.__class__) + dir(np.ndarray))
+
+    def __call__(self, *args, **kwargs):
+        return self.__class__(a(*args, **kwargs) for a in self)
 
 
 class AxesTuple(tuple):
@@ -40,17 +45,17 @@ class AxesTuple(tuple):
     @property
     def centers(self):
         gen = (s.centers for s in self)
-        return AxesArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
+        return ArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
 
     @property
     def edges(self):
         gen = (s.edges for s in self)
-        return AxesArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
+        return ArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
 
     @property
     def widths(self):
         gen = (s.widths for s in self)
-        return AxesArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
+        return ArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
 
     def value(self, *indexes):
         if len(indexes) != len(self):

--- a/src/boost_histogram/_internal/axistuple.py
+++ b/src/boost_histogram/_internal/axistuple.py
@@ -8,6 +8,14 @@ import numpy as np
 del absolute_import, division, print_function
 
 
+class AxesArrayTuple(tuple):
+    __slots__ = ()
+
+    @property
+    def T(self):
+        return self.__class__(a.T for a in self)
+
+
 class AxesTuple(tuple):
     __slots__ = ()
     _MGRIDOPTS = {"sparse": True, "indexing": "ij"}
@@ -32,17 +40,17 @@ class AxesTuple(tuple):
     @property
     def centers(self):
         gen = (s.centers for s in self)
-        return np.meshgrid(*gen, **self._MGRIDOPTS)
+        return AxesArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
 
     @property
     def edges(self):
         gen = (s.edges for s in self)
-        return np.meshgrid(*gen, **self._MGRIDOPTS)
+        return AxesArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
 
     @property
     def widths(self):
         gen = (s.widths for s in self)
-        return np.meshgrid(*gen, **self._MGRIDOPTS)
+        return AxesArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
 
     def value(self, *indexes):
         if len(indexes) != len(self):

--- a/src/boost_histogram/_internal/axistuple.py
+++ b/src/boost_histogram/_internal/axistuple.py
@@ -20,6 +20,14 @@ class ArrayTuple(tuple):
     def __call__(self, *args, **kwargs):
         return self.__class__(a(*args, **kwargs) for a in self)
 
+    def broadcast(self):
+        """
+        The arrays in this tuple will be compressed if possible to save memory.
+        Use this method to broadcast them out into their full memory
+        representation.
+        """
+        return self.__class__(np.broadcast_arrays(*self))
+
 
 class AxesTuple(tuple):
     __slots__ = ()

--- a/tests/test_axes_object.py
+++ b/tests/test_axes_object.py
@@ -30,6 +30,7 @@ def test_axes_all_at_once():
     for i in range(3):
         np.testing.assert_allclose(centers[i], answers[i])
         np.testing.assert_allclose(centers.T[i], answers[i].T)
+        np.testing.assert_allclose(centers.flatten()[i], answers[i].flatten())
         np.testing.assert_allclose(h.axes[i].centers, answers[i].ravel())
 
     edges = h.axes.edges
@@ -38,6 +39,7 @@ def test_axes_all_at_once():
     for i in range(3):
         np.testing.assert_allclose(edges[i], answers[i])
         np.testing.assert_allclose(edges.T[i], answers[i].T)
+        np.testing.assert_allclose(edges.ravel()[i], answers[i].ravel())
         np.testing.assert_allclose(h.axes[i].edges, answers[i].ravel())
 
     widths = h.axes.widths
@@ -46,4 +48,5 @@ def test_axes_all_at_once():
     for i in range(3):
         np.testing.assert_allclose(widths[i], answers[i])
         np.testing.assert_allclose(widths.T[i], answers[i].T)
+        np.testing.assert_allclose(widths.ravel()[i], answers[i].ravel())
         np.testing.assert_allclose(h.axes[i].widths, answers[i].ravel())

--- a/tests/test_axes_object.py
+++ b/tests/test_axes_object.py
@@ -29,6 +29,7 @@ def test_axes_all_at_once():
 
     for i in range(3):
         np.testing.assert_allclose(centers[i], answers[i])
+        np.testing.assert_allclose(centers.T[i], answers[i].T)
         np.testing.assert_allclose(h.axes[i].centers, answers[i].ravel())
 
     edges = h.axes.edges
@@ -36,6 +37,7 @@ def test_axes_all_at_once():
 
     for i in range(3):
         np.testing.assert_allclose(edges[i], answers[i])
+        np.testing.assert_allclose(edges.T[i], answers[i].T)
         np.testing.assert_allclose(h.axes[i].edges, answers[i].ravel())
 
     widths = h.axes.widths
@@ -43,4 +45,5 @@ def test_axes_all_at_once():
 
     for i in range(3):
         np.testing.assert_allclose(widths[i], answers[i])
+        np.testing.assert_allclose(widths.T[i], answers[i].T)
         np.testing.assert_allclose(h.axes[i].widths, answers[i].ravel())

--- a/tests/test_axes_object.py
+++ b/tests/test_axes_object.py
@@ -26,8 +26,10 @@ def test_axes_all_at_once():
 
     centers = h.axes.centers
     answers = np.ogrid[0.5:10, 0.5:5, 0.5:2]
+    full_answers = np.mgrid[0.5:10, 0.5:5, 0.5:2]
 
     for i in range(3):
+        np.testing.assert_allclose(centers.broadcast()[i], full_answers[i])
         np.testing.assert_allclose(centers[i], answers[i])
         np.testing.assert_allclose(centers.T[i], answers[i].T)
         np.testing.assert_allclose(centers.flatten()[i], answers[i].flatten())
@@ -35,8 +37,10 @@ def test_axes_all_at_once():
 
     edges = h.axes.edges
     answers = np.ogrid[0:11, 0:6, 0:3]
+    full_answers = np.mgrid[0:11, 0:6, 0:3]
 
     for i in range(3):
+        np.testing.assert_allclose(edges.broadcast()[i], full_answers[i])
         np.testing.assert_allclose(edges[i], answers[i])
         np.testing.assert_allclose(edges.T[i], answers[i].T)
         np.testing.assert_allclose(edges.ravel()[i], answers[i].ravel())
@@ -44,8 +48,10 @@ def test_axes_all_at_once():
 
     widths = h.axes.widths
     answers = np.ogrid[1:1:10j, 1:1:5j, 1:1:2j]
+    full_answers = np.mgrid[1:1:10j, 1:1:5j, 1:1:2j]
 
     for i in range(3):
+        np.testing.assert_allclose(widths.broadcast()[i], full_answers[i])
         np.testing.assert_allclose(widths[i], answers[i])
         np.testing.assert_allclose(widths.T[i], answers[i].T)
         np.testing.assert_allclose(widths.ravel()[i], answers[i].ravel())


### PR DESCRIPTION
@HDembinski , this is what my suggestion in #412 would look like. There are two possible methods. The first commit simply adds `.T`. The second commit allows any `np.array` action to operate on the tuple. So `h.axes.edges.ravel()` is also valid. (or `.flatten()`, but that always makes a copy). Tab completion still works in IPython (just not static typing). This feels just like the AxesTuple itself, actions are applied to each item in the tuple.