### PR TITLE
fix: nicer error message for indexing failures

### DIFF
--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -45,7 +45,11 @@ class Axis(object):
         if not _isstr(value):
             return self._ax.index(value)
         else:
-            raise TypeError("index(value) cannot be a string for a numerical axis")
+            raise TypeError(
+                "index({value}) cannot be a string for a numerical axis".format(
+                    value=value
+                )
+            )
 
     def value(self, index):
         """
@@ -536,7 +540,9 @@ class StrCategory(BaseCategory):
             return self._ax.index(value)
         else:
             raise TypeError(
-                "index(value) must be a string or iterable of strings for a StrCategory axis"
+                "index({value}) must be a string or iterable of strings for a StrCategory axis".format(
+                    value=value
+                )
             )
 
     def _repr_args(self):

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -577,6 +577,14 @@ class Histogram(object):
                 raise IndexError(
                     "Must be a slice, an integer, or follow the locator protocol."
                 )
+            # If the dictionary brackets are forgotten, it's easy to put a slice
+            # into a slice - adding a nicer error message in that case
+            if any(isinstance(v, slice) for v in (ind.start, ind.stop, ind.step)):
+                raise TypeError(
+                    "You have put a slice in a slice. Did you forget curly braces [{...}]?"
+                )
+
+            # This ensures that callable start/stop are handled
             start, stop = self.axes[i]._process_loc(ind.start, ind.stop)
 
             if ind != slice(None):


### PR DESCRIPTION
Slightly more helpful if you mix up indices; this way you know a bit more about the str/int that was failing.