### PR TITLE
refactor: use custom boolean, faster compile, simpler fill

### DIFF
--- a/include/bh_python/axis.hpp
+++ b/include/bh_python/axis.hpp
@@ -112,13 +112,16 @@ class boolean : public bh::axis::integer<int, metadata_t, option::none_t> {
   public:
     explicit boolean(metadata_t meta = {})
         : integer(0, 2, std::move(meta)) {}
+    explicit boolean(const boolean& src,
+                     bh::axis::index_type begin,
+                     bh::axis::index_type end,
+                     unsigned merge)
+        : integer(src, begin, end, merge) {}
     boolean(const boolean& other)
         : integer(other) {}
     bh::axis::index_type index(int x) const noexcept {
-        return static_cast<bh::axis::index_type>(x != 0);
+        return integer::index(x == 0 ? 0 : 1);
     }
-    int value(bh::axis::index_type i) const noexcept { return static_cast<int>(i); }
-    bh::axis::index_type size() const noexcept { return 2; }
 };
 
 // Built-in boolean requires bool fill, slower compile

--- a/include/bh_python/axis.hpp
+++ b/include/bh_python/axis.hpp
@@ -115,7 +115,7 @@ class boolean : public bh::axis::integer<int, metadata_t, option::none_t> {
     boolean(const boolean& other)
         : integer(other) {}
     bh::axis::index_type index(int x) const noexcept {
-        return static_cast<bh::axis::index_type>(x < 0 ? -1 : (x > 2 ? 2 : x));
+        return static_cast<bh::axis::index_type>(x != 0);
     }
     int value(bh::axis::index_type i) const noexcept { return static_cast<int>(i); }
     bh::axis::index_type size() const noexcept { return 2; }

--- a/include/bh_python/axis.hpp
+++ b/include/bh_python/axis.hpp
@@ -108,7 +108,21 @@ using category_str_growth
 BHP_SPECIALIZE_NAME(category_str)
 BHP_SPECIALIZE_NAME(category_str_growth)
 
-using boolean = bh::axis::boolean<metadata_t>;
+class boolean : public bh::axis::integer<int, metadata_t, option::none_t> {
+  public:
+    explicit boolean(metadata_t meta = {})
+        : integer(0, 2, std::move(meta)) {}
+    boolean(const boolean& other)
+        : integer(other) {}
+    bh::axis::index_type index(int x) const noexcept {
+        return static_cast<bh::axis::index_type>(x < 0 ? -1 : (x > 2 ? 2 : x));
+    }
+    int value(bh::axis::index_type i) const noexcept { return static_cast<int>(i); }
+    bh::axis::index_type size() const noexcept { return 2; }
+};
+
+// Built-in boolean requires bool fill, slower compile
+// using boolean = bh::axis::boolean<metadata_t>;
 BHP_SPECIALIZE_NAME(boolean)
 
 // Axis defined elsewhere

--- a/include/bh_python/fill.hpp
+++ b/include/bh_python/fill.hpp
@@ -32,8 +32,8 @@ namespace variant = boost::variant2;
 static_assert(
     mp11::mp_empty<mp11::mp_set_difference<
         mp11::mp_unique<mp11::mp_transform<bh::axis::traits::value_type, axis_variant>>,
-        mp11::mp_list<double, int, std::string, bool>>>::value,
-    "supported value types are double, int, std::string, bool; "
+        mp11::mp_list<double, int, std::string>>>::value,
+    "supported value types are double, int, std::string; "
     "new axis was added with different value type");
 
 template <class T>
@@ -60,7 +60,7 @@ struct c_array_t<std::string> : std::vector<std::string> {
     }
 };
 
-// for int, double, bool
+// for int, double
 template <class T>
 bool is_value(py::handle h) {
     if(py::isinstance<py::array>(h) && py::cast<py::array>(h).ndim() > 0)
@@ -99,8 +99,6 @@ using arg_t = variant::variant<c_array_t<double>,
                                double,
                                c_array_t<int>,
                                int,
-                               c_array_t<bool>,
-                               bool,
                                c_array_t<std::string>,
                                std::string>;
 
@@ -116,7 +114,7 @@ inline auto get_vargs(const vector_axis_variant& axes, const py::args& args) {
         axes,
         [args_it = args.begin(), vargs_it = vargs.begin()](const auto& ax) mutable {
             using T = bh::axis::traits::value_type<std::decay_t<decltype(ax)>>;
-            // T is one of: int, double, std::string, bool
+            // T is one of: int, double, std::string
 
             const auto& x = *args_it++;
             auto& v       = *vargs_it++;

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -551,9 +551,6 @@ class Histogram(object):
 
         indexes = self._compute_commonindex(index)
 
-        # Workaround for missing "pick" and no reduction on bool axes
-        pick_bool = {}
-
         # If this is (now) all integers, return the bin contents
         # But don't try *dict!
         if not hasattr(indexes, "items"):
@@ -568,11 +565,7 @@ class Histogram(object):
         # Compute needed slices and projections
         for i, ind in enumerate(indexes):
             if hasattr(ind, "__index__"):
-                if isinstance(self.axes[i]._ax, _core.axis.boolean):
-                    pick_bool[i] = ind
-                    ind = slice(None, None, sum)
-                else:
-                    ind = slice(ind.__index__(), ind.__index__() + 1, sum)
+                ind = slice(ind.__index__(), ind.__index__() + 1, sum)
 
             elif not isinstance(ind, slice):
                 raise IndexError(
@@ -612,13 +605,6 @@ class Histogram(object):
                         )
 
                 slices.append(_core.algorithm.slice_and_rebin(i, start, stop, merge))
-
-        for i, select in pick_bool.items():
-            self = self.copy()
-            view = self.view(flow=True)
-            view[
-                tuple(~select if j == i else slice(None) for j in range(self.ndim))
-            ] = 0
 
         reduced = self._hist.reduce(*slices)
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -667,6 +667,14 @@ def test_pickle_1():
     assert a == b
 
 
+def test_fill_bool_not_bool():
+    a = bh.Histogram(bh.axis.Boolean())
+
+    a.fill([0, 1, 1, 7, -3])
+
+    assert_array_equal(a.view(), [1, 2])
+
+
 def test_pick_bool():
     a = bh.Histogram(bh.axis.Boolean(), bh.axis.Boolean(metadata={"one": 1}))
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -672,7 +672,7 @@ def test_fill_bool_not_bool():
 
     a.fill([0, 1, 1, 7, -3])
 
-    assert_array_equal(a.view(), [1, 2])
+    assert_array_equal(a.view(), [1, 4])
 
 
 def test_pick_bool():


### PR DESCRIPTION
Suggested by @HDembinski. This should restore the compile times, make it easier to compile `register_histograms.cpp` in under 10 minutes on simulated ARM reliably, and still keeps part of the performance boost by not having state in the axis type.