### PR TITLE
fix: support reductions again

### DIFF
--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -8,6 +8,8 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from io import BytesIO
 import sys
+import operator
+import functools
 
 try:
     import cPickle as pickle
@@ -1201,3 +1203,12 @@ def test_mul_shallow():
 
     assert h.metadata is h2.metadata
     assert h.axes[0].metadata is h2.axes[0].metadata
+
+
+def test_reductions():
+    h = bh.Histogram(bh.axis.Variable([1, 2, 4, 7, 9, 9.5, 10]))
+
+    widths_1 = functools.reduce(operator.mul, h.axes.widths)
+    widths_2 = np.prod(h.axes.widths, axis=0)
+
+    assert_array_equal(widths_1, widths_2)


### PR DESCRIPTION
NumPy unconditionally calls matching named attrs when reducing. This restores the old behavior when reducing, _and_ still gets rid of the warning that occurs in NumPy 1.19 if this was just a raw Tuple. Also filters `_*` attributes, so we don't trigger anything surprising.

Note that we changed to the correct Python reductions recently, due to the warning, which is why the tests didn't catch that they completely fail in 0.10.0, rather than just showing a warning. But now we are able to fix the warning, too.

TLDR: `np.prod(x)` calls `x.prod()`, so that needs to be handled differently.

TODO: Add tests