### PR TITLE
fix: view ops correctly supported on WeightedSum View

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,24 @@
 # What's new in boost-histogram
 
 ## Version 0.10
+### Version 0.10.1
+
+Several fixes were made, mostly related to Weight storage histograms from Uproot 4.
+
+#### Bug fixes
+
+* Reduction on `h.axes.widths` supported again [#428][]
+* Operations shallow copy (non-copyable metadata supported) [#433][]
+* Pandas Series as samples/weights supported [#434][]
+* WeightedSumView supports standard array operations [#432][]
+
+
+[#428]: https://github.com/scikit-hep/boost-histogram/pull/428
+[#433]: https://github.com/scikit-hep/boost-histogram/pull/433
+[#434]: https://github.com/scikit-hep/boost-histogram/pull/434
+[#432]: https://github.com/scikit-hep/boost-histogram/pull/432
+
+
 ### Version 0.10.0
 
 This version was released during PyHEP 2020. Several improvements were made to
@@ -16,6 +34,7 @@ usability when plotting and indexing.
 * AxesTuple now available publicly for subprojects [#419][]
 
 #### Bug fixes
+
 * Histograms support operations with arrays, no longer take the first element only [#417][]
 
 [#414]: https://github.com/scikit-hep/boost-histogram/pull/414
@@ -40,10 +59,12 @@ along with a few new features to better support downstream projects.
 * Deprecated `cpp` module removed [#402][]
 
 #### Developer changes
+
 * Subclasses can override axes generation [#401][]
 * `[dev]` extra now installs `pytest` [#401][]
 
 #### Bug fixes
+
 * Fix `numpy.histogramdd` return structure [#406][]
 * Travis deploy multi-arch fixes [#399][]
 * Selecting on a bool axes supports 2D+ histograms [#398][]

--- a/src/boost_histogram/_internal/view.py
+++ b/src/boost_histogram/_internal/view.py
@@ -100,42 +100,45 @@ class WeightedSumView(View):
                 return result.view(self.__class__)
 
         if method == "__call__" and len(inputs) == 2:
+            input_0 = inputs[0]
+            input_1 = np.asarray(inputs[1])
+
             (result,) = kwargs.pop("out", [np.empty(self.shape, self.dtype)])
 
             # Addition of two views
-            if isinstance(inputs[1], self.__class__):
+            if input_0.dtype == input_1.dtype:
                 if ufunc in {np.add}:
                     ufunc(
-                        inputs[0]["value"],
-                        inputs[1]["value"],
+                        input_0["value"],
+                        input_1["value"],
                         out=result["value"],
                         **kwargs
                     )
                     ufunc(
-                        inputs[0]["variance"],
-                        inputs[1]["variance"],
+                        input_0["variance"],
+                        input_1["variance"],
                         out=result["variance"],
                         **kwargs
                     )
                     return result.view(self.__class__)
 
             # View with normal value or array
-            elif not isinstance(inputs[1], self.__class__):
+            else:
                 if ufunc in {np.add, np.subtract}:
-                    ufunc(inputs[0]["value"], inputs[1], out=result["value"], **kwargs)
+                    ufunc(input_0["value"], input_1, out=result["value"], **kwargs)
                     np.add(
-                        inputs[0]["variance"],
-                        inputs[1] ** 2,
+                        input_0["variance"],
+                        input_1 ** 2,
                         out=result["variance"],
                         **kwargs
                     )
                     return result.view(self.__class__)
 
                 elif ufunc in {np.multiply, np.divide, np.true_divide, np.floor_divide}:
-                    ufunc(inputs[0]["value"], inputs[1], out=result["value"], **kwargs)
+                    ufunc(input_0["value"], input_1, out=result["value"], **kwargs)
                     ufunc(
-                        inputs[0]["variance"],
-                        np.abs(inputs[1]),
+                        input_0["variance"],
+                        np.abs(input_1),
                         out=result["variance"],
                         **kwargs
                     )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+import boost_histogram as bh
+from numpy.testing import assert_allclose
+import pytest
+
+
+@pytest.fixture
+def v():
+    h = bh.Histogram(bh.axis.Integer(0, 4), storage=bh.storage.Weight())
+    h.fill([1, 1, 1, 2, 2, 3])
+    return h.view()
+
+
+def test_basic_view(v):
+    assert_allclose(v.value, [0, 3, 2, 1])
+    assert_allclose(v.variance, [0, 3, 2, 1])
+
+
+def test_view_mul(v):
+    v2 = v * 2
+    assert_allclose(v2.value, [0, 6, 4, 2])
+    assert_allclose(v2.variance, [0, 6, 4, 2])
+
+    v2 = v * (-2)
+    assert_allclose(v2.value, [0, -6, -4, -2])
+    assert_allclose(v2.variance, [0, 6, 4, 2])
+
+    v *= 2
+    assert_allclose(v.value, [0, 6, 4, 2])
+    assert_allclose(v.variance, [0, 6, 4, 2])
+
+
+def test_view_div(v):
+    v2 = v / 2
+    assert_allclose(v2.value, [0, 1.5, 1, 0.5])
+    assert_allclose(v2.variance, [0, 1.5, 1, 0.5])
+
+    v2 = v / (-0.5)
+    assert_allclose(v2.value, [0, -6, -4, -2])
+    assert_allclose(v2.variance, [0, 6, 4, 2])
+
+    v /= 0.5
+    assert_allclose(v.value, [0, 6, 4, 2])
+    assert_allclose(v.variance, [0, 6, 4, 2])
+
+
+def test_view_add(v):
+    v2 = v + 1
+    assert_allclose(v2.value, [1, 4, 3, 2])
+    assert_allclose(v2.variance, [1, 4, 3, 2])
+
+    v2 = v + 2
+    assert_allclose(v2.value, [2, 5, 4, 3])
+    assert_allclose(v2.variance, [4, 7, 6, 5])
+
+    v += 2
+    assert_allclose(v.value, [2, 5, 4, 3])
+    assert_allclose(v.variance, [4, 7, 6, 5])
+
+
+def test_view_sub(v):
+    v2 = v - 1
+    assert_allclose(v2.value, [-1, 2, 1, 0])
+    assert_allclose(v2.variance, [1, 4, 3, 2])
+
+    v2 = v - 2
+    assert_allclose(v2.value, [-2, 1, 0, -1])
+    assert_allclose(v2.variance, [4, 7, 6, 5])
+
+    v -= 2
+    assert_allclose(v.value, [-2, 1, 0, -1])
+    assert_allclose(v.variance, [4, 7, 6, 5])
+
+
+def test_view_unary(v):
+    v2 = +v
+    assert_allclose(v.value, v2.value)
+    assert_allclose(v.variance, v2.variance)
+
+    v2 = -v
+    assert_allclose(-v.value, v2.value)
+    assert_allclose(v.variance, v2.variance)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import division
+
 import boost_histogram as bh
 from numpy.testing import assert_allclose
 import pytest
@@ -21,6 +23,10 @@ def test_view_mul(v):
     assert_allclose(v2.value, [0, 6, 4, 2])
     assert_allclose(v2.variance, [0, 6, 4, 2])
 
+    v2 = 2 * v
+    assert_allclose(v2.value, [0, 6, 4, 2])
+    assert_allclose(v2.variance, [0, 6, 4, 2])
+
     v2 = v * (-2)
     assert_allclose(v2.value, [0, -6, -4, -2])
     assert_allclose(v2.variance, [0, 6, 4, 2])
@@ -39,6 +45,10 @@ def test_view_div(v):
     assert_allclose(v2.value, [0, -6, -4, -2])
     assert_allclose(v2.variance, [0, 6, 4, 2])
 
+    v2 = 1 / v[1:]
+    assert_allclose(v2.value, [1 / 3, 1 / 2, 1])
+    assert_allclose(v2.variance, [1 / 3, 1 / 2, 1])
+
     v /= 0.5
     assert_allclose(v.value, [0, 6, 4, 2])
     assert_allclose(v.variance, [0, 6, 4, 2])
@@ -50,6 +60,10 @@ def test_view_add(v):
     assert_allclose(v2.variance, [1, 4, 3, 2])
 
     v2 = v + 2
+    assert_allclose(v2.value, [2, 5, 4, 3])
+    assert_allclose(v2.variance, [4, 7, 6, 5])
+
+    v2 = 2 + v
     assert_allclose(v2.value, [2, 5, 4, 3])
     assert_allclose(v2.variance, [4, 7, 6, 5])
 
@@ -66,6 +80,10 @@ def test_view_sub(v):
     v2 = v - 2
     assert_allclose(v2.value, [-2, 1, 0, -1])
     assert_allclose(v2.variance, [4, 7, 6, 5])
+
+    v2 = 1 - v
+    assert_allclose(v2.value, [1, -2, -1, 0])
+    assert_allclose(v2.variance, [1, 4, 3, 2])
 
     v -= 2
     assert_allclose(v.value, [-2, 1, 0, -1])

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -80,3 +80,21 @@ def test_view_unary(v):
     v2 = -v
     assert_allclose(-v.value, v2.value)
     assert_allclose(v.variance, v2.variance)
+
+
+def test_view_add_same(v):
+    v2 = v + v
+
+    assert_allclose(v.value * 2, v2.value)
+    assert_allclose(v.variance * 2, v2.variance)
+
+    v2 = v + v[1]
+    assert_allclose(v.value + 3, v2.value)
+    assert_allclose(v.variance + 3, v2.variance)
+
+    v2 = v + bh.accumulators.WeightedSum(5, 6)
+    assert_allclose(v.value + 5, v2.value)
+    assert_allclose(v.variance + 6, v2.variance)
+
+    with pytest.raises(TypeError):
+        v2 = v + bh.accumulators.WeightedMean(1, 2, 5, 6)


### PR DESCRIPTION
Fix for comment in #431 by @colizz; expands NEP 13 support for WeighedSum View. Scalars like `WeighedSum()` are now supported too!