### PR TITLE
fix: ops do shallow copy

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -182,7 +182,7 @@ class Histogram(object):
         return self.view(False)
 
     def __add__(self, other):
-        result = self.copy()
+        result = self.copy(deep=False)
         return result.__iadd__(other)
 
     def __iadd__(self, other):
@@ -206,18 +206,18 @@ class Histogram(object):
 
     # If these fail, the underlying object throws the correct error
     def __mul__(self, other):
-        result = self.copy()
+        result = self.copy(deep=False)
         return result._compute_inplace_op("__imul__", other)
 
     def __rmul__(self, other):
         return self * other
 
     def __truediv__(self, other):
-        result = self.copy()
+        result = self.copy(deep=False)
         return result._compute_inplace_op("__itruediv__", other)
 
     def __div__(self, other):
-        result = self.copy()
+        result = self.copy(deep=False)
         return result._compute_inplace_op("__idiv__", other)
 
     def _compute_inplace_op(self, name, other):

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1186,3 +1186,18 @@ def test_add_broadcast():
 
     h5 = h + np.ones((1, 22))
     assert h5.sum(flow=True) == 12 * 22
+
+
+# Issue #431
+def test_mul_shallow():
+    import threading
+
+    my_lock = threading.Lock()
+
+    h = bh.Histogram(bh.axis.Integer(0, 3, metadata=my_lock), metadata=my_lock)
+    h.fill([0, 0, 0, 1])
+
+    h2 = h * 2
+
+    assert h.metadata is h2.metadata
+    assert h.axes[0].metadata is h2.axes[0].metadata


### PR DESCRIPTION
Fix for actual issue in #431. (still need info from @jpivarski as to why a lock is in Histogram metadata, but now simple operations do shallow copies, which was the original intent).