### PR TITLE
fix: pandas weights/samples, TypeError for extra kwargs

### DIFF
--- a/include/bh_python/kwargs.hpp
+++ b/include/bh_python/kwargs.hpp
@@ -49,6 +49,6 @@ inline void none_only_arg(py::kwargs& kwargs, const char* name) {
 inline void finalize_args(const py::kwargs& kwargs) {
     if(kwargs.size() > 0) {
         auto keys = py::str(", ").attr("join")(kwargs.attr("keys")());
-        throw py::key_error(py::str("Unidentified keyword(s) found: {0}").format(keys));
+        throw py::type_error(py::str("Keyword(s) {0} not expected").format(keys));
     }
 }

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -78,9 +78,9 @@ def test_fill_int_1d():
         h.fill()
     with pytest.raises(ValueError):
         h.fill(1, 2)
-    with pytest.raises(KeyError) as k:
+    with pytest.raises(TypeError) as k:
         h.fill(1, fiddlesticks=2)
-    assert k.value.args[0] == "Unidentified keyword(s) found: fiddlesticks"
+    assert k.value.args[0] == "Keyword(s) fiddlesticks not expected"
 
     h.fill(-3)
     assert h.empty()
@@ -963,13 +963,13 @@ def test_fill_with_sequence_1():
     assert a[1].value == 8
     assert a[2].value == 6
 
-    with pytest.raises(KeyError):
+    with pytest.raises(TypeError):
         a.fill((1, 2), foo=(1, 1))
     with pytest.raises(ValueError):
         a.fill((1, 2, 3), weight=(1, 2))
     with pytest.raises(ValueError):
         a.fill((1, 2), weight="ab")
-    with pytest.raises(KeyError):
+    with pytest.raises(TypeError):
         a.fill((1, 2), weight=(1, 1), foo=1)
     with pytest.raises(ValueError):
         a.fill((1, 2), weight=([1, 1], [2, 2]))

--- a/tests/test_pandaslike.py
+++ b/tests/test_pandaslike.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import boost_histogram as bh
+import numpy as np
+
+
+# This is not a reasonable approximation of Pandas, but rather a test for an
+# arbitrary convertible object (but if this works, so does Pandas)
+class Seriesish(object):
+    def __init__(self, array):
+        self.array = np.asarray(array)
+
+    def __array__(self):
+        return self.array
+
+
+def test_setting_weighted_profile_convertable():
+    h = bh.Histogram(bh.axis.Regular(10, 0, 10), storage=bh.storage.WeightedMean())
+    data = Seriesish([0.3, 0.3, 0.4, 1.2, 1.6])
+    samples = Seriesish([1, 2, 3, 4, 4])
+    weights = Seriesish([1, 1, 1, 1, 2])
+
+    h.fill(data, sample=samples, weight=weights)
+
+    assert h[0] == bh.accumulators.WeightedMean(
+        sum_of_weights=3, sum_of_weights_squared=3, value=2, variance=1
+    )
+    assert h[1] == bh.accumulators.WeightedMean(
+        sum_of_weights=3, sum_of_weights_squared=5, value=4, variance=0
+    )


### PR DESCRIPTION
Fix #380 and add test.

Also converts `.fill` to kwargs, raises correct error now.