### PR TITLE
fix: array division issues

### DIFF
--- a/src/boost_histogram/_internal/axistuple.py
+++ b/src/boost_histogram/_internal/axistuple.py
@@ -20,7 +20,7 @@ class ArrayTuple(tuple):
         if name.startswith("_"):
             return super().__getattr__(name)
         elif name in self._REDUCTIONS:
-            return partial(getattr(np, name), np.asarray(tuple(self), dtype=object))
+            return partial(getattr(np, name), np.broadcast_arrays(*self))
         else:
             return self.__class__(getattr(a, name) for a in self)
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -245,7 +245,9 @@ class Histogram(object):
                 getattr(view, name)(other)
             else:
                 raise ValueError(
-                    "Wrong shape, expected {0} or {1}".format(self.shape, self.extent)
+                    "Wrong shape {0}, expected {1} or {2}".format(
+                        other.shape, self.shape, self.axes.extent
+                    )
                 )
         else:
             view = self.view(flow=False)

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -230,7 +230,7 @@ class Histogram(object):
             getattr(self._hist, name)(other._hist)
         elif isinstance(other, _histograms):
             getattr(self._hist, name)(other)
-        elif hasattr(other, "shape"):
+        elif hasattr(other, "shape") and other.shape:
             if len(other.shape) != self.ndim:
                 raise ValueError(
                     "Number of dimensions {0} must match histogram {1}".format(

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1212,3 +1212,21 @@ def test_reductions():
     widths_2 = np.prod(h.axes.widths, axis=0)
 
     assert_array_equal(widths_1, widths_2)
+
+
+# Issue 435
+def test_np_scalars():
+    hist = bh.Histogram(bh.axis.Regular(30, 1, 500, transform=bh.axis.transform.log))
+    hist.fill([7, 7])
+
+    hist2 = hist / np.float64(2.0)
+    assert hist2[bh.loc(7)] == 1.0
+
+    hist2 = hist / hist.axes.widths.prod(axis=0)
+    assert hist2[bh.loc(7)] == approx(1.3467513416439476)
+
+    with pytest.raises(ValueError):
+        hist / np.array([1, 2, 3])
+
+    hist /= np.float64(2.0)
+    assert hist[bh.loc(7)] == 1.0


### PR DESCRIPTION
There was an issue when applying a NumPy scalar to a histogram, brought up in, and fixes #435. I've improved the error message, avoid returning object array from reductions (making reductions on ArrayTuples useful), and fixed the 0 dimensional scalar (the actual problem in #435).