### PR TITLE
fix: drop fill print statement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   hooks:
   - id: flake8
     exclude: docs/conf.py
-    additional_dependencies: [flake8-bugbear]
+    additional_dependencies: [flake8-bugbear, flake8-print]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.782

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,21 @@
 # What's new in boost-histogram
 
 ## Version 0.10
+### Version 0.10.2
+
+Quick fix for extra print statement in fill.
+
+#### Bug fixes
+
+* Fixed debugging print statement in fill. [#438]
+
+#### Developer changes
+
+* Added CI/pre-commit check for print statements [#438]
+
+[#438]: https://github.com/scikit-hep/boost-histogram/pull/438
+
+
 ### Version 0.10.1
 
 Several fixes were made, mostly related to Weight storage histograms from Uproot 4.

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,8 +58,15 @@ testpaths =
 [flake8]
 max-line-length = 80
 max-complexity = 13
-select = C, E, F, W, B, B9
+select = C, E, F, W, B, B9, T
 ignore = E203, E231, E501, E722, W503, B950
+per-file-ignores =
+    tests/*: T
+    examples/*: T
+    notebooks/*: T
+    docs/*: T
+    scripts/*: T
+    setup.py: T
 
 [mypy]
 warn_unused_configs = True

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -292,7 +292,6 @@ class Histogram(object):
         args = _fill_cast(args)
         weight = _fill_cast(weight)
         sample = _fill_cast(sample)
-        print(args, weight, sample)
 
         if threads is None or threads == 1:
             self._hist.fill(*args, weight=weight, sample=sample)


### PR DESCRIPTION
For #437. Won't close that issue until 0.10.2. @HDembinski should we push a quick 0.10.2 with just this fix? Or should we wait a little to see if anything else comes up? The printing when filling is really irritating (though it is just an irritant).

I'm still looking into this to see if there's a good way to detect this in tests or pre-commit for the future (0.7.0 had the same issue in a different place). Edit: Now we have CI and pre-commit ensuring this never happens again!