### PR TITLE
ci: winwheel dirty directory bug

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: actions/setup-python@v2
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.5.2
+      run: python -m pip install cibuildwheel==1.5.5
 
     - name: Build wheel
       run: python -m cibuildwheel --output-dir wheelhouse
@@ -81,6 +81,10 @@ jobs:
 
     - name: Show files
       run: ls -lh wheelhouse
+      shell: bash
+
+    - name: Verify clean directory
+      run: git diff --exit-code
       shell: bash
 
     - name: Upload wheels
@@ -102,7 +106,7 @@ jobs:
     - uses: actions/setup-python@v2
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.5.2
+      run: python -m pip install cibuildwheel==1.5.5
 
     - uses: ilammy/msvc-dev-cmd@v1
 
@@ -126,6 +130,10 @@ jobs:
 
     - name: Show files
       run: ls -lh wheelhouse
+      shell: bash
+
+    - name: Verify clean directory
+      run: git diff --exit-code
       shell: bash
 
     - uses: actions/upload-artifact@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ requires = [
     "setuptools>=42",
     "wheel",
     "numpy",
-    "setuptools_scm[toml]>=4.1.2"
+    "toml",
+    "setuptools_scm>=4.1.2"
 ]
 
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Running cibuildwheel creates a dirty git directory on Windows.

Manually triggered an upload for the missing 0.10.2 Windows wheels, this should should workaround and watch for this problem again. Issue raised upstream, too. https://github.com/joerick/cibuildwheel/issues/421