### PR TITLE
fix: scalar failed in ND fill

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -42,7 +42,7 @@ def _fill_cast(value, inner=False):
     elif not inner and isinstance(value, (tuple, list)):
         return tuple(_fill_cast(a, inner=True) for a in value)
     elif hasattr(value, "__iter__") or hasattr(value, "__array__"):
-        return np.ascontiguousarray(value)
+        return np.asarray(value)
     else:
         return value
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -283,6 +283,9 @@ def test_fill_2d(flow):
             for j in range(-flow, h.axes[1].size + flow):
                 assert get(h, i, j) == m[i][j]
 
+    h.fill(1, [1, 2])
+    h.fill(np.float64(1), [1, 2])
+
 
 def test_add_2d(flow):
     h0 = bh.Histogram(


### PR DESCRIPTION
This should both fix the linked issue, as well avoid an extra copy when the dtype is non-matching and the array is non-contigious. Pybind11 makes a copy if either of those are not true; but we were making a copy here but keeping the dtype, possibly making two copies.

Closes #452.
