### PR TITLE
chore: cleanup and labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# Add 'needs changelog` label to any change to code files as long as the `CHANGELOG` hasn't changed
+needs changelog:
+- any: ['src/**/*.py', 'src/**/*.cpp', 'include/**/*.hpp']
+  all: ['!docs/CHANGELOG.md']

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        sync-labels: true

--- a/include/bh_python/transform.hpp
+++ b/include/bh_python/transform.hpp
@@ -71,8 +71,8 @@ struct func_transform {
             auto c = py::reinterpret_borrow<py::capsule>(
                 PyCFunction_GET_SELF(cfunc.ptr()));
 
-            // NOLINTNEXTLINE(google-readability-casting)
-            auto rec = (py::detail::function_record*)(c);
+            // This calls operator T* (PyCapsule_SetPointer)
+            auto rec = static_cast<py::detail::function_record*>(c);
 
             if(rec && rec->is_stateless
                && py::detail::same_type(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = boost_histogram
 author = Hans Dembinski and Henry Schreiner
-author_email="hschrein@cern.ch",
+author_email = hschrein@cern.ch
 maintainer = Hans Dembinski and Henry Schreiner
 maintainer_email = hschrein@cern.ch
 url = https://github.com/scikit-hep/boost-histogram


### PR DESCRIPTION
Quotes get (incorrectly) added to the METADATA file. Adds one small cleanup, and adds a labeler that adds a needs changelog label on any PR that doesn't have a change to the changelog.