### PR TITLE
ci: fix Win PyPy and Py2 builds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: black
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.3.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -26,20 +26,20 @@ repos:
     additional_dependencies: [pyyaml]
 
 - repo: https://github.com/pycqa/flake8
-  rev: 3.8.3
+  rev: 3.8.4
   hooks:
   - id: flake8
     exclude: docs/conf.py
     additional_dependencies: [flake8-bugbear, flake8-print]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.782
+  rev: v0.790
   hooks:
   - id: mypy
     files: src
 
 - repo: https://github.com/mgedmin/check-manifest
-  rev: "0.43"
+  rev: "0.44"
   hooks:
   - id: check-manifest
     stages: [manual]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,6 @@
 graft include
-graft scripts
 graft src
 graft tests
-graft docs
 
 graft extern/assert/include
 graft extern/config/include
@@ -17,8 +15,6 @@ graft extern/pybind11/tools
 graft extern/pybind11/pybind11
 include extern/pybind11/CMakeLists.txt
 
-prune docs/_build
-
 global-exclude .git*
 global-exclude .pytest_cache
 global-exclude .DS_Store
@@ -26,5 +22,5 @@ global-exclude .ipynb_checkpoints
 global-exclude *.py[co]
 global-exclude __pycache__
 
-include CMakeLists.txt LICENSE README.md setup.py setup_helpers.py dev-requirements.txt setup.cfg pyproject.toml CONTRIBUTING.md
+include CMakeLists.txt LICENSE README.md setup.py setup.cfg pyproject.toml
 recursive-include extern *LICENSE*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,11 +17,16 @@
 import os
 import re
 
+# Docs require Python 3.6+ to generate
+from pathlib import Path
+
+import shutil
 import sys
 
-DIR = os.path.abspath(os.path.dirname(__file__))
-BASEDIR = os.path.abspath(os.path.dirname(DIR))
-sys.path.append(os.path.join(BASEDIR, "src"))
+DIR = Path(__file__).parent.resolve()
+BASEDIR = DIR.parent
+
+sys.path.append(str(BASEDIR / "src"))
 
 # -- Project information -----------------------------------------------------
 
@@ -112,3 +117,27 @@ html_static_path = []  # _static
 # Simpler docs (no build required)
 
 autodoc_mock_imports = ["boost_histogram._core"]
+
+
+def prepare(app):
+    outer = BASEDIR / "notebooks"
+    inner = DIR / "notebooks"
+    notebooks = outer.glob("*.ipynb")
+
+    for notebook in notebooks:
+        shutil.copy(notebook, inner / notebook.name)
+
+
+def clean_up(app, exception):
+    inner = DIR / "notebooks"
+    for notebook in inner.glob("*.ipynb"):
+        notebook.unlink()
+
+
+def setup(app):
+
+    # Copy the notebooks in
+    app.connect("builder-inited", prepare)
+
+    # Clean up the generated notebooks
+    app.connect("build-finished", clean_up)

--- a/docs/notebooks/BoostHistogramHandsOn.ipynb
+++ b/docs/notebooks/BoostHistogramHandsOn.ipynb
@@ -1,1 +1,0 @@
-../../notebooks/BoostHistogramHandsOn.ipynb

--- a/docs/notebooks/PerformanceComparison.ipynb
+++ b/docs/notebooks/PerformanceComparison.ipynb
@@ -1,1 +1,0 @@
-../../notebooks/PerformanceComparison.ipynb

--- a/docs/notebooks/SimpleExample.ipynb
+++ b/docs/notebooks/SimpleExample.ipynb
@@ -1,1 +1,0 @@
-../../notebooks/SimpleExample.ipynb

--- a/docs/notebooks/ThreadedFills.ipynb
+++ b/docs/notebooks/ThreadedFills.ipynb
@@ -1,1 +1,0 @@
-../../notebooks/ThreadedFills.ipynb

--- a/docs/notebooks/aghast.ipynb
+++ b/docs/notebooks/aghast.ipynb
@@ -1,1 +1,0 @@
-../../notebooks/aghast.ipynb

--- a/docs/notebooks/xarray.ipynb
+++ b/docs/notebooks/xarray.ipynb
@@ -1,1 +1,0 @@
-../../notebooks/xarray.ipynb

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
+ipython
 nbsphinx
 numpy
 recommonmark>=0.5.0
-Sphinx>=2.0.0
+Sphinx>=3.0.0
 sphinx-book-theme>=0.0.33
 sphinx_copybutton

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,10 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: C++
+    Programming Language :: Python :: Implementation :: PyPy
+    Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Information Analysis
     Topic :: Scientific/Engineering :: Mathematics

--- a/setup.cfg
+++ b/setup.cfg
@@ -101,6 +101,8 @@ ignore =
   examples/**
   notebooks/**
   docs/**
+  scripts/**
+  dev-requirements.txt
   extern/**/*.py
   extern/**/*.md
   extern/**/*.rst


### PR DESCRIPTION
Closes #458 

Issue discovered in https://github.com/joerick/cibuildwheel/issues/437 ; this is a workaround for us - the correct fix likely is not even in cibuildwheel, but in whatever makes the copy during the building (pip? pep517? wheel?)