### PR TITLE
feat: settable accumulator storage views

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,31 @@
 # What's new in boost-histogram
 
+# Version 0.12
+
+### Version 0.12.0 (WIP)
+
+Pressing forward to 1.0.
+
+
+#### User changes
+
+* You can now set all complex storages, either on a Histogram or a View with an (N+1)D array [#475][]
+
+#### Bug fixes
+
+* Fixed issue if final bin of Variable histogram was infinite by updating to Boost 1.75 [#470][]
+* NumPy arrays can be used for weights in `bh.numpy` [#472][]
+
+#### Developer changes
+
+* Bumped to pybind11 2.6.1 [#470][]
+* Black formatting used in notebooks too [#470][]
+
+[#470]: https://github.com/scikit-hep/boost-histogram/pull/470
+[#472]: https://github.com/scikit-hep/boost-histogram/pull/472
+[#475]: https://github.com/scikit-hep/boost-histogram/pull/475
+
+
 ## Version 0.11
 
 ### Version 0.11.1

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -116,10 +116,6 @@ class Histogram(object):
             self.__init__(axes[0]._hist)
             self._from_histogram_object(axes[0])
             return
-        # Support objects that provide a to_boost method, like Uproot
-        elif len(axes) == 1 and hasattr(axes[0], "to_boost"):
-            self.__init__(axes[0].to_boost())
-            return
 
         # Keyword only trick (change when Python2 is dropped)
         with KWArgs(kwargs) as k:

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -116,6 +116,10 @@ class Histogram(object):
             self.__init__(axes[0]._hist)
             self._from_histogram_object(axes[0])
             return
+        # Support objects that provide a to_boost method, like Uproot
+        elif len(axes) == 1 and hasattr(axes[0], "to_boost"):
+            self.__init__(axes[0].to_boost())
+            return
 
         # Keyword only trick (change when Python2 is dropped)
         with KWArgs(kwargs) as k:

--- a/src/boost_histogram/_internal/view.py
+++ b/src/boost_histogram/_internal/view.py
@@ -36,6 +36,18 @@ class View(np.ndarray):
             self=self, fields=fields, arr=self.view(np.ndarray)
         )
 
+    def __setitem__(self, ind, value):
+        array = np.asarray(value)
+        if (
+            array.ndim == super(View, self).__getitem__(ind).ndim + 1
+            and len(self._FIELDS) == array.shape[-1]
+        ):
+            self.__setitem__(ind, self._PARENT._array(*np.moveaxis(array, -1, 0)))
+        elif self.dtype == array.dtype:
+            super(View, self).__setitem__(ind, array)
+        else:
+            raise ValueError("Needs matching ndarray or n+1 dim array")
+
 
 def make_getitem_property(name):
     def fget(self):

--- a/src/register_accumulators.cpp
+++ b/src/register_accumulators.cpp
@@ -104,7 +104,13 @@ void register_accumulators(py::module& accumulators) {
             "variance"_a = py::none(),
             "Fill the accumulator with values. Optional variance parameter.")
 
+        // This adapts existing memory to an accumulator
         .def_static("_make", py::vectorize([](const double& a, const double& b) {
+                        return weighted_sum(a, b);
+                    }))
+
+        // This creates a array of accumulators using the normal constructor arguments
+        .def_static("_array", py::vectorize([](const double& a, const double& b) {
                         return weighted_sum(a, b);
                     }))
 
@@ -200,8 +206,15 @@ void register_accumulators(py::module& accumulators) {
         .def_static(
             "_make",
             py::vectorize(
-                [](const double& a, const double& b, const double& c, double& d) {
+                [](const double& a, const double& b, const double& c, const double& d) {
                     return weighted_mean(a, b, c, d, true);
+                }))
+
+        .def_static(
+            "_array",
+            py::vectorize(
+                [](const double& a, const double& b, const double& c, const double& d) {
+                    return weighted_mean(a, b, c, d);
                 }))
 
         .def("__getitem__",
@@ -284,6 +297,12 @@ void register_accumulators(py::module& accumulators) {
             "_make",
             py::vectorize([](const double& a, const double& b, const double& c) {
                 return mean(a, b, c, true);
+            }))
+
+        .def_static(
+            "_array",
+            py::vectorize([](const double& a, const double& b, const double& c) {
+                return mean(a, b, c);
             }))
 
         .def("__getitem__",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -169,3 +169,9 @@ def test_view_assign_wmean():
     assert_allclose(w.value, [3, 7, 11, 15])
     assert_allclose(w.variance, [4, 8, 12, 16])
     # Note: if sum_of_weights <= 1, variance is undefined
+
+    w[0] = [9, 1, 2, 3]
+    assert w.sum_of_weights[0] == 9
+    assert w[0].sum_of_weights_squared == 1
+    assert w.value[0] == 2
+    assert w[0].variance == 3


### PR DESCRIPTION
The view support has been refactored to allow setting with arrays on all storages, rather than just Weight() as implemented in #375. This also moves the code for supporting this directly to the view, simplifying the histogram and avoiding custom checks for storages. This uses the actual constructor from Boost.Histogram, so it avoids the internal Boost.Histogram data structure being required/exposed for Uproot 4 making TProfiles. Also fixed a bug with a missing `const` that kept the WeightedMean conversion from working for non-scalars (non-const cannot be vectorized).

Note that the histogram is now directly settable too, since it sends the request on to the view. This was manually patched in for Weight storage, but now it is properly implemented for all storages via the View.

Will be very useful in Uproot, as it has to set this when converting from ROOT.

Examples:

```python
h = bh.Histogram(bh.axis.Integer(0, 2), storage=bh.storage.Mean())
h[...] = [[3,2,1], [3,2,1]] # Sets count=3, value=2, variance=1 for both cells
h.view()[...] = [[3,2,1], [3,2,1]] # Also works on views

# Works with WeighedMean too:
# Assume w is a WeighedMean View
w[0] = [9, 1, 2, 3]
assert w.sum_of_weights[0] == 9
assert w[0].sum_of_weights_squared == 1
assert w.value[0] == 2
assert w[0].variance == 3
```