### PR TITLE
feat: __dict__ major simplification

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,8 +9,11 @@ Pressing forward to 1.0.
 
 #### User changes
 
-* You can now set all complex storages, either on a Histogram or a View with an (N+1)D array [#475][]
-* Axes provide a `__dict__` attribute that can be set and deleted. [#477][]
+* You can now set all complex storages, either on a Histogram or a View with an
+  (N+1)D array [#475][]
+* Axes are now normal `__dict__` classes, you can manipulate the `__dict__` as
+  normal. Axes construction now lets you either use the old metadata shortcut
+  or the `__dict__` inline. [#477][]
 
 #### Bug fixes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ Pressing forward to 1.0.
 #### User changes
 
 * You can now set all complex storages, either on a Histogram or a View with an (N+1)D array [#475][]
-* Classes provide a `__dict__` attribute that can be set and deleted. [#477][]
+* Axes provide a `__dict__` attribute that can be set and deleted. [#477][]
 
 #### Bug fixes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,11 +10,13 @@ Pressing forward to 1.0.
 #### User changes
 
 * You can now set all complex storages, either on a Histogram or a View with an (N+1)D array [#475][]
+* Classes provide a `__dict__` attribute that can be set and deleted. [#477][]
 
 #### Bug fixes
 
 * Fixed issue if final bin of Variable histogram was infinite by updating to Boost 1.75 [#470][]
 * NumPy arrays can be used for weights in `bh.numpy` [#472][]
+* Vectorization for WeightedMean accumulators was broken [#475][]
 
 #### Developer changes
 
@@ -24,6 +26,7 @@ Pressing forward to 1.0.
 [#470]: https://github.com/scikit-hep/boost-histogram/pull/470
 [#472]: https://github.com/scikit-hep/boost-histogram/pull/472
 [#475]: https://github.com/scikit-hep/boost-histogram/pull/475
+[#477]: https://github.com/scikit-hep/boost-histogram/pull/477
 
 
 ## Version 0.11

--- a/src/boost_histogram/_internal/axestuple.py
+++ b/src/boost_histogram/_internal/axestuple.py
@@ -94,7 +94,7 @@ class AxesTuple(tuple):
         return self.__class__(result) if isinstance(result, tuple) else result
 
     def __getattr__(self, attr):
-        return self.__class__(s.__getattr__(attr) for s in self)
+        return self.__class__(getattr(s, attr) for s in self)
 
     def __setattr__(self, attr, values):
         return self.__class__(s.__setattr__(attr, v) for s, v in zip(self, values))

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -304,6 +304,9 @@ class Regular(Axis):
             The full metadata dictionary
         """
 
+        # Inheriting an axis and forgetting to add __slots__ should be an error
+        assert not hasattr(self, "__weakref__"), "Axis subclasses must have __slots__!"
+
         with KWArgs(kwargs) as k:
             metadata = k.optional("metadata")
             transform = k.optional("transform")
@@ -411,6 +414,10 @@ class Variable(Axis):
         __dict__: Optional[Dict[str, Any]] = None
             The full metadata dictionary
         """
+
+        # Inheriting an axis and forgetting to add __slots__ should be an error
+        assert not hasattr(self, "__weakref__"), "Axis subclasses must have __slots__!"
+
         with KWArgs(kwargs) as k:
             metadata = k.optional("metadata")
             __dict__ = k.optional("__dict__")
@@ -492,6 +499,10 @@ class Integer(Axis):
         __dict__: Optional[Dict[str, Any]] = None
             The full metadata dictionary
         """
+
+        # Inheriting an axis and forgetting to add __slots__ should be an error
+        assert not hasattr(self, "__weakref__"), "Axis subclasses must have __slots__!"
+
         with KWArgs(kwargs) as k:
             metadata = k.optional("metadata")
             __dict__ = k.optional("__dict__")
@@ -575,6 +586,9 @@ class StrCategory(BaseCategory):
             The full metadata dictionary
         """
 
+        # Inheriting an axis and forgetting to add __slots__ should be an error
+        assert not hasattr(self, "__weakref__"), "Axis subclasses must have __slots__!"
+
         with KWArgs(kwargs) as k:
             metadata = k.optional("metadata")
             __dict__ = k.optional("__dict__")
@@ -640,6 +654,10 @@ class IntCategory(BaseCategory):
         __dict__: Optional[Dict[str, Any]] = None
             The full metadata dictionary
         """
+
+        # Inheriting an axis and forgetting to add __slots__ should be an error
+        assert not hasattr(self, "__weakref__"), "Axis subclasses must have __slots__!"
+
         with KWArgs(kwargs) as k:
             metadata = k.optional("metadata")
             __dict__ = k.optional("__dict__")
@@ -681,6 +699,10 @@ class Boolean(Axis):
         __dict__: Optional[Dict[str, Any]] = None
             The full metadata dictionary
         """
+
+        # Inheriting an axis and forgetting to add __slots__ should be an error
+        assert not hasattr(self, "__weakref__"), "Axis subclasses must have __slots__!"
+
         with KWArgs(kwargs) as k:
             metadata = k.optional("metadata")
             __dict__ = k.optional("__dict__")

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -58,17 +58,15 @@ class Axis(object):
                 "Cannot provide metadata by keyword and __dict__, use __dict__ only"
             )
         elif __dict__ is not None:
-            self.__dict__ = __dict__
+            self._ax.metadata = __dict__
         elif metadata is not None:
-            self.__dict__["metadata"] = metadata
+            self._ax.metadata["metadata"] = metadata
 
-        self._ax.metadata = self.__dict__
-        assert self.__dict__ is self._ax.metadata
+        self.__dict__ = self._ax.metadata
 
     def __setstate__(self, state):
         self._ax = state["_ax"]
         self.__dict__ = self._ax.metadata
-        assert self.__dict__ is self._ax.metadata
 
     def __getstate__(self):
         return {"_ax": self._ax}
@@ -77,7 +75,6 @@ class Axis(object):
         other = self.__class__.__new__(self.__class__)
         other._ax = copy.copy(self._ax)
         other.__dict__ = other._ax.metadata
-        assert other.__dict__ is other._ax.metadata
         return other
 
     def index(self, value):
@@ -121,7 +118,6 @@ class Axis(object):
         nice_ax = cls.__new__(cls)
         nice_ax._ax = cpp_object
         nice_ax.__dict__ = cpp_object.metadata
-        assert nice_ax._ax.metadata == nice_ax.__dict__
         return nice_ax
 
     def __len__(self):

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -10,6 +10,7 @@ from .utils import cast, register, set_family, MAIN_FAMILY, set_module
 from .six import string_types
 
 import copy
+
 from typing import Dict, Any, TYPE_CHECKING
 
 del absolute_import, division, print_function
@@ -52,6 +53,12 @@ class Axis(object):
         other = self.__class__.__new__(self.__class__)
         other._ax = copy.copy(self._ax)
         return other
+
+    def __setstate__(self, state):
+        self._ax = state["_ax"]
+
+    def __getstate__(self):
+        return {"_ax": self._ax}
 
     def __getattr__(self, item):
         if item == "_ax":

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -154,7 +154,7 @@ class Histogram(object):
         self.__dict__ = copy.copy(h.__dict__)
         self.axes = self._generate_axes_()
         for ax in self.axes:
-            ax._ax.metadata = copy.copy(ax._ax.metadata)
+            ax.__dict__ = copy.copy(ax._ax.metadata)
 
         # Allow custom behavior on either "from" or "to"
         h._export_bh_(self)
@@ -198,9 +198,9 @@ class Histogram(object):
         other.axes = other._generate_axes_()
         for ax in other.axes:
             if memo is NOTHING:
-                ax._ax.metadata = copy.copy(ax._ax.metadata)
+                ax.__dict__ = copy.copy(ax._ax.metadata)
             else:
-                ax._ax.metadata = copy.deepcopy(ax._ax.metadata, memo)
+                ax.__dict__ = copy.deepcopy(ax._ax.metadata, memo)
         return other
 
     @property
@@ -440,9 +440,9 @@ class Histogram(object):
         else:  # Classic (0.10 and before) state
             self._hist = state["_hist"]
             self.metadata = state.get("metadata", None)
+            for i in range(self._hist.rank()):
+                self._hist.axis(i).metadata = {"metadata": self._hist.axis(i).metadata}
             self.axes = self._generate_axes_()
-            for ax in self.axes:
-                ax._ax.metadata = {"metadata": ax._ax.metadata}
 
     def __repr__(self):
         newline = "\n  "

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -81,22 +81,14 @@ def test_metadata(axis, args, opt, kwargs):
     new_kwargs = copy.copy(kwargs)
     new_kwargs["__dict__"] = {"something": 2}
     new_kwargs["metadata"] = 3
-    ax = axis(*args, **new_kwargs)
-    assert ax.__dict__ == {"something": 2, "metadata": 3}
+    with pytest.raises(KeyError):
+        axis(*args, **new_kwargs)
 
     new_kwargs = copy.copy(kwargs)
     new_kwargs["__dict__"] = {"metadata": 2}
     new_kwargs["metadata"] = 3
     with pytest.raises(KeyError):
         axis(*args, **new_kwargs)
-
-    # An assertion failure should occur if you forget to set slots!
-    @boost_histogram.utils.set_family(object())
-    class TmpAxis(axis):
-        pass
-
-    with pytest.raises(AssertionError):
-        TmpAxis(*args, **kwargs)
 
 
 # The point of this ABC is to force all the tests listed here to be

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -62,7 +62,29 @@ def test_metadata(axis, args, opt, kwargs):
         assert axis(*args, **kwargs) == axis(*args, **kwargs)
         assert axis(*args, **kwargs) != axis(*args, metadata="bar")
 
+    del kwargs["metadata"]
 
+    ax = axis(*args, __dict__={"metadata": 3, "other": 2})
+    assert ax.metadata == 3
+    assert ax.other == 2
+
+    del ax.__dict__
+    assert ax.__dict__ == {}
+    assert ax.metadata is None
+
+    ax.__dict__ = {"metadata": 5}
+    assert ax.__dict__ == {"metadata": 5}
+    assert ax.metadata == 5
+
+    ax = axis(*args, **kwargs, __dict__={"something": 2}, metadata=3)
+    assert ax.__dict__ == {"something": 2, "metadata": 3}
+
+    with pytest.raises(KeyError):
+        axis(*args, **kwargs, __dict__={"metadata": 2}, metadata=3)
+
+
+# The point of this ABC is to force all the tests listed here to be
+# implemented for each axis type.
 class Axis(ABC):
     @abc.abstractmethod
     def test_init(self):

--- a/tests/test_subclassing.py
+++ b/tests/test_subclassing.py
@@ -11,7 +11,7 @@ def test_subclass():
 
     @bh.utils.set_family(NEW_FAMILY)
     class MyRegular(bh.axis.Regular):
-        pass
+        __slots__ = ()
 
     @bh.utils.set_family(NEW_FAMILY)
     class MyIntStorage(bh.storage.Int64):


### PR DESCRIPTION
This removes the whole facade and just really makes this a `__dict__` class. You can now manipulate __dict__ directly, it's completely natural, and C++ just caries a pointer to it. If you need to clear the dict, set it, etc., you can.