### PR TITLE
feat: support _to_boost_

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -134,8 +134,8 @@ class Histogram(object):
             return
 
         # Support objects that provide a to_boost method, like Uproot
-        elif len(axes) == 1 and hasattr(axes[0], "_as_boost_histogram_"):
-            self.__init__(axes[0]. _as_boost_histogram_())
+        elif len(axes) == 1 and hasattr(axes[0], "_to_boost_"):
+            self.__init__(axes[0]. _to_boost_())
             return
 
         # Keyword only trick (change when Python2 is dropped)

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -134,8 +134,8 @@ class Histogram(object):
             return
 
         # Support objects that provide a to_boost method, like Uproot
-        elif len(axes) == 1 and hasattr(axes[0], "to_boost"):
-            self.__init__(axes[0].to_boost())
+        elif len(axes) == 1 and hasattr(axes[0], "_as_boost_histogram_"):
+            self.__init__(axes[0]. _as_boost_histogram_())
             return
 
         # Keyword only trick (change when Python2 is dropped)

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -134,8 +134,8 @@ class Histogram(object):
             return
 
         # Support objects that provide a to_boost method, like Uproot
-        elif len(axes) == 1 and hasattr(axes[0], "_to_boost_"):
-            self.__init__(axes[0]. _to_boost_())
+        elif len(axes) == 1 and hasattr(axes[0], "_to_boost_histogram_"):
+            self.__init__(axes[0]. _to_boost_histogram_())
             return
 
         # Keyword only trick (change when Python2 is dropped)

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -133,6 +133,11 @@ class Histogram(object):
             self._from_histogram_object(axes[0])
             return
 
+        # Support objects that provide a to_boost method, like Uproot
+        elif len(axes) == 1 and hasattr(axes[0], "to_boost"):
+            self.__init__(axes[0].to_boost())
+            return
+
         # Keyword only trick (change when Python2 is dropped)
         with KWArgs(kwargs) as k:
             storage = k.optional("storage")


### PR DESCRIPTION
Pulled the change out from #475 so that it can get a proper discussion if it needs it.

Boost-histogram already supports casting - you can call `Hist(a_boost_object)`, where Hist is any boost-powered project, including Hist, and it converts. Likewise with `Histogram(a_hist_object)` . This allows uproot to participate - you can call `bh.Histogram(an_uproot_histogram)` and it converts by first calling `to_boost`, then using the standard mechanism to convert it to `bh.Histogram` (or Hist, or any other dependent project if more get added).

The main question I'd like to discuss is: should we use the current method uproot provides, `.to_boost()`, or instead provide a hidden method to do this, like `_to_boost_()`, and add it to uproot? If Physt were to add a method, I bet Jan would be fine with `to_boost()`, but not requiring a user-visible method might be better? Also, in the future, we might want to provide a way to produce a structure that boost-histogram can adapt to reduce coupling - but that's _very_ far away - sticking to a hidden method now would keep us from having to expose a public method tied to the old method if a new one was added.

Edit: As seen below, I went with `_as_boost_histogram_()`.