### PR TITLE
ci: work around broken PyPy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,8 @@ jobs:
       with:
         submodules: true
 
-    - uses: actions/setup-python@v2
+    # TODO: unpin after 2.2.0 gets fixed. PyPy is broken in 2.2.0.
+    - uses: actions/setup-python@v2.1.4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
We can unpin after the issue in GHA is fixed. See actions/setup-python#171