### PR TITLE
fix: access getitem via string was broken (and attr access uses this too)

### DIFF
--- a/src/boost_histogram/_internal/view.py
+++ b/src/boost_histogram/_internal/view.py
@@ -37,6 +37,11 @@ class View(np.ndarray):
         )
 
     def __setitem__(self, ind, value):
+        # `.value` really is ["value"] for an record array
+        if isinstance(ind, str):
+            super(View, self).__setitem__(ind, value)
+            return
+
         array = np.asarray(value)
         if (
             array.ndim == super(View, self).__getitem__(ind).ndim + 1

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -201,3 +201,17 @@ def test_setting_weighted_profile():
         a.view()._sum_of_weighted_deltas_squared,
         b.view()["_sum_of_weighted_deltas_squared"],
     )
+
+
+# Issue #486
+def test_modify_weights_by_view():
+    bins = [0, 1, 2]
+    hist = bh.Histogram(bh.axis.Variable(bins), storage=bh.storage.Weight())
+    yields = [3, 4]
+    var = [0.1, 0.2]
+    hist[...] = np.stack([yields, var], axis=-1)
+
+    hist.view().value /= 2
+
+    assert hist.view().value[0] == pytest.approx(1.5)
+    assert hist.view().value[1] == pytest.approx(2)


### PR DESCRIPTION
Fixes #486. Thanks to @alexander-held for testing the latests develop branch!

If I had static types here, I would have seen that ind could be a string, which probably would have kept me from making this mistake. But I might be giving myself too much credit there...