### PR TITLE
ci: cibuildwheel action, bump to v1.7.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,8 +58,7 @@ jobs:
       with:
         submodules: true
 
-    # TODO: unpin after 2.2.0 gets fixed. PyPy is broken in 2.2.0.
-    - uses: actions/setup-python@v2.1.4
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -81,29 +80,28 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: true
 
-    - name: Setup Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.7'
+    - uses: actions/setup-python@v2
 
-    - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.5.5 twine
-
-    - name: Build wheel
-      run: python -m cibuildwheel --output-dir wheelhouse
+    - uses: joerick/cibuildwheel@v1.7.3
       env:
         CIBW_BUILD: cp38-win_amd64 cp27-manylinux_i686 cp37-macosx_x86_64
         CIBW_TEST_EXTRAS: test
         CIBW_TEST_COMMAND: pytest {project}/tests
         CIBW_BUILD_VERBOSITY: 1
 
+    - uses: actions/upload-artifact@v2
+      with:
+        path: wheelhouse/*
+
     - name: Check wheels
-      run: twine check wheelhouse/*
+      run: |
+        python -m pip install twine
+        twine check wheelhouse/*
       shell: bash

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -72,11 +72,7 @@ jobs:
 
     - uses: actions/setup-python@v2
 
-    - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.7.1
-
-    - name: Build wheel
-      run: python -m cibuildwheel --output-dir wheelhouse
+    - uses: joerick/cibuildwheel@v1.7.3
       env:
         CIBW_SKIP: cp27-win* pp*
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}
@@ -113,11 +109,7 @@ jobs:
 
     - uses: actions/setup-python@v2
 
-    - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.7.1
-
-    - name: Build wheel
-      run: python -m cibuildwheel --output-dir wheelhouse
+    - uses: joerick/cibuildwheel@v1.7.3
       env:
         CIBW_SKIP: cp*
 
@@ -147,13 +139,11 @@ jobs:
 
     - uses: actions/setup-python@v2
 
-    - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==1.7.1
 
     - uses: ilammy/msvc-dev-cmd@v1
 
     - name: Build 64-bit wheel
-      run: python -m cibuildwheel --output-dir wheelhouse
+      uses: joerick/cibuildwheel@v1.7.3
       env:
         CIBW_BUILD: cp27-win_amd64
         DISTUTILS_USE_SDK: 1
@@ -164,7 +154,7 @@ jobs:
         arch: x86
 
     - name: Build 32-bit wheel
-      run: python -m cibuildwheel --output-dir wheelhouse
+      uses: joerick/cibuildwheel@v1.7.3
       env:
         CIBW_BUILD: cp27-win32 pp27-win32
         DISTUTILS_USE_SDK: 1


### PR DESCRIPTION
While this is only a minor simplification (bundling two steps into one), it is a huge maintenance relief - we can now use GitHub's dependabot to keep us up to date on new releases (and insync in the tests & wheel files, which was not in sync before)!
