### PR TITLE
feat: to_numpy matching uproot, extra mode

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -552,18 +552,25 @@ class Histogram(object):
 
         return indexes
 
-    @inject_signature("self, flow=False, *, dd=False")
+    @inject_signature("self, flow=False, *, dd=False, mode='numpy'")
     def to_numpy(self, flow=False, **kwargs):
         """
-        Convert to a Numpy style tuple of return arrays.
+        Convert to a Numpy style tuple of return arrays. Edges are converted
+        to exactly match NumPy standards, with upper edge inclusive, unlike
+        boost-histogram, where upper edge is exclusive.
 
         Parameters
         ----------
-
         flow : bool = False
             Include the flow bins.
         dd : bool = False
-            Use the histogramdd return syntax, where the edges are in a tuple
+            Use the histogramdd return syntax, where the edges are in a tuple.
+            Otherwise, this is the histogram/histogram2d return style.
+        mode : Literal["numpy", "view"] = "numpy"
+            The behavior for the return value. "numpy" will return the NumPy
+            array of the values only regardless of the storage (which is all
+            NumPy's histogram function can do). "view" will leave the
+            boost-histogram view of the storage untouched.
 
         Return
         ------
@@ -575,13 +582,23 @@ class Histogram(object):
 
         with KWArgs(kwargs) as kw:
             dd = kw.optional("dd", False)
+            mode = kw.optional("mode", "numpy")
 
+        # Python 3+ would be simpler
         return_tuple = self._hist.to_numpy(flow)
+        hist = return_tuple[0]
+
+        if mode == "numpy":
+            hist = self.values(flow=flow)
+        elif mode == "view":
+            hist = self.view(flow=flow)
+        else:
+            raise KeyError("Invalid mode")
 
         if dd:
-            return return_tuple[0], return_tuple[1:]
+            return hist, return_tuple[1:]
         else:
-            return return_tuple
+            return (hist,) +  return_tuple[1:]
 
     @inject_signature("self, *, deep=True")
     def copy(self, **kwargs):

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -552,11 +552,11 @@ class Histogram(object):
 
         return indexes
 
-    @inject_signature("self, flow=False, *, dd=False, mode='numpy'")
+    @inject_signature("self, flow=False, *, dd=False, view=False")
     def to_numpy(self, flow=False, **kwargs):
         """
-        Convert to a Numpy style tuple of return arrays. Edges are converted
-        to exactly match NumPy standards, with upper edge inclusive, unlike
+        Convert to a Numpy style tuple of return arrays. Edges are converted to
+        match NumPy standards, with upper edge inclusive, unlike
         boost-histogram, where upper edge is exclusive.
 
         Parameters
@@ -566,11 +566,11 @@ class Histogram(object):
         dd : bool = False
             Use the histogramdd return syntax, where the edges are in a tuple.
             Otherwise, this is the histogram/histogram2d return style.
-        mode : Literal["numpy", "view"] = "numpy"
-            The behavior for the return value. "numpy" will return the NumPy
+        view : bool  = False
+            The behavior for the return value. By default, this will return
             array of the values only regardless of the storage (which is all
-            NumPy's histogram function can do). "view" will leave the
-            boost-histogram view of the storage untouched.
+            NumPy's histogram function can do). view=True will return the
+            boost-histogram view of the storage.
 
         Return
         ------
@@ -582,18 +582,16 @@ class Histogram(object):
 
         with KWArgs(kwargs) as kw:
             dd = kw.optional("dd", False)
-            mode = kw.optional("mode", "numpy")
+            view = kw.optional("view", False)
 
         # Python 3+ would be simpler
         return_tuple = self._hist.to_numpy(flow)
         hist = return_tuple[0]
 
-        if mode == "numpy":
-            hist = self.values(flow=flow)
-        elif mode == "view":
+        if view:
             hist = self.view(flow=flow)
         else:
-            raise KeyError("Invalid mode")
+            hist = self.values(flow=flow)
 
         if dd:
             return hist, return_tuple[1:]

--- a/src/boost_histogram/numpy.py
+++ b/src/boost_histogram/numpy.py
@@ -79,7 +79,10 @@ def histogramdd(
         density = hist.view() / hist.sum() / areas
         return (density, hist.to_numpy()[1:])
 
-    return hist if bh_cls is not None else hist.to_numpy(dd=True)
+    # Note: this is mode="view" since users have to ask explicilty for special
+    # storages, so mode="numpy" would throw away part of what they are asking
+    # for. Users can use a histogram return type if they need mode="numpy".
+    return hist if bh_cls is not None else hist.to_numpy(dd=True, mode="view")
 
 
 @_inject_signature(

--- a/src/boost_histogram/numpy.py
+++ b/src/boost_histogram/numpy.py
@@ -79,10 +79,10 @@ def histogramdd(
         density = hist.view() / hist.sum() / areas
         return (density, hist.to_numpy()[1:])
 
-    # Note: this is mode="view" since users have to ask explicilty for special
-    # storages, so mode="numpy" would throw away part of what they are asking
-    # for. Users can use a histogram return type if they need mode="numpy".
-    return hist if bh_cls is not None else hist.to_numpy(dd=True, mode="view")
+    # Note: this is view=True since users have to ask explicitly for special
+    # storages, so view=False would throw away part of what they are asking
+    # for. Users can use a histogram return type if they need view=False.
+    return hist if bh_cls is not None else hist.to_numpy(view=True, dd=True)
 
 
 @_inject_signature(

--- a/tests/test_internal_histogram.py
+++ b/tests/test_internal_histogram.py
@@ -135,6 +135,31 @@ def test_numpy_dd():
     assert_array_equal(x1, x2)
     assert_array_equal(y1, y2)
 
+def test_numpy_weights():
+    h = bh.Histogram(
+        bh.axis.Regular(10, 0, 1), bh.axis.Regular(5, 0, 1), storage=bh.storage.Weight()
+    )
+
+    for i in range(10):
+        for j in range(5):
+            x, y = h.axes[0].centers[i], h.axes[1].centers[j]
+            v = i + j * 10 + 1
+            h.fill([x] * v, [y] * v)
+
+    h2, x2, y2 = h.to_numpy(mode="numpy")
+    h1, (x1, y1) = h.to_numpy(dd=True, mode="numpy")
+
+    assert_array_equal(h1, h2)
+    assert_array_equal(x1, x2)
+    assert_array_equal(y1, y2)
+
+    h1, (x1, y1) = h.to_numpy(dd=True, mode="numpy")
+    h2, x2, y2 = h.to_numpy(mode="view")
+
+    assert_array_equal(h1, h2.value)
+    assert_array_equal(x1, x2)
+    assert_array_equal(y1, y2)
+
 
 def test_numpy_flow():
     h = bh.Histogram(

--- a/tests/test_internal_histogram.py
+++ b/tests/test_internal_histogram.py
@@ -146,15 +146,15 @@ def test_numpy_weights():
             v = i + j * 10 + 1
             h.fill([x] * v, [y] * v)
 
-    h2, x2, y2 = h.to_numpy(mode="numpy")
-    h1, (x1, y1) = h.to_numpy(dd=True, mode="numpy")
+    h2, x2, y2 = h.to_numpy(view=False)
+    h1, (x1, y1) = h.to_numpy(dd=True, view=False)
 
     assert_array_equal(h1, h2)
     assert_array_equal(x1, x2)
     assert_array_equal(y1, y2)
 
-    h1, (x1, y1) = h.to_numpy(dd=True, mode="numpy")
-    h2, x2, y2 = h.to_numpy(mode="view")
+    h1, (x1, y1) = h.to_numpy(dd=True, view=False)
+    h2, x2, y2 = h.to_numpy(view=True)
 
     assert_array_equal(h1, h2.value)
     assert_array_equal(x1, x2)


### PR DESCRIPTION
This closes #413, with a proposal I made in scikit-hep/uproot3#511 - we match uproot4 by default, returning normal NumPy histogram output from `to_numpy()` on all storages. If the full view is required, a `mode="view"` can be passed. In boost-histogram 1.0, this will be type checked by MyPy. An expression like this:

```python
mplhep.histplot(h.to_numpy())
```

will no longer crash if `h` is not backed by a simple storage. Of course, since mplhep supports PlottableProtocol now, there's no need to call `to_numpy`, but other classic interfaces out of our control still use this. Including Uproot3 writing.

I've also added clarification to the docstring that `to_numpy` is not a replacement for calling `h.axes.edges()`; `to_numpy` returns the actual NumPy edges, not the boost-histogram ones, which differ on the upper edge. If you were to refill the histogram using `np.histogram`, this would produce identical results if you use the edges returned by `to_numpy`, but not if you use the edges returned boost-histogram style.
