### PR TITLE
feat: allow build system to be set to C++17, rename multithread var

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.5", "3.8", "3.9", "pypy3"]
+        python-version: ["2.7", "3.5", "3.9", "pypy3"]
+        include:
+        - python-version: "3.8"
+          cmake-extras: "-DCMAKE_CXX_STANDARD=17"
 
     name: CMake Python ${{ matrix.python-version }}
 
@@ -66,7 +69,7 @@ jobs:
       run: python -m pip install -r dev-requirements.txt pytest-github-actions-annotate-failures
 
     - name: Configure
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBOOST_HISTOGRAM_ERRORS=ON
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBOOST_HISTOGRAM_ERRORS=ON ${{ matrix.cmake-extras }}
 
     - name: Build
       run: cmake --build build -j 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(BOOST_HISTOGRAM LANGUAGES CXX)
 # Version is added later
 
 # Boost histogram requires C++14
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ standard to compile with, 14+")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/include/bh_python/register_axis.hpp
+++ b/include/bh_python/register_axis.hpp
@@ -155,7 +155,7 @@ py::class_<A> register_axis(py::module& m, Args&&... args) {
 
         .def_property_readonly(
             "size",
-            &A::size,
+            [](const A& ob){ return ob.size(); },
             "Returns the number of bins excluding under- and overflow")
 
         .def_property_readonly(

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,10 @@ from pybind11.setup_helpers import ParallelCompile, Pybind11Extension  # noqa: E
 
 del sys.path[-1]
 
-# Use the environment variable NPY_NUM_BUILD_JOBS
-ParallelCompile("NPY_NUM_BUILD_JOBS").install()
+# Use the environment variable CMAKE_BUILD_PARALLEL_LEVEL to control parallel builds
+ParallelCompile("CMAKE_BUILD_PARALLEL_LEVEL").install()
+
+cxx_std = int(os.environ.get("CMAKE_CXX_STANDAR", "14"))
 
 SRC_FILES = [
     "src/module.cpp",
@@ -42,7 +44,7 @@ ext_modules = [
         "boost_histogram._core",
         SRC_FILES,
         include_dirs=INCLUDE_DIRS,
-        cxx_std=14,
+        cxx_std=cxx_std,
         extra_compile_args=["/d2FH4-"] if sys.platform.startswith("win32") else [],
     )
 ]

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ ext_modules = [
 
 
 extras = {
-    "test": ["pytest", "pytest-benchmark", "typing_extensions"],
+    "test": ["pytest", "pytest-benchmark", "typing_extensions", "cloudpickle"],
     "docs": [
         "Sphinx~=3.0",
         "recommonmark>=0.5.0",
@@ -60,7 +60,7 @@ extras = {
         "sphinx_copybutton",
     ],
     "examples": ["matplotlib", "xarray", "xhistogram", "netCDF4", "numba", "uproot3"],
-    "dev": ["ipykernel", "cloudpickle", "typer"],
+    "dev": ["ipykernel", "typer"],
 }
 extras["all"] = sum(extras.values(), [])
 extras["dev"] += extras["test"]


### PR DESCRIPTION
Fix #501

Support setting C++ mode in setuptools or CMake. Use the CMake naming for parallel threading. CPython 3.8 compiles in C++17 mode.

Not bothering to fix Travis because I'll be dumping it in #474 and want to avoid the merge conflict. The Conda recipe will need an update, though.
