### PR TITLE
chore: drop deprecated .rank

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,9 @@ Python 2, and mostly equivalent in API to 1.0.
   the Kind of the histogram (`bh.Kind.COUNT` or `bh.Kind.MEAN`). `.options` has
   been renamed to `.traits`, and a few more useful traits were added, like
   `.discrete`. Most other portions of the Protocol were already present. [#476][]
+* `.options` has been replaced with `.traits`, with a wider range of
+  Boost.Histogram traits.
+* Removed deprecated `.rank` on histograms (since 0.8). Use `.ndim` instead.
 
 
 #### Developer changes

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -12,7 +12,6 @@ import numpy as np
 from .. import _core
 from .axestuple import AxesTuple
 from .axis import Axis
-from .deprecated import deprecated
 from .enum import Kind
 from .kwargs import KWArgs
 from .sig_tools import inject_signature
@@ -226,15 +225,6 @@ class Histogram(object):
                 ax.__dict__ = copy.deepcopy(ax._ax.metadata, memo)
 
         return other
-
-    def __getattr__(self, attr):
-        # type: (str) -> Any
-        if attr == "rank":
-            return self._rank()
-
-        raise AttributeError(
-            "object {} has not attribute {}".format(self.__class__.__name__, attr)
-        )
 
     @property
     def ndim(self):
@@ -630,14 +620,6 @@ class Histogram(object):
         Compute the sum over the histogram bins (optionally including the flow bins).
         """
         return self._hist.sum(flow)
-
-    @deprecated("Use .ndim instead", name="rank")
-    def _rank(self):
-        # type: () -> int
-        """
-        Number of axes (dimensions) of histogram.
-        """
-        return self._hist.rank()
 
     @property
     def size(self):

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -43,8 +43,6 @@ def test_init():
 
     h = bh.Histogram(bh.axis.Integer(-1, 2))
     assert h.ndim == 1
-    with pytest.warns(FutureWarning):
-        assert h.rank == 1
     assert h.axes[0] == bh.axis.Integer(-1, 2)
     assert h.axes[0].extent == 5
     assert h.axes[0].size == 3


### PR DESCRIPTION
Just a small part of #503 - this is the only previously deprecated part.
