### PR TITLE
feat: new simpler Python 3.6+ family usage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,10 +3,20 @@
 ## Version 1.0
 
 Dropped support for Python 2 and 3.5; removed large numbers of workarounds.
+Subclassing histogram components now uses Python 3 class keyword syntax to set
+families.
 
+#### User changes
+
+* Dropped Python 2.7 and 3.5 support [#512][]
 * Removed deprecated `.options` from axes. Use `.traits` instead. [#503][]
+* Use keyword class family setting when subclassing histogram components
+  instead of custom decorator. [#513][]
 
 [#503]: https://github.com/scikit-hep/boost-histogram/pull/503
+[#512]: https://github.com/scikit-hep/boost-histogram/pull/512
+[#513]: https://github.com/scikit-hep/boost-histogram/pull/513
+
 
 ## Version 0.13
 

--- a/src/boost_histogram/__init__.py
+++ b/src/boost_histogram/__init__.py
@@ -1,4 +1,4 @@
-from . import accumulators, axis, numpy, storage, utils
+from . import accumulators, axis, numpy, storage
 from ._internal.enum import Kind
 from ._internal.hist import Histogram
 from .tag import loc, overflow, rebin, sum, underflow
@@ -24,7 +24,6 @@ __all__ = (
     "axis",
     "storage",
     "accumulators",
-    "utils",
     "numpy",
     "loc",
     "rebin",

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -1,10 +1,12 @@
 import copy
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Set, Tuple, Union
+
+import boost_histogram
 
 from .._core import axis as ca
 from .axis_transform import AxisTransform
 from .traits import Traits
-from .utils import MAIN_FAMILY, cast, register, set_family, set_module
+from .utils import cast, register, set_module
 
 
 def _isstr(value: Any) -> bool:
@@ -20,7 +22,7 @@ def _isstr(value: Any) -> bool:
         return False
 
 
-def opts(**kwargs: bool):
+def opts(**kwargs: bool) -> Set[str]:
     return {k for k, v in kwargs.items() if v}
 
 
@@ -28,6 +30,11 @@ def opts(**kwargs: bool):
 @set_module("boost_histogram.axis")
 class Axis:
     __slots__ = ("_ax", "__dict__")
+    _family: object
+
+    def __init_subclass__(cls, *, family: object) -> None:
+        super().__init_subclass__()
+        cls._family = family
 
     def __setattr__(self, attr: str, value: Any) -> None:
         if attr == "__dict__":
@@ -244,8 +251,7 @@ class Axis:
     }
 )
 @set_module("boost_histogram.axis")
-@set_family(MAIN_FAMILY)
-class Regular(Axis):
+class Regular(Axis, family=boost_histogram):
     __slots__ = ()
 
     def __init__(
@@ -361,9 +367,8 @@ class Regular(Axis):
         ca.variable_circular,
     }
 )
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.axis")
-class Variable(Axis):
+class Variable(Axis, family=boost_histogram):
     __slots__ = ()
 
     def __init__(
@@ -444,9 +449,8 @@ class Variable(Axis):
         ca.integer_circular,
     }
 )
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.axis")
-class Integer(Axis):
+class Integer(Axis, family=boost_histogram):
     __slots__ = ()
 
     def __init__(
@@ -514,7 +518,7 @@ class Integer(Axis):
         return "{start:g}, {stop:g}".format(start=self.edges[0], stop=self.edges[-1])
 
 
-class BaseCategory(Axis):
+class BaseCategory(Axis, family=boost_histogram):
     __slots__ = ()
 
     def _repr_kwargs(self):
@@ -536,10 +540,9 @@ class BaseCategory(Axis):
         return ret
 
 
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.axis")
 @register({ca.category_str_growth, ca.category_str})
-class StrCategory(BaseCategory):
+class StrCategory(BaseCategory, family=boost_histogram):
     __slots__ = ()
 
     def __init__(
@@ -603,10 +606,9 @@ class StrCategory(BaseCategory):
         return "[{}]".format(", ".join(repr(c) for c in self))
 
 
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.axis")
 @register({ca.category_int, ca.category_int_growth})
-class IntCategory(BaseCategory):
+class IntCategory(BaseCategory, family=boost_histogram):
     __slots__ = ()
 
     def __init__(
@@ -655,9 +657,8 @@ class IntCategory(BaseCategory):
 
 # Contains all common methods and properties for the boolean axis
 @register({ca.boolean})
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.axis")
-class Boolean(Axis):
+class Boolean(Axis, family=boost_histogram):
     __slots__ = ()
 
     def __init__(self, *, metadata: Any = None, __dict__: Dict[str, Any] = None):

--- a/src/boost_histogram/_internal/axis_transform.py
+++ b/src/boost_histogram/_internal/axis_transform.py
@@ -1,13 +1,20 @@
 import copy
 from typing import Any
 
+import boost_histogram
+
 from .._core import axis as ca
-from .utils import MAIN_FAMILY, register, set_family, set_module
+from .utils import register, set_module
 
 
 @set_module("boost_histogram.axis.transform")
 class AxisTransform:
     __slots__ = ("_this",)
+    _family: object
+
+    def __init_subclass__(cls, *, family: object) -> None:
+        super().__init_subclass__()
+        cls._family = family
 
     def __copy__(self):
         other = self.__class__.__new__(self.__class__)
@@ -33,7 +40,7 @@ class AxisTransform:
 
     def __init__(self) -> None:
         "Create a new transform instance"
-        # Note: this comes from set_family
+        # Note: this comes from family
         (cpp_class,) = self._types  # type: ignore
         self._this = cpp_class()
 
@@ -49,16 +56,15 @@ class AxisTransform:
 core = "__init__ forward inverse".split()
 
 
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.axis.transform")
 @register({ca.transform.pow})
-class Pow(AxisTransform):
+class Pow(AxisTransform, family=boost_histogram):
     __slots__ = ()
     _type = ca.regular_pow
 
     def __init__(self, power: float):
         "Create a new transform instance"
-        # Note: this comes from set_family
+        # Note: this comes from family
         (cpp_class,) = self._types  # type: ignore
         self._this = cpp_class(power)
 
@@ -72,10 +78,9 @@ class Pow(AxisTransform):
         return self.__class__._type(bins, start, stop, self.power)
 
 
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.axis.transform")
 @register({ca.transform.func_transform})
-class Function(AxisTransform):
+class Function(AxisTransform, family=boost_histogram):
     __slots__ = ()
     _type = ca.regular_trans
 
@@ -126,7 +131,7 @@ class Function(AxisTransform):
 
         """
 
-        # Note: this comes from set_family
+        # Note: this comes from family
         (cpp_class,) = self._types  # type: ignore
         self._this = cpp_class(forward, inverse, convert, name)
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -6,12 +6,14 @@ from typing import TYPE_CHECKING, Any, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 
+import boost_histogram
+
 from .. import _core
 from .axestuple import AxesTuple
 from .axis import Axis
 from .enum import Kind
 from .storage import Double, Storage
-from .utils import MAIN_FAMILY, cast, register, set_family, set_module
+from .utils import cast, register, set_module
 from .view import _to_view
 
 if TYPE_CHECKING:
@@ -83,7 +85,6 @@ H = TypeVar("H", bound="Histogram")
 # We currently do not cast *to* a histogram, but this is consistent
 # and could be used later.
 @register(_histograms)
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram")
 class Histogram:
     # Note this is a __slots__ __dict__ class!
@@ -93,6 +94,12 @@ class Histogram:
         "__dict__",
     )
     # .metadata and ._variance_known are part of the dict
+
+    _family: object = boost_histogram
+
+    def __init_subclass__(cls, *, family: object) -> None:
+        super().__init_subclass__()
+        cls._family = family
 
     def __init__(
         self,

--- a/src/boost_histogram/_internal/storage.py
+++ b/src/boost_histogram/_internal/storage.py
@@ -1,53 +1,51 @@
+import boost_histogram
+
 from .._core import storage as store
-from .utils import MAIN_FAMILY, set_family, set_module
+from .utils import set_module
 
 
 # Simple mixin to provide a common base class for types
 class Storage:
+    _family: object
+
+    def __init_subclass__(cls, *, family: object) -> None:
+        super().__init_subclass__()
+        cls._family = family
+
     def __repr__(self):
         return f"{self.__class__.__name__}()"
 
 
-# MAIN FAMILY
-
-
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.storage")
-class Int64(store.int64, Storage):
+class Int64(store.int64, Storage, family=boost_histogram):
     pass
 
 
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.storage")
-class Double(store.double, Storage):
+class Double(store.double, Storage, family=boost_histogram):
     pass
 
 
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.storage")
-class AtomicInt64(store.atomic_int64, Storage):
+class AtomicInt64(store.atomic_int64, Storage, family=boost_histogram):
     pass
 
 
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.storage")
-class Unlimited(store.unlimited, Storage):
+class Unlimited(store.unlimited, Storage, family=boost_histogram):
     pass
 
 
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.storage")
-class Weight(store.weight, Storage):
+class Weight(store.weight, Storage, family=boost_histogram):
     pass
 
 
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.storage")
-class Mean(store.mean, Storage):
+class Mean(store.mean, Storage, family=boost_histogram):
     pass
 
 
-@set_family(MAIN_FAMILY)
 @set_module("boost_histogram.storage")
-class WeightedMean(store.weighted_mean, Storage):
+class WeightedMean(store.weighted_mean, Storage, family=boost_histogram):
     pass

--- a/src/boost_histogram/_internal/utils.py
+++ b/src/boost_histogram/_internal/utils.py
@@ -1,8 +1,4 @@
-# Custom families (other packages can define custom families)
-MAIN_FAMILY = object()  # This family will be used as a fallback
-
-# These are not exported because custom user classes do not need to
-# add to the original families, they should make their own.
+import boost_histogram
 
 
 def set_module(name):
@@ -18,40 +14,22 @@ def set_module(name):
     return add_module
 
 
-def set_family(family):
-    """
-    Decorator to set the family of a class. When an object
-    is produced from the C++ bindings, it will look through
-    all subclasses of the base class (Axis, Transform, Storage,
-    etc.) to find a match. If possible, it will match the family
-    of the object that is producing it (Histogram, Axis, etc.).
-    If a family is not found, it will return the main family
-    as a fallback.
-    """
-
-    def add_family(cls):
-        cls._family = family
-        return cls
-
-    return add_family
-
-
 def register(cpp_types=None):
     """
     Decorator to register a C++ type to a Python class.
     Each class given will be added to a lookup list "_types"
     that cast knows about. It should also part of a "family",
     and any class in a family will cast to the same family.
-    See set_family. You do not need to register a class if it
-    inherits from the C++ class.
+    You do not need to register a class if it inherits from
+    the C++ class.
 
     For example, internally this call:
 
         ax = hist._axis(0)
 
     which will get a raw C++ object and need to cast it to a Python
-    wrapped object. There is currently one candidates (users
-    could add more): MAIN_FAMILY. Cast will use the
+    wrapped object. There is currently one candidate (users
+    could add more): boost_histogram. Cast will use the
     parent class's family to return the correct family. If the
     requested family is not found, then the regular family is the
     fallback.
@@ -121,10 +99,10 @@ def cast(self, cpp_object, parent_class):
         cast(self, hist.cpp_axis(), Axis)
         # -> returns Regular(...) if regular axis, etc.
 
-    If self is None, just use the MAIN_FAMILY.
+    If self is None, just use the boost_histogram family.
     """
     if self is None:
-        family = MAIN_FAMILY
+        family = boost_histogram
     else:
         family = self._family
 
@@ -152,7 +130,7 @@ def cast(self, cpp_object, parent_class):
                 return _cast_make_object(canidate_class, cpp_object, is_class)
 
             # Or remember the class if it was from the main family
-            if canidate_class._family is MAIN_FAMILY:
+            if canidate_class._family is boost_histogram:
                 fallback_class = canidate_class
 
     # If no perfect match was registered, return the main family

--- a/src/boost_histogram/utils.py
+++ b/src/boost_histogram/utils.py
@@ -1,3 +1,0 @@
-from ._internal.utils import set_family
-
-__all__ = ("set_family",)

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_allclose, assert_array_equal
 from pytest import approx
 
 import boost_histogram as bh
-import boost_histogram.utils
 
 
 @pytest.mark.parametrize(

--- a/tests/test_subclassing.py
+++ b/tests/test_subclassing.py
@@ -4,20 +4,16 @@ import boost_histogram as bh
 def test_subclass():
     NEW_FAMILY = object()
 
-    @bh.utils.set_family(NEW_FAMILY)
-    class MyHist(bh.Histogram):
+    class MyHist(bh.Histogram, family=NEW_FAMILY):
         pass
 
-    @bh.utils.set_family(NEW_FAMILY)
-    class MyRegular(bh.axis.Regular):
+    class MyRegular(bh.axis.Regular, family=NEW_FAMILY):
         __slots__ = ()
 
-    @bh.utils.set_family(NEW_FAMILY)
-    class MyIntStorage(bh.storage.Int64):
+    class MyIntStorage(bh.storage.Int64, family=NEW_FAMILY):
         pass
 
-    @bh.utils.set_family(NEW_FAMILY)
-    class MyPowTransform(bh.axis.transform.Pow):
+    class MyPowTransform(bh.axis.transform.Pow, family=NEW_FAMILY):
         pass
 
     h = MyHist(MyRegular(10, 0, 2, transform=MyPowTransform(2)), storage=MyIntStorage())


### PR DESCRIPTION
This is a much simpler to use family system. As a reminder, the old method (developed in #200, and which @HDembinski was still rightfully a little unhappy about in #456) is shown here:

```python
CUSTOM_FAMILY = object()

@bh.utils.set_family(CUSTOM_FAMILY)
class Hist(bh.Histogram):
    ...
```

This requires that you know about the magic decorator when you subclass Histogram, and if you forget it, there's no warning, you just don't convert to the right Python class from C++ all the time.

Now that we are Python 3.6+, we can support a much better system! Here it is:

```python
import hist

class Hist(bh.Histogram, family=hist):
    ...
```

There are two key changes. First, by making this a class keyword, this is now a missing "family" error if you do not set a family when subclassing! And, second, we change the recommendation for the tag object to the owning module. Any object supporting "is" still works, but this is a nice suggestion that also happens to be readable (`boost_histogram` is the family for the built-in classes). (Speaking of suggestions, not sure it's in the docs anywhere yet. I plan to do a docs sprint before 1.0). So users are now helped in making good subclasses, and don't have to find some weird `bh.utils` thing.

I'll take care up updating Hist with this; AFAIK that's the only user subclassing boost-histograms at the moment.

