### PR TITLE
docs: update for 1.0, part 1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
       with:
-        extra_args: -a --hook-stage manual
+        extra_args: -a docker-clang-format --hook-stage manual
 
   clang-tidy:
     name: Clang-Tidy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ci:
-  skip: [docker-clang-format]
+  skip:
+  - docker-clang-format
 
 repos:
 - repo: https://github.com/psf/black
@@ -12,8 +13,15 @@ repos:
   hooks:
   - id: nbqa-black
     additional_dependencies: [black==20.8b1]
-    args:
-      - "--nbqa-mutate"
+    args: ["--nbqa-mutate"]
+
+# - repo: https://github.com/asottile/blacken-docs
+#   rev: v1.10.0
+#   hooks:
+#   - id: blacken-docs
+#     additional_dependencies: [black==20.8b1]
+#     args: ["--target-version=py36"]
+#     stages: ["manual"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v3.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ pip install -ve .[all]
 
 You can set up a kernel for external Jupyter then deactivate your environment:
 
-```python
+```bash
 python -m ipykernel install --user --name boost-hist
 deactivate
 ```

--- a/README.md
+++ b/README.md
@@ -19,34 +19,13 @@
 Python bindings for [Boost::Histogram][] ([source][Boost::Histogram
 source]), a C++14 library. This is of the [fastest libraries][] for
 histogramming, while still providing the power of a full histogram object. See
-[what's new](./docs/CHANGELOG.md). 
+[what's new](./docs/CHANGELOG.md).
 
 For end users interested in analysis, see [Hist][], a first-party
 analyst-friendly histogram library that extends boost-histogram with many new
 shortcuts, plotting, and more.
 
-## Installation
-
-You can install this library from [PyPI](https://pypi.org/project/boost-histogram/) with pip:
-
-```bash
-python -m pip install boost-histogram
-```
-
-or you can use Conda through [conda-forge](https://github.com/conda-forge/boost-histogram-feedstock):
-
-```bash
-conda install -c conda-forge boost-histogram
-```
-
-All the normal best-practices for Python apply; you should be in a virtual
-environment, etc. Python 3.6+ is required; for older versions of Python,
-version `0.13` will be installed instead, which is API equivalent to 1.0, but
-will not be gaining new features.
-
-
 ## Usage
-
 
 ```python
 import boost_histogram as bh
@@ -59,15 +38,16 @@ hist = bh.Histogram(
 
 # Filling can be done with arrays, one per dimension
 hist.fill(
-    [0.3, 0.5, 0.2], [0.1, 0.4, 0.9]
+    [0.3, 0.5, 0.2],
+    [0.1, 0.4, 0.9],
 )
 
 # Numpy array view into histogram counts, no overflow bins
 values = hist.values()
 
 # Make a new histogram with just the second axis, summing over the first, and
-rebinning the second into larger bins:
-h2 = hist[::sum, ::bh.rebin(2)]
+# rebinning the second into larger bins:
+h2 = hist[::sum, :: bh.rebin(2)]
 ```
 
 We support the [uhi][] [PlottableHistogram][] protocol, so boost-histogram/hist
@@ -173,17 +153,27 @@ histograms can be plotted via any compatible library, such as [mplhep][].
 
 </details>
 
-## Supported platforms
+
+## Installation
+
+You can install this library from [PyPI](https://pypi.org/project/boost-histogram/) with pip:
+
+```bash
+python3 -m pip install boost-histogram
+```
+
+
+All the normal best-practices for Python apply; Pip should not be very old, you
+should be in a virtual environment, etc. Python 3.6+ is required; for older
+versions of Python, version `0.13` will be installed instead, which is API
+equivalent to 1.0, but will not be gaining new features.
 
 #### Binaries available:
 
-The easiest way to get boost-histogram is to use a binary wheel, which happens when you run:
-
-```bash
-python -m pip install boost-histogram
-```
-
-Wheels are produced using [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/); all common platforms have wheels provided in boost-histogram:
+The easiest way to get boost-histogram is to use a binary wheel, which happens
+when you run the above command on a supported platform.  Wheels are produced using
+[cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/); all common
+platforms have wheels provided in boost-histogram:
 
 | System | Arch | Python versions | PyPy versions |
 |---------|-----|------------------|--------------|
@@ -205,7 +195,7 @@ If you are on a Linux system that is not part of the "many" in manylinux, such a
 
 #### Conda-Forge
 
-The boost-histogram package is available on Conda-Forge, as well. All supported variants are available.
+The boost-histogram package is available on [conda-forge](https://github.com/conda-forge/boost-histogram-feedstock), as well. All supported variants are available.
 
 ```bash
 conda install -c conda-forge boost-histogram

--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@
 [![Scikit-HEP][sk-badge]](https://scikit-hep.org/)
 
 
-Python bindings for [Boost::Histogram][] ([source][Boost::Histogram source]), a
-C++14 library. This is of the [fastest libraries][] for
-histogramming, while still providing the power of a full histogram object. See [what's new](./docs/CHANGELOG.md). Powers [Hist][], an analyst-friendly histogram library.
+Python bindings for [Boost::Histogram][] ([source][Boost::Histogram
+source]), a C++14 library. This is of the [fastest libraries][] for
+histogramming, while still providing the power of a full histogram object. See
+[what's new](./docs/CHANGELOG.md). 
+
+For end users interested in analysis, see [Hist][], a first-party
+analyst-friendly histogram library that extends boost-histogram with many new
+shortcuts, plotting, and more.
 
 ## Installation
 
@@ -34,7 +39,10 @@ or you can use Conda through [conda-forge](https://github.com/conda-forge/boost-
 conda install -c conda-forge boost-histogram
 ```
 
-All the normal best-practices for Python apply; you should be in a virtual environment, etc.
+All the normal best-practices for Python apply; you should be in a virtual
+environment, etc. Python 3.6+ is required; for older versions of Python,
+version `0.13` will be installed instead, which is API equivalent to 1.0, but
+will not be gaining new features.
 
 
 ## Usage
@@ -56,9 +64,22 @@ hist.fill(
 
 # Numpy array view into histogram counts, no overflow bins
 values = hist.values()
+
+# Make a new histogram with just the second axis, summing over the first, and
+rebinning the second into larger bins:
+h2 = hist[::sum, ::bh.rebin(2)]
 ```
 
-## Features
+We support the [uhi][] [PlottableHistogram][] protocol, so boost-histogram/hist
+histograms can be plotted via any compatible library, such as [mplhep][].
+
+[uhi]: https://github.com/scikit-hep/uhi
+[PlottableHistogram]: https://uhi.readthedocs.io/en/latest/plotting.html
+[mplhep]: https://github.com/scikit-hep/mplhep
+
+## Cheatsheet
+
+<details><summary>Simplified list of features (click to expand)</summary>
 
 * Many axis types (all support `metadata=...`)
     * `bh.axis.Regular(n, start, stop, ...)`: Make a regular axis. Options listed below.
@@ -70,9 +91,10 @@ values = hist.values()
         * `transform=bh.axis.transform.Sqrt`: Square root spacing
         * `transform=bh.axis.transform.Pow(v)`: Power spacing
         * See also the flexible [Function transform](https://boost-histogram.readthedocs.io/en/latest/usage/transforms.html)
-    * `bh.axis.Integer(start, stop, underflow=True, overflow=True, growth=False)`: Special high-speed version of `regular` for evenly spaced bins of width 1
-    * `bh.axis.Variable([start, edge1, edge2, ..., stop], underflow=True, overflow=True)`: Uneven bin spacing
-    * `bh.axis.Category([...], growth=False)`: Integer or string categories
+    * `bh.axis.Integer(start, stop, *, underflow=True, overflow=True, growth=False, circular=False)`: Special high-speed version of `regular` for evenly spaced bins of width 1
+    * `bh.axis.Variable([start, edge1, edge2, ..., stop], *, underflow=True, overflow=True, circular=False)`: Uneven bin spacing
+    * `bh.axis.IntCategory([...], *, growth=False)`: Integer categories
+    * `bh.axis.StrCategory([...], *, growth=False)`: String categories
     * `bh.axis.Boolean()`: A True/False axis
 * Axis features:
     * `.index(value)`: The index at a point (or points) on the axis
@@ -82,7 +104,7 @@ values = hist.values()
     * `.edges`: The N+1 bin edges (if continuous)
     * `.extent`: The number of bins (including under/overflow)
     * `.metadata`: Anything a user wants to store
-    * `.traits`: The options set on the axis (`bh.axis.options`)
+    * `.traits`: The options set on the axis
     * `.size`: The number of bins (not including under/overflow)
     * `.widths`: The N bin widths
 * Many storage types
@@ -106,8 +128,8 @@ values = hist.values()
   * `/=`: Divide by a scaler (not all storages) (`hist / scalar` supported too)
   * `.kind`: Either `bh.Kind.COUNT` or `bh.Kind.MEAN`, depending on storage
   * `.sum(flow=False)`: The total count of all bins
-  * `.project(ax1, ax2, ...)`: Project down to listed axis (numbers)
-  * `.to_numpy(flow=False)`: Convert to a NumPy style tuple (with or without under/overflow bins)
+  * `.project(ax1, ax2, ...)`: Project down to listed axis (numbers). Can also reorder axes.
+  * `.to_numpy(flow=False, view=False)`: Convert to a NumPy style tuple (with or without under/overflow bins)
   * `.view(flow=False)`: Get a view on the bin contents (with or without under/overflow bins)
   * `.values(flow=False)`: Get a view on the values (counts or means, depending on storage)
   * `.variances(flow=False)`: Get the variances if available
@@ -126,7 +148,7 @@ values = hist.values()
       * `.axes.bin(*args)`: Returns the bin edges as a tuple of pairs (continuous axis) or values (describe)
       * `.axes.index(*args)`: Returns the bin index at a value for each axis
       * `.axes.value(*args)`: Returns the bin value at an index for each axis
-* Indexing - Supports the [Unified Histogram Indexing (UHI)](https://boost-histogram.readthedocs.io/en/latest/usage/indexing.html) proposal
+* Indexing - Supports [UHI Indexing](https://uhi.readthedocs.io/en/latest/indexing.html)
     * Bin content access / setting
         * `v = h[b]`: Access bin content by index number
         * `v = h[{0:b}]`: All actions can be represented by `axis:item` dictionary instead of by position (mostly useful for slicing)
@@ -147,9 +169,9 @@ values = hist.values()
     * Histograms follow the buffer interface, and provide `.view()`
     * Histograms can be converted to NumPy style output tuple with `.to_numpy()`
 * Details
-    * Use `bh.Histogram(..., storage=...)` to make a histogram (there are several different types)
     * All objects support copy/deepcopy/pickle
 
+</details>
 
 ## Supported platforms
 
@@ -173,16 +195,13 @@ Wheels are produced using [cibuildwheel](https://cibuildwheel.readthedocs.io/en/
 | Windows | 32 & 64-bit | 3.6, 3.7, 3.8, 3.9 | (32 bit) 7.3: 3.6, 3.7 |
 
 
-* manylinux1: Using a custom docker container with GCC 9; should work but can't be called directly other compiled extensions unless they do the same thing (think that's the main caveat). Supporting 32 bits because it's there. Anything running Python 3.9 should be compatible with manylinux2010, so manylinux1 not provided for Python 3.9 (like NumPy).
-* manylinux2010: Requires pip 10+ and a version of Linux newer than 2010.
-* PyPy: Supported  for both pypy3.6 and pypy3.7 variants.
+* manylinux1: Using a custom docker container with GCC 9 to produce. Anything running Python 3.9 should be compatible with manylinux2010, so manylinux1 not provided for Python 3.9 (like NumPy).
+* manylinux2010: Requires pip 10+.
+* PyPy 7.3.x: Supported for both pypy3.6 and pypy3.7 variants on all platforms.
 * ARM on Linux is supported for newer Python versions via `manylinux2014`. PowerPC or IBM-Z available on request, or `manylinux_2_24`.
 * macOS Universal2 wheels for Apple Silicon and Intel provided for Python 3.9 (requires Pip 21.0.1).
 
-[msvc2015]: https://www.microsoft.com/en-us/download/details.aspx?id=48145
-
-If you are on a Linux system that is not part of the "many" in manylinux, such as Alpine or ClearLinux, building from source is usually fine, since the compilers on those systems are often quite new. It will just take longer to install when it is using the sdist instead of a wheel.
-
+If you are on a Linux system that is not part of the "many" in manylinux, such as Alpine or ClearLinux, building from source is usually fine, since the compilers on those systems are often quite new. It will just take longer to install when it is using the sdist instead of a wheel. All dependencies are header-only and included.
 
 #### Conda-Forge
 
@@ -194,17 +213,19 @@ conda install -c conda-forge boost-histogram
 
 #### Source builds
 
-For a source build, for example from an "sdist" package, the only requirements are a C++14 compatible compiler. The compiler requirements are dictated by Boost.Histogram's C++ requirements: gcc >= 5.5, clang >= 3.8, msvc >= 14.1. You should have a version of pip less than 2-3 years old (10+).
+For a source build, for example from an "SDist" package, the only requirements are a C++14 compatible compiler. The compiler requirements are dictated by Boost.Histogram's C++ requirements: gcc >= 5.5, clang >= 3.8, or msvc >= 14.1. You should have a version of pip less than 2-3 years old (10+).
 
-Boost is not required or needed (this only depends on included header-only dependencies). This library is under active development; you can install directly from GitHub if you would like.
+Boost is not required or needed (this only depends on included header-only dependencies). You can install directly from GitHub if you would like.
 
 ```bash
 python -m pip install git+https://github.com/scikit-hep/boost-histogram.git@develop
 ```
 
+
 ## Developing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for details on how to set up a development environment.
+
 
 ## Contributors
 

--- a/docs/usage/analyses.rst
+++ b/docs/usage/analyses.rst
@@ -36,7 +36,7 @@ True ``is_valid`` selection, you can use a ``sum``:
 
 .. code:: python3
 
-   h1 = hist[:, True, ::bh.sum]
+   h1 = hist[:, True, :: bh.sum]
 
 You can expand this example to any number of dimensions, boolean flags,
 and categories.

--- a/docs/usage/histogram.rst
+++ b/docs/usage/histogram.rst
@@ -72,10 +72,10 @@ You can save a histogram using pickle:
 
     import pickle
 
-    with open('file.pkl', 'wb') as f:
+    with open("file.pkl", "wb") as f:
         pickle.dump(h, f)
 
-    with open('file.pkl', 'rb') as f:
+    with open("file.pkl", "rb") as f:
         h2 = pickle.load(f)
 
     assert h == h2

--- a/docs/usage/indexing.rst
+++ b/docs/usage/indexing.rst
@@ -195,7 +195,7 @@ shortcut to quickly generate slices is provided, as well:
 
 .. code:: python3
 
-   ans = h[{1: slice(None,bh.loc(2.4),bh.sum)}]
+   ans = h[{1: slice(None, bh.loc(2.4), bh.sum)}]
 
    # Identical:
    s = bh.tag.Slicer()
@@ -298,7 +298,9 @@ Basic implementation (WIP):
                    high = binning.left(indexes[-1][-1])
                    hasover = True
 
-               binning = Regular(num, binning.low, high, hasunder=binning.hasunder, hasover=hasover)
+               binning = Regular(
+                   num, binning.low, high, hasunder=binning.hasunder, hasover=hasover
+               )
                counts = numpy.add.reduceat(counts, numpy.concatenate(indexes), axis=axis)
                return binning, counts
 

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -40,7 +40,7 @@ The exact same syntax is used for 1D, 2D, and ND histograms:
    hist3D = bh.Histogram(
        bh.axis.Regular(10, 0, 100, circular=True),
        bh.axis.Regular(10, 0.0, 10.0),
-       bh.axis.Variable([1, 2, 3, 4, 5, 5.5, 6])
+       bh.axis.Variable([1, 2, 3, 4, 5, 5.5, 6]),
    )
 
 See :ref:`usage-axes` and :ref:`usage-transforms`.
@@ -76,7 +76,7 @@ using ``bh.sum`` as the third slice argument:
         bh.axis.Regular(10, 0, 1),
         bh.axis.Regular(10, 0, 1),
     )
-    mini = hist[1:5, bh.loc(0.2):bh.loc(0.9), ::bh.sum]
+    mini = hist[1:5, bh.loc(0.2) : bh.loc(0.9), :: bh.sum]
     # Will be 4 bins x 7 bins
 
 See :ref:`usage-indexing`.
@@ -110,8 +110,8 @@ you can set either values or arrays at a time:
 .. code:: python3
 
     hist[2] = 3.5
-    hist[bh.underflow] = 0 # set the underflow bin
-    hist2d[3:5, 2:4] = np.eye(2) # set with array
+    hist[bh.underflow] = 0  # set the underflow bin
+    hist2d[3:5, 2:4] = np.eye(2)  # set with array
 
 For non-simple storages, you can add an extra dimension that matches the
 constructor arguments of that accumulator. For example, if you want to fill
@@ -119,7 +119,7 @@ a Weight histogram with three values, you can dimension:
 
 .. code:: python3
 
-    hist[0:3] = [[1,.1], [2, .2], [3, .3]]
+    hist[0:3] = [[1, 0.1], [2, 0.2], [3, 0.3]]
 
 See :ref:`usage-indexing`.
 
@@ -147,10 +147,10 @@ You can save histograms using pickle:
 
     import pickle
 
-    with open('file.pkl', 'wb') as f:
+    with open("file.pkl", "wb") as f:
         pickle.dump(h, f)
 
-    with open('file.pkl', 'rb') as f:
+    with open("file.pkl", "rb") as f:
         h2 = pickle.load(f)
 
     assert h == h2

--- a/docs/usage/storage.rst
+++ b/docs/usage/storage.rst
@@ -23,9 +23,9 @@ a copy.
 
 .. code:: python3
 
-    h = bh.Histogram(bh.axis.Regular(10, 0, 1))    # Double() is the default
-    h.fill([.2, .3], weight=[.5, 2])             # Weights are optional
-    print(f"{h[bh.loc(.2)]=}\n{h[bh.loc(.3)]=}") # Python 3.8 print
+    h = bh.Histogram(bh.axis.Regular(10, 0, 1))  # Double() is the default
+    h.fill([0.2, 0.3], weight=[0.5, 2])  # Weights are optional
+    print(f"{h[bh.loc(.2)]=}\n{h[bh.loc(.3)]=}")  # Python 3.8 print
 
 .. code:: text
 
@@ -50,7 +50,7 @@ non-integer fills for data that should represent raw, unweighed counts.
 .. code:: python3
 
     h = bh.Histogram(bh.axis.Regular(10, 0, 1), storage=bh.storage.Int64())
-    h.fill([.2, .3], weight=[1, 2])               # Integer weights supported
+    h.fill([0.2, 0.3], weight=[1, 2])  # Integer weights supported
     print(f"{h[bh.loc(.2)]=}\n{h[bh.loc(.2)]=}")
 
 .. code:: text

--- a/docs/usage/transforms.rst
+++ b/docs/usage/transforms.rst
@@ -30,13 +30,18 @@ transformed axis, and this will be 15-90 times slower than a compiled method, li
 .. code-block:: python
 
    import ctypes
+
    ftype = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double)
 
    # Pure Python (15x slower)
-   bh.axis.Regular(10, 1, 4, transform=bh.axis.transform.Function(ftype(math.log), ftype(math.exp)))
+   bh.axis.Regular(
+       10, 1, 4, transform=bh.axis.transform.Function(ftype(math.log), ftype(math.exp))
+   )
 
    # Pure Python: Numpy (90x slower)
-   bh.axis.Regular(10, 1, 4, transform=bh.axis.transform.Function(ftype(np.log), ftype(np.exp)))
+   bh.axis.Regular(
+       10, 1, 4, transform=bh.axis.transform.Function(ftype(np.log), ftype(np.exp))
+   )
 
 You can create a Variable axis from the edges of this axis; often that will be faster.
 
@@ -54,13 +59,16 @@ a callable that will run directly through the C interface. This is just as fast 
 
    import numba
 
+
    @numba.cfunc(numba.float64(numba.float64))
    def exp(x):
        return math.exp(x)
 
+
    @numba.cfunc(numba.float64(numba.float64))
    def log(x):
        return math.log(x)
+
 
    bh.axis.Regular(10, 1, 4, transform=bh.axis.transform.Function(log, exp))
 
@@ -93,6 +101,7 @@ You can now use it like this:
 .. code-block:: python
 
    import ctypes
+
    ftype = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double)
 
    mylib = ctypes.CDLL("mylib.so")
@@ -130,7 +139,13 @@ ctypes call into the convert function. You need a little wrapper function to mak
        ftype = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double)
        return ftype(func)
 
-   bh.axis.Regular(10, 1, 4, transform=bh.axis.transform.Function(math.log, math.exp, convert=convert_python))
+
+   bh.axis.Regular(
+       10,
+       1,
+       4,
+       transform=bh.axis.transform.Function(math.log, math.exp, convert=convert_python),
+   )
 
 That's it.
 
@@ -145,14 +160,21 @@ function. Here are your options:
 
     import numba, math
 
+
     def convert_numba(func):
         return numba.cfunc(numba.double(numba.double))(func)
 
+
     # Built-ins and ufuncs need to be wrapped (numba can't read a signature)
     # User functions would not need the lambda
-    bh.axis.Regular(10, 1, 4,
-                    transform=bh.axis.transform.Function(lambda x: math.log(x), lambda x: math.exp(x),
-                                                         convert=convert_numba))
+    bh.axis.Regular(
+        10,
+        1,
+        4,
+        transform=bh.axis.transform.Function(
+            lambda x: math.log(x), lambda x: math.exp(x), convert=convert_numba
+        ),
+    )
 
 Note that ``numba.cfunc`` does not work on its own builtins, but requires a user function. Since with the exception
 of the simple example I'm showing here that is already available directly in boost-histogram, you will probably be
@@ -170,6 +192,7 @@ You can use strings to look up functions in the shared library:
        function = getattr(mylib, name)
        return ctypes.cast(function, ftype)
 
-   bh.axis.Regular(10, 1, 4,
-                   transform=bh.axis.transform.Function("my_log", "my_exp",
-                                                         convert=lookup))
+
+   bh.axis.Regular(
+       10, 1, 4, transform=bh.axis.transform.Function("my_log", "my_exp", convert=lookup)
+   )

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ maintainer_email = hschrein@cern.ch
 license = BSD-3-Clause
 license_file = LICENSE
 classifiers =
-    Development Status :: 4 - Beta
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     Intended Audience :: Information Technology
     Intended Audience :: Science/Research


### PR DESCRIPTION
Working on some docs cleanup and updates. So far:

Updated the readme quite a bit, making the cheatsheet unexpanded by default, and highlighting other integrations a bit more (hist, mplhep, uhi).

Reformatted some of the examples in the docs to use Black. Some areas (like the indexing page) are already carefully formatted, so it's just a manual hook for now.

TODO:
* Point at the UHI docs instead of repeating them, to reduce duplication
* Reduce duplication a bit, period - the same information shows up in a couple
  of places. It's hard to avoid some duplication with the README unless we
  reformat the README to rst (and even then can be tricky).

