### PR TITLE
fix: restore metadata in repr

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,9 +13,13 @@ families.
 * Use keyword class family setting when subclassing histogram components
   instead of custom decorator. [#513][]
 
+#### Bug fixes
+* Consistently show `metadata=` in repr if present; refactored internal repr handling [#518][]
+
 [#503]: https://github.com/scikit-hep/boost-histogram/pull/503
 [#512]: https://github.com/scikit-hep/boost-histogram/pull/512
 [#513]: https://github.com/scikit-hep/boost-histogram/pull/513
+[#518]: https://github.com/scikit-hep/boost-histogram/pull/518
 
 
 ## Version 0.13

--- a/docs/usage/subclassing.rst
+++ b/docs/usage/subclassing.rst
@@ -42,4 +42,5 @@ libraries. ``cls._export_bh(self)`` is called from the outgoing class (being
 converted from), and ``self._import_bh_()`` is called afterward on the incoming
 class (being converted to). So if ``h1`` is an instance of ``H1``, and ``H2``
 is the new class, then ``H2(h1)`` calls ``H1._export_bh_(h2)`` and then
-``h2._import_bh()`` before returning ``h2``.
+``h2._import_bh()`` before returning ``h2``. The internal repr building for axes is
+a list produced by ``_repr_args_`` representing each item in the repr.

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -5,6 +5,7 @@ from typing import (
     Dict,
     Iterable,
     Iterator,
+    List,
     Optional,
     Set,
     Tuple,
@@ -177,27 +178,20 @@ class Axis:
         return begin, end
 
     def __repr__(self) -> str:
-        return "{self.__class__.__name__}({args}{kwargs})".format(
-            self=self, args=self._repr_args(), kwargs=self._repr_kwargs()
-        )
+        arg_str = ", ".join(self._repr_args_())
+        return f"{self.__class__.__name__}({arg_str})"
 
-    def _repr_kwargs(self) -> str:
+    def _repr_args_(self) -> List[str]:
         """
-        Return options for use in repr. Metadata is last,
-        just in case it spans multiple lines.
+        Return arg options for use in the repr as strings.
         """
 
-        ret = ""
-        if self.traits.growth:
-            ret += ", growth=True"
-        elif self.traits.circular:
-            ret += ", circular=True"
-        else:
-            if not self.traits.underflow:
-                ret += ", underflow=False"
-            if not self.traits.overflow:
-                ret += ", overflow=False"
-
+        ret = []
+        if self.metadata is not None:
+            if isinstance(self.metadata, str):
+                ret.append(f"metadata={self.metadata!r}")
+            else:
+                ret.append("metadata=...")
         return ret
 
     @property
@@ -363,18 +357,25 @@ class Regular(Axis, family=boost_histogram):
 
         super().__init__(ax, metadata, __dict__)
 
-    def _repr_args(self) -> str:
+    def _repr_args_(self) -> List[str]:
         "Return inner part of signature for use in repr"
 
-        return "{bins:g}, {start:g}, {stop:g}".format(
-            bins=self.size, start=self.edges[0], stop=self.edges[-1]
-        )
+        ret = [f"{self.size:g}", f"{self.edges[0]:g}", f"{self.edges[-1]:g}"]
 
-    def _repr_kwargs(self) -> str:
-        ret = super()._repr_kwargs()
+        if self.traits.growth:
+            ret.append("growth=True")
+        elif self.traits.circular:
+            ret.append("circular=True")
+        else:
+            if not self.traits.underflow:
+                ret.append("underflow=False")
+            if not self.traits.overflow:
+                ret.append("overflow=False")
 
         if self.transform is not None:
-            ret += f", transform={self.transform}"
+            ret.append(f"transform={self.transform}")
+
+        ret += super()._repr_args_()
 
         return ret
 
@@ -458,13 +459,27 @@ class Variable(Axis, family=boost_histogram):
 
         super().__init__(ax, metadata, __dict__)
 
-    def _repr_args(self) -> str:
+    def _repr_args_(self) -> List[str]:
         "Return inner part of signature for use in repr"
 
         if len(self) > 20:
-            return repr(self.edges)
+            ret = [repr(self.edges)]
         else:
-            return "[{}]".format(", ".join(format(v, "g") for v in self.edges))
+            ret = ["[{}]".format(", ".join(format(v, "g") for v in self.edges))]
+
+        if self.traits.growth:
+            ret.append("growth=True")
+        elif self.traits.circular:
+            ret.append("circular=True")
+        else:
+            if not self.traits.underflow:
+                ret.append("underflow=False")
+            if not self.traits.overflow:
+                ret.append("overflow=False")
+
+        ret += super()._repr_args_()
+
+        return ret
 
 
 @register(
@@ -540,31 +555,40 @@ class Integer(Axis, family=boost_histogram):
 
         super().__init__(ax, metadata, __dict__)
 
-    def _repr_args(self) -> str:
+    def _repr_args_(self) -> List[str]:
         "Return inner part of signature for use in repr"
 
-        return f"{self.edges[0]:g}, {self.edges[-1]:g}"
+        ret = [f"{self.edges[0]:g}", f"{self.edges[-1]:g}"]
+
+        if self.traits.growth:
+            ret.append("growth=True")
+        elif self.traits.circular:
+            ret.append("circular=True")
+        else:
+            if not self.traits.underflow:
+                ret.append("underflow=False")
+            if not self.traits.overflow:
+                ret.append("overflow=False")
+
+        ret += super()._repr_args_()
+
+        return ret
 
 
 class BaseCategory(Axis, family=boost_histogram):
     __slots__ = ()
 
-    def _repr_kwargs(self) -> str:
-        """
-        Return options for use in repr. Metadata is last,
-        just in case it spans multiple lines.
+    def _repr_args_(self) -> List[str]:
+        "Return inner part of signature for use in repr"
 
+        ret = []
 
-        This is specialized for Category axes to avoid repeating
-        the flow arguments unnecessarily.
-        """
-
-        ret = ""
         if self.traits.growth:
-            ret += ", growth=True"
+            ret.append("growth=True")
         elif self.traits.circular:
-            ret += ", circular=True"
+            ret.append("circular=True")
 
+        ret += super()._repr_args_()
         return ret
 
 
@@ -628,10 +652,12 @@ class StrCategory(BaseCategory, family=boost_histogram):
                 )
             )
 
-    def _repr_args(self) -> str:
+    def _repr_args_(self) -> List[str]:
         "Return inner part of signature for use in repr"
 
-        return "[{}]".format(", ".join(repr(c) for c in self))
+        ret = ["[{}]".format(", ".join(repr(c) for c in self))]
+        ret += super()._repr_args_()
+        return ret
 
 
 @set_module("boost_histogram.axis")
@@ -677,10 +703,12 @@ class IntCategory(BaseCategory, family=boost_histogram):
 
         super().__init__(ax, metadata, __dict__)
 
-    def _repr_args(self) -> str:
+    def _repr_args_(self) -> List[str]:
         "Return inner part of signature for use in repr"
 
-        return "[{}]".format(", ".join(format(c, "g") for c in self))
+        ret = ["[{}]".format(", ".join(format(c, "g") for c in self))]
+        ret += super()._repr_args_()
+        return ret
 
 
 # Contains all common methods and properties for the boolean axis
@@ -707,24 +735,16 @@ class Boolean(Axis, family=boost_histogram):
 
         super().__init__(ax, metadata, __dict__)
 
-    def _repr_args(self) -> str:
+    def _repr_args_(self) -> List[str]:
         "Return inner part of signature for use in repr"
-        if self.size == 2:
-            return ""
-        elif self.size == 0:
-            return "<empty>"
+        ret = []
+
+        if self.size == 0:
+            ret.append("<empty>")
         elif self.size == 1 and self.centers[0] < 0.75:
-            return "<False>"
+            ret.append("<False>")
         elif self.size == 1:
-            return "<True>"
-        else:
-            # Shouldn't be possible, can't grow
-            return "<unknown>"
+            ret.append("<True>")
 
-    def _repr_kwargs(self) -> str:
-        """
-        Return options for use in repr. Metadata is last,
-        just in case it spans multiple lines.
-        """
-
-        return ""
+        ret += super()._repr_args_()
+        return ret

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -37,7 +37,7 @@ def _isstr(value: Any) -> bool:
         return False
 
 
-def opts(**kwargs: bool) -> Set[str]:
+def _opts(**kwargs: bool) -> Set[str]:
     return {k for k, v in kwargs.items() if v}
 
 
@@ -319,7 +319,7 @@ class Regular(Axis, family=boost_histogram):
             The full metadata dictionary
         """
 
-        options = opts(
+        options = _opts(
             underflow=underflow, overflow=overflow, growth=growth, circular=circular
         )
 
@@ -434,7 +434,7 @@ class Variable(Axis, family=boost_histogram):
             The full metadata dictionary
         """
 
-        options = opts(
+        options = _opts(
             underflow=underflow, overflow=overflow, growth=growth, circular=circular
         )
 
@@ -532,7 +532,7 @@ class Integer(Axis, family=boost_histogram):
             The full metadata dictionary
         """
 
-        options = opts(
+        options = _opts(
             underflow=underflow, overflow=overflow, growth=growth, circular=circular
         )
 
@@ -624,7 +624,7 @@ class StrCategory(BaseCategory, family=boost_histogram):
             The full metadata dictionary
         """
 
-        options = opts(growth=growth)
+        options = _opts(growth=growth)
 
         # henryiii: We currently expand "abc" to "a", "b", "c" - some
         # Python interfaces protect against that
@@ -692,7 +692,7 @@ class IntCategory(BaseCategory, family=boost_histogram):
             The full metadata dictionary
         """
 
-        options = opts(growth=growth)
+        options = _opts(growth=growth)
 
         if options == {"growth"}:
             ax = ca.category_int_growth(tuple(categories))

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -218,16 +218,16 @@ class TestRegular(Axis):
         assert repr(ax) == "Regular(4, 1.1, 2.2)"
 
         ax = bh.axis.Regular(4, 1.1, 2.2, metadata="ra")
-        assert repr(ax) == "Regular(4, 1.1, 2.2)"
+        assert repr(ax) == "Regular(4, 1.1, 2.2, metadata='ra')"
 
         ax = bh.axis.Regular(4, 1.1, 2.2, underflow=False)
         assert repr(ax) == "Regular(4, 1.1, 2.2, underflow=False)"
 
         ax = bh.axis.Regular(4, 1.1, 2.2, metadata="ra", overflow=False)
-        assert repr(ax) == "Regular(4, 1.1, 2.2, overflow=False)"
+        assert repr(ax) == "Regular(4, 1.1, 2.2, overflow=False, metadata='ra')"
 
         ax = bh.axis.Regular(4, 1.1, 2.2, metadata="ra", circular=True)
-        assert repr(ax) == "Regular(4, 1.1, 2.2, circular=True)"
+        assert repr(ax) == "Regular(4, 1.1, 2.2, circular=True, metadata='ra')"
 
         ax = bh.axis.Regular(4, 1.1, 2.2, transform=bh.axis.transform.log)
         assert repr(ax) == "Regular(4, 1.1, 2.2, transform=log)"
@@ -402,7 +402,7 @@ class TestCircular(Axis):
         assert repr(ax) == "Regular(4, 1.1, 2.2, circular=True)"
 
         ax = bh.axis.Regular(4, 1.1, 2.2, metadata="hi", circular=True)
-        assert repr(ax) == "Regular(4, 1.1, 2.2, circular=True)"
+        assert repr(ax) == "Regular(4, 1.1, 2.2, circular=True, metadata='hi')"
 
     def test_getitem(self):
         a = bh.axis.Regular(2, 1, 1 + np.pi * 2, circular=True)
@@ -515,7 +515,7 @@ class TestVariable(Axis):
         assert repr(a) == "Variable([-0.1, 0.2])"
 
         a = bh.axis.Variable([-0.1, 0.2], metadata="hi")
-        assert repr(a) == "Variable([-0.1, 0.2])"
+        assert repr(a) == "Variable([-0.1, 0.2], metadata='hi')"
 
     def test_getitem(self):
         ref = [-0.1, 0.2, 0.3]
@@ -634,7 +634,10 @@ class TestInteger:
         assert repr(a) == "Integer(-1, 1)"
 
         a = bh.axis.Integer(-1, 1, metadata="hi")
-        assert repr(a) == "Integer(-1, 1)"
+        assert repr(a) == "Integer(-1, 1, metadata='hi')"
+
+        a = bh.axis.Integer(-1, 1, metadata=2)
+        assert repr(a) == "Integer(-1, 1, metadata=...)"
 
         a = bh.axis.Integer(-1, 1, underflow=False)
         assert repr(a) == "Integer(-1, 1, underflow=False)"
@@ -754,10 +757,10 @@ class TestCategory(Axis):
         assert repr(ax) == "IntCategory([1, 2, 3])"
 
         ax = bh.axis.IntCategory([1, 2, 3], metadata="foo")
-        assert repr(ax) == "IntCategory([1, 2, 3])"
+        assert repr(ax) == "IntCategory([1, 2, 3], metadata='foo')"
 
         ax = bh.axis.StrCategory("ABC", metadata="foo")
-        assert repr(ax) == "StrCategory(['A', 'B', 'C'])"
+        assert repr(ax) == "StrCategory(['A', 'B', 'C'], metadata='foo')"
 
     @pytest.mark.parametrize("ref", ([1, 2, 3], "ABC"))
     def test_getitem(self, ref, growth):
@@ -855,7 +858,7 @@ class TestBoolean:
         assert repr(a) == "Boolean()"
 
         a = bh.axis.Boolean(metadata="hi")
-        assert repr(a) == "Boolean()"
+        assert repr(a) == "Boolean(metadata='hi')"
 
     def test_label(self):
         a = bh.axis.Boolean(metadata="foo")


### PR DESCRIPTION
Restore metadata in all the reprs, as requested by @HDembinski a while back. Now that we have a way to store "long" metadata (not nice to print) via `__dict__`, showing metadata= isn't a problem. It was partially shown before, but was missing on some axes types (category and boolean, at least). This also provides a more structured method for building the repr, and is clearly named to indicate that Hist is using it too.

- fix: metadata repr restored
- refactor: use more consistent name
