### PR TITLE
chore: support version in mypy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -99,9 +99,6 @@ warn_return_any = True
 no_implicit_reexport = True
 strict_equality = True
 
-[mypy-boost_histogram.version]
-ignore_missing_imports = True
-
 [check-manifest]
 ignore =
     .all-contributorsrc

--- a/src/boost_histogram/version.pyi
+++ b/src/boost_histogram/version.pyi
@@ -1,0 +1,2 @@
+version: str
+version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]


### PR DESCRIPTION
This drops an "unused" flag in setup.cfg, but better yet supports downstream projects accessing the version too.
