### PR TITLE
fix(types): ellipsis support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Version 1.0
 
+### Version 1.0.1
+
+#### Typing changes
+
+* Added Ellipsis support to typing. [#525][]
+
+[#526]: https://github.com/scikit-hep/boost-histogram/pull/526
+
+### Version 1.0.0
+
 Dropped support for Python 2 and 3.5; removed large numbers of workarounds.
 Fully statically typed. API compatible with the final `0.x` release for most
 uses, except for subclassing; subclassing histogram components now uses Python

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -33,6 +33,9 @@ from .typing import Accumulator, ArrayLike, CppHistogram, SupportsIndex
 from .utils import cast, register, set_module
 from .view import View, _to_view
 
+if TYPE_CHECKING:
+    from builtins import ellipsis
+
 NOTHING = object()
 
 
@@ -49,7 +52,7 @@ _histograms: Set[Type[CppHistogram]] = {
 
 CppAxis = NewType("CppAxis", object)
 
-InnerIndexing = Union[SupportsIndex, Callable[[Axis], int], slice]
+InnerIndexing = Union[SupportsIndex, Callable[[Axis], int], slice, "ellipsis"]
 IndexingWithMapping = Union[InnerIndexing, Mapping[int, InnerIndexing]]
 IndexingExpr = Union[IndexingWithMapping, Tuple[IndexingWithMapping, ...]]
 

--- a/src/boost_histogram/_internal/typing.py
+++ b/src/boost_histogram/_internal/typing.py
@@ -7,6 +7,8 @@ else:
     from typing import Protocol, SupportsIndex
 
 if TYPE_CHECKING:
+    from builtins import ellipsis
+
     from numpy import ufunc as Ufunc
     from numpy.typing import ArrayLike
 
@@ -41,5 +43,7 @@ class AxisLike(Protocol):
         ...
 
 
-StdIndex = Union[int, slice, Tuple[Union[slice, int], ...]]
-StrIndex = Union[int, slice, str, Tuple[Union[slice, int, str], ...]]
+StdIndex = Union[int, slice, "ellipsis", Tuple[Union[slice, int, "ellipsis"], ...]]
+StrIndex = Union[
+    int, slice, str, "ellipsis", Tuple[Union[slice, int, str, "ellipsis"], ...]
+]


### PR DESCRIPTION
See #525. Ellipsis was missing from typing support.

- fix(types): support ellipsis in get/set
- fix(types): support ellipsis in View
