### PR TITLE
fix(types): better typing for view returns

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,9 +11,11 @@
 #### Typing changes
 
 * Added Ellipsis support to typing. [#525][]
+* Better typing for Views. [#530][]
 
 [#526]: https://github.com/scikit-hep/boost-histogram/pull/526
 [#529]: https://github.com/scikit-hep/boost-histogram/pull/529
+[#530]: https://github.com/scikit-hep/boost-histogram/pull/530
 
 ### Version 1.0.0
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -31,7 +31,7 @@ from .enum import Kind
 from .storage import Double, Storage
 from .typing import Accumulator, ArrayLike, CppHistogram, SupportsIndex
 from .utils import cast, register, set_module
-from .view import View, _to_view
+from .view import MeanView, WeightedMeanView, WeightedSumView, _to_view
 
 if TYPE_CHECKING:
     from builtins import ellipsis
@@ -279,7 +279,9 @@ class Histogram:
         """
         return self._hist.rank()  # type: ignore
 
-    def view(self, flow: bool = False) -> Union[np.ndarray, View]:
+    def view(
+        self, flow: bool = False
+    ) -> Union[np.ndarray, WeightedSumView, WeightedMeanView, MeanView]:
         """
         Return a view into the data, optionally with overflow turned on.
         """


### PR DESCRIPTION
See #527. This improves the return type for `.view()`, and helps with the typing of views.
