### PR TITLE
fix: allow Histogram-only subclassing to be simpler

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Version 1.0.1
 
+#### Subclassing Histogram changes
+
+* A `family=` is no longer required if you _only_ subclass Histogram. [#533][]
+
 #### Bug fixes
 
 * Added missing dependency on `typing_extensions` for Python 3.6 & 3.7 [#529][]
@@ -18,6 +22,7 @@
 [#529]: https://github.com/scikit-hep/boost-histogram/pull/529
 [#530]: https://github.com/scikit-hep/boost-histogram/pull/530
 [#532]: https://github.com/scikit-hep/boost-histogram/pull/532
+[#533]: https://github.com/scikit-hep/boost-histogram/pull/532
 
 ### Version 1.0.0
 

--- a/docs/usage/subclassing.rst
+++ b/docs/usage/subclassing.rst
@@ -4,7 +4,7 @@
 Subclassing (advanced)
 ======================
 
-Subclassing boost-histogram components is supported, but requires a little extra care to ensure the subclasses do not return un-wrapped boost-histogram components when a subclassed version is available. The issue is that various actions make the C++ -> Python transition over again, such as using ``.project()``. For example, let's say you have a MyHistogram and a MyRegular. If you use ``project(0)``, that needs to also return a MyRegular, but it is reconverting the return value from C++ to Python, so it has to somehow know that MyRegular is the right axis subclass to select from for MyHistogram. This is accomplished with families.
+Subclassing boost-histogram components is supported, but requires a little extra care to ensure the subclasses do not return un-wrapped boost-histogram components when a subclassed version is available. The issue is that various actions make the C++ -> Python transition over again, such as using ``.project()``. For example, let's say you have a ``MyHistogram`` and a ``MyRegular``. If you use ``project(0)``, that needs to also return a ``MyRegular``, but it is reconverting the return value from C++ to Python, so it has to somehow know that ``MyRegular`` is the right axis subclass to select from for ``MyHistogram``. This is accomplished with families.
 
 When you subclass, you will need to add a family. Any object can be used - the module for your library is a good choice if you only have one "family" of histograms. Boost-histogram uses ``boost_histogram``, Hist uses ``hist``. You can use anything you want, though; a custom tag object like ``MY_FAMILY = object()`` works well too. It just has to support ``is``, and be the exact same object on all your subclasses.
 
@@ -19,7 +19,7 @@ When you subclass, you will need to add a family. Any object can be used - the m
     class Regular(bh.axis.Regular, family=my_package):
         ...
 
-If you only override Histogram, just use ``family=object()``.
+If you only override ``Histogram``, you can leave off the ``family=`` argument, or set it to ``None``. It will generate a private ``object()`` in this case. You must add an explicit family to ``Histogram`` if you subclass any further components.
 
 If you use Mixins, special care needs to be taken if you need a left-acting
 Mixin, since class keywords are handled via ``super()`` left to right. This is
@@ -32,7 +32,7 @@ a Mixin that will work on either side:
             super().__init_subclass__(**kwargs)  # type: ignore
 
 Mixins are recommended if you want to provide functionality to a collection of
-different subclasses, like Axis.
+different subclasses, like ``Axis``.
 
 There are customization hooks provided for subclasses as well.
 ``self._generate_axis_()`` is called to produce an ``AxesTuple``, so you can

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -121,9 +121,16 @@ class Histogram:
 
     _family: object = boost_histogram
 
-    def __init_subclass__(cls, *, family: object) -> None:
+    def __init_subclass__(cls, *, family: Optional[object] = None) -> None:
+        """
+        Sets the family for the histogram. This should be a unique object (such
+        as the main module of your package) that is consistently set across all
+        subclasses. When converting back from C++, casting will try to always
+        pick the best matching family from the loaded subclasses for Axis and
+        such.
+        """
         super().__init_subclass__()
-        cls._family = family
+        cls._family = family if family is not None else object()
 
     @typing.overload
     def __init__(self, *args: "Histogram") -> None:

--- a/tests/test_subclassing.py
+++ b/tests/test_subclassing.py
@@ -22,3 +22,13 @@ def test_subclass():
     assert h._storage_type == MyIntStorage
     assert type(h.axes[0]) == MyRegular
     assert type(h.axes[0].transform) == MyPowTransform
+
+
+def test_subclass_hist_only():
+    class MyHist(bh.Histogram):
+        pass
+
+    h = MyHist(bh.axis.Regular(10, 0, 2))
+
+    assert type(h) == MyHist
+    assert type(h.axes[0]) == bh.axis.Regular


### PR DESCRIPTION
Allows `=None` for family, and makes that the default - only for Histogram. If you
subclass any further components, that requires a family for all components. This should
make subclassing _just_ Histogram easier, and should still push users to implement
families if they subclass any other components.

Better parity with 0.x series; a module that _just_ subclasses Histogram can now work with either version.
