### PR TITLE
fix: Mean/WeightedMean accumulator addition fix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 #### Bug fixes
 
+* Fix summing of Mean/WeightedMean accumulators [#537][]
 * Added missing dependency on `typing_extensions` for Python 3.6 & 3.7 [#529][]
 
 #### Typing changes
@@ -24,6 +25,7 @@
 [#530]: https://github.com/scikit-hep/boost-histogram/pull/530
 [#532]: https://github.com/scikit-hep/boost-histogram/pull/532
 [#533]: https://github.com/scikit-hep/boost-histogram/pull/532
+[#537]: https://github.com/scikit-hep/boost-histogram/pull/537
 
 ### Version 1.0.0
 

--- a/include/bh_python/accumulators/mean.hpp
+++ b/include/bh_python/accumulators/mean.hpp
@@ -59,12 +59,20 @@ struct mean {
     }
 
     mean& operator+=(const mean& rhs) noexcept {
-        if(count != 0 || rhs.count != 0) {
-            const auto tmp = value * count + rhs.value * rhs.count;
-            count += rhs.count;
-            value = tmp / count;
-        }
+        if(rhs.count == 0)
+            return *this;
+
+        const auto mu1 = value;
+        const auto mu2 = rhs.value;
+        const auto n1  = count;
+        const auto n2  = rhs.count;
+
+        count += rhs.count;
+        value = (n1 * mu1 + n2 * mu2) / count;
         sum_of_deltas_squared += rhs.sum_of_deltas_squared;
+        sum_of_deltas_squared
+            += n1 * (value - mu1) * (value - mu1) + n2 * (value - mu2) * (value - mu2);
+
         return *this;
     }
 

--- a/include/bh_python/accumulators/weighted_mean.hpp
+++ b/include/bh_python/accumulators/weighted_mean.hpp
@@ -62,13 +62,23 @@ struct weighted_mean {
     }
 
     weighted_mean& operator+=(const weighted_mean& rhs) {
-        if(sum_of_weights != 0 || rhs.sum_of_weights != 0) {
-            const auto tmp = value * sum_of_weights + rhs.value * rhs.sum_of_weights;
-            sum_of_weights += rhs.sum_of_weights;
-            sum_of_weights_squared += rhs.sum_of_weights_squared;
-            value = tmp / sum_of_weights;
-        }
+        if(rhs.sum_of_weights == 0)
+            return *this;
+
+        const auto mu1 = value;
+        const auto mu2 = rhs.value;
+        const auto n1  = sum_of_weights;
+        const auto n2  = rhs.sum_of_weights;
+
+        sum_of_weights += rhs.sum_of_weights;
+        sum_of_weights_squared += rhs.sum_of_weights_squared;
+
+        value = (n1 * mu1 + n2 * mu2) / sum_of_weights;
+
         _sum_of_weighted_deltas_squared += rhs._sum_of_weighted_deltas_squared;
+        _sum_of_weighted_deltas_squared
+            += n1 * (value - mu1) * (value - mu1) + n2 * (value - mu2) * (value - mu2);
+
         return *this;
     }
 

--- a/include/bh_python/register_accumulator.hpp
+++ b/include/bh_python/register_accumulator.hpp
@@ -53,6 +53,13 @@ py::class_<A> register_accumulator(py::module acc, Args&&... args) {
 
         .def(py::self *= double())
 
+        .def("__add__",
+             [](const A& self, const A& other) {
+                 A retval(self);
+                 retval += other;
+                 return retval;
+             })
+
         // The c++ name is replaced with the Python name here
         .def("__repr__",
              [](py::object self) {

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -1,3 +1,6 @@
+import pytest
+from pytest import approx
+
 import boost_histogram as bh
 
 
@@ -85,3 +88,48 @@ def test_mean():
     assert a == bh.accumulators.Mean(3, 2, 1)
 
     assert repr(a) == "Mean(count=3, value=2, variance=1)"
+
+
+def test_sum_mean():
+    a = bh.accumulators.Mean()
+    a.fill([1, 2, 3])
+
+    b = bh.accumulators.Mean()
+    b.fill([5, 6])
+
+    c = bh.accumulators.Mean()
+    c.fill([1, 2, 3, 5, 6])
+
+    ab = a + b
+    assert ab.value == approx(c.value)
+    assert ab.variance == approx(c.variance)
+    assert ab.count == approx(c.count)
+
+    a += b
+    assert a.value == approx(c.value)
+    assert a.variance == approx(c.variance)
+    assert a.count == approx(c.count)
+
+
+@pytest.mark.skip(reason="Needs to be fixed")
+def test_sum_weighed_mean():
+    a = bh.accumulators.WeightedMean()
+    a.fill([1, 2, 3])
+
+    b = bh.accumulators.WeightedMean()
+    b.fill([5, 6])
+
+    c = bh.accumulators.WeightedMean()
+    c.fill([1, 2, 3, 5, 6])
+
+    ab = a + b
+    assert ab.value == approx(c.value)
+    assert ab.variance == approx(c.variance)
+    assert ab.sum_of_weights == approx(c.sum_of_weights)
+    assert ab.sum_of_weights_squared == approx(c.sum_of_weights_squared)
+
+    a += b
+    assert a.value == approx(c.value)
+    assert a.variance == approx(c.variance)
+    assert a.sum_of_weights == approx(c.sum_of_weights)
+    assert a.sum_of_weights_squared == approx(c.sum_of_weights_squared)

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest import approx
 
 import boost_histogram as bh
@@ -111,7 +110,6 @@ def test_sum_mean():
     assert a.count == approx(c.count)
 
 
-@pytest.mark.skip(reason="Needs to be fixed")
 def test_sum_weighed_mean():
     a = bh.accumulators.WeightedMean()
     a.fill([1, 2, 3])

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -112,13 +112,13 @@ def test_sum_mean():
 
 def test_sum_weighed_mean():
     a = bh.accumulators.WeightedMean()
-    a.fill([1, 2, 3])
+    a.fill([1, 2, 3], weight=[2, 5, 3])
 
     b = bh.accumulators.WeightedMean()
-    b.fill([5, 6])
+    b.fill([5, 6], weight=[12, 17])
 
     c = bh.accumulators.WeightedMean()
-    c.fill([1, 2, 3, 5, 6])
+    c.fill([1, 2, 3, 5, 6], weight=[2, 5, 3, 12, 17])
 
     ab = a + b
     assert ab.value == approx(c.value)


### PR DESCRIPTION
Closes #531, implements https://github.com/boostorg/histogram/pull/308 .

Also fixes WeightedMean. Needs backport. Also supporting `__add__` on accumulators from the Python side since that's easier to test and work with in Python.

I'm thinking releasing 1.0.1 / 0.13.1 after this sounds like a good idea.
