### PR TITLE
docs: convert recommonmark to myst-parser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ except DistributionNotFound:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "recommonmark",
+    "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "nbsphinx",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 ipython
 nbsphinx
 numpy
-recommonmark>=0.5.0
+myst_parser>=0.13
 Sphinx>=3.0.0
 sphinx-book-theme>=0.0.33
 sphinx_copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 ipython
+myst_parser>=0.13
 nbsphinx
 numpy
-myst_parser>=0.13
 Sphinx>=3.0.0
 sphinx-book-theme>=0.0.33
 sphinx_copybutton

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ extras = {
     "test": ["pytest", "pytest-benchmark", "cloudpickle", "hypothesis >=6.0"],
     "docs": [
         "Sphinx~=3.0",
-        "recommonmark>=0.5.0",
+        "myst_parser>=0.13",
         "sphinx_book_theme==0.38.0",
         "nbsphinx",
         "sphinx_copybutton",


### PR DESCRIPTION
A direct switch seems to be trivial. CC https://github.com/readthedocs/recommonmark/issues/221 