### PR TITLE
fix possible typo in sphinx_book_theme requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ extras = {
     "docs": [
         "Sphinx~=3.0",
         "myst_parser>=0.13",
-        "sphinx_book_theme==0.38.0",
+        "sphinx_book_theme==0.0.38",
         "nbsphinx",
         "sphinx_copybutton",
     ],

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ extras = {
     "docs": [
         "Sphinx~=3.0",
         "myst_parser>=0.13",
-        "sphinx_book_theme==0.0.38",
+        "sphinx-book-theme>=0.0.33",
         "nbsphinx",
         "sphinx_copybutton",
     ],


### PR DESCRIPTION
docs require sphinx_book_theme==0.38.0, but this version is not out as the newest is 0.1.0. I assume it's a typo and 0.0.38 was meant (which exists).

Fixed in the setup.py.