### PR TITLE
fix: slicing supports under/overflow

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## UPCOMING
 
-No changes yet.
+* Fix "picking" on a flow bin [#576][]
+
+[#576]: https://github.com/scikit-hep/boost-histogram/pull/576
+
 
 ## Version 1.0
 

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
+from pytest import approx
 
 import boost_histogram as bh
 
@@ -349,6 +350,30 @@ def test_pick_int_category():
     assert_array_equal(h[{2: bh.loc(3)}].view(), vals)
     assert_array_equal(h[:, :, bh.loc(5)].view(), vals + 1)
     assert_array_equal(h[:, :, bh.loc(7)].view(), 0)
+
+
+@pytest.mark.parametrize(
+    "ax",
+    [bh.axis.Regular(3, 0, 1), bh.axis.Variable([0, 0.3, 0.6, 1])],
+    ids=["regular", "variable"],
+)
+def test_pick_flowbin(ax):
+    w = 1e-2  # e.g. a cross section for a process
+    x = [-0.1, -0.1, 0.1, 0.1, 0.1]
+    y = [-0.1, 0.1, -0.1, -0.1, 0.1]
+
+    h = bh.Histogram(
+        ax,
+        ax,
+        storage=bh.storage.Weight(),
+    )
+    h.fill(x, y, weight=w)
+
+    uf_slice = h[bh.tag.underflow, ...]
+    assert uf_slice.values(flow=True) == approx(np.array([1, 1, 0, 0, 0]) * w)
+
+    uf_slice = h[..., bh.tag.underflow]
+    assert uf_slice.values(flow=True) == approx(np.array([1, 2, 0, 0, 0]) * w)
 
 
 def test_axes_tuple():


### PR DESCRIPTION
Closes #574.

This could be expanded to support picking a set, but then the axes computations become more complex - we have to propagate metadata manually, and we have to manually handle (the) flow bin. Would be nicer with upstream support for picking. :)
