### PR TITLE
fix/feat: support scaling flow bins

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -380,7 +380,7 @@ class Histogram:
                     )
                 )
         else:
-            view = self.view(flow=False)
+            view = self.view(flow=True)
             getattr(view, name)(other)
         self._variance_known = False
         return self

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1178,7 +1178,7 @@ def test_add_broadcast():
 
     h2 = h + [[1]]
     assert h2.sum() == 10 * 20
-    assert h2.sum(flow=True) == 10 * 20
+    assert h2.sum(flow=True) == 12 * 22
 
     h3 = h + np.ones((10, 20))
     assert h3.sum() == 10 * 20

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -429,3 +429,29 @@ def test_single_flow_bin():
     assert h[3::sum] == 1
 
     assert h[1:2][sum] == 5
+
+
+# issue 579
+
+
+def test_scale_flowbins():
+    w = 1e-1
+    x = np.random.normal(loc=0.4, scale=0.4, size=100)
+
+    h = bh.Histogram(bh.axis.Variable([0, 0.5, 1]), storage=bh.storage.Weight())
+
+    h.fill(x, weight=w)
+
+    ref_value = h.values(flow=True) * 5
+    scale_value = (h * 5).values(flow=True)
+
+    assert scale_value == approx(ref_value)
+
+
+def test_add_flowbins():
+    h = bh.Histogram(bh.axis.Variable([0, 0.5, 1]), storage=bh.storage.Weight())
+
+    ref_value = h.values(flow=True) + 5
+    scale_value = (h + 5).values(flow=True)
+
+    assert scale_value == approx(ref_value)


### PR DESCRIPTION
Closes #579.

This was an intentional design decision, based on the fact that `h + 1` shouldn't add 1 to the flow bins, but scaling makes more sense to apply to all. 
