### PR TITLE
WIP: try config mode & build for cibw 2.0 alpha

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,7 @@ jobs:
     name: Wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: pypa/cibuildwheel@v2.0.0a4
+    - run: pipx run --spec cibuildwheel==2.0.0b1 cibuildwheel
       env:
         CIBW_BUILD: cp38-win_amd64 cp310-manylinux_i686 cp37-macosx_x86_64
         CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         platforms: all
 
-    - uses: pypa/cibuildwheel@v2.0.0a4
+    - run: pipx run --spec cibuildwheel==2.0.0b1 cibuildwheel
       env:
         CIBW_BUILD: cp${{ matrix.python }}-*
         CIBW_ARCHS: ${{ matrix.arch }}
@@ -110,7 +110,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: pypa/cibuildwheel@v2.0.0a4
+    - run: pipx run --spec cibuildwheel==2.0.0b1 cibuildwheel
       env:
         CIBW_BUILD: ${{ matrix.build }}
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ ignore = [
 
 
 [tool.cibuildwheel]
+build-frontend = "build"
 test-extras = "test"
 test-command = "pytest {project}/tests"
 test-skip = ["pp*macos*", "pp*win*", "*universal2:arm64"]


### PR DESCRIPTION
Adding the default Python3 that comes with Big Sur (via the command line tools).

Edit: This is identical to #593 - so will put this back in draft and use it to test config support in cibuildwheel 2.0.0a3.

Edit: And now build-support in 2.0.0a4.