### PR TITLE
fix: improve __getattr__ error message

### DIFF
--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -66,7 +66,7 @@ class Axis:
         if attr == "metadata":
             return None
         raise AttributeError(
-            f"object {self.__class__.__name__} has not attribute {attr}"
+            f"object {self.__class__.__name__} has no attribute {attr}"
         )
 
     def __init__(


### PR DESCRIPTION
The error message in \_\_getattr\_\_ had `not` instead of `no`.