### PR TITLE
ci: use CIBW 2.0 config, Python 3.10 beta testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,11 +90,9 @@ jobs:
       with:
         submodules: true
 
-    - uses: pypa/cibuildwheel@v1.12.0
+    - uses: pypa/cibuildwheel@v2.0.0a4
       env:
         CIBW_BUILD: cp38-win_amd64 cp36-manylinux_i686 cp37-macosx_x86_64
-        CIBW_TEST_EXTRAS: test
-        CIBW_TEST_COMMAND: pytest {project}/tests
         CIBW_BUILD_VERBOSITY: 1
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
         include:
         - python-version: "3.8"
           cmake-extras: "-DCMAKE_CXX_STANDARD=17"
+        - python-version: "3.10-dev"
 
     name: CMake Python ${{ matrix.python-version }}
 
@@ -92,8 +93,9 @@ jobs:
 
     - uses: pypa/cibuildwheel@v2.0.0a4
       env:
-        CIBW_BUILD: cp38-win_amd64 cp36-manylinux_i686 cp37-macosx_x86_64
+        CIBW_BUILD: cp38-win_amd64 cp310-manylinux_i686 cp37-macosx_x86_64
         CIBW_BUILD_VERBOSITY: 1
+        CIBW_PRERELEASE_PYTHONS: 1
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,9 +20,6 @@ on:
 env:
   SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.event.inputs.overrideVersion }}
   CIBW_ENVIRONMENT: "PIP_ONLY_BINARY=numpy SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"
-  CIBW_TEST_EXTRAS: test
-  CIBW_TEST_COMMAND: "pytest {project}/tests"
-  CIBW_TEST_SKIP: "pp*macos* pp*win* pp27-* *universal2:arm64"
 
 jobs:
   build_sdist:
@@ -34,7 +31,7 @@ jobs:
         submodules: true
 
     - name: Build SDist
-      run: pipx run --spec build pyproject-build --sdist
+      run: pipx run build --sdist
 
     - name: Check metadata
       run: pipx run twine check dist/*
@@ -61,7 +58,7 @@ jobs:
       with:
         platforms: all
 
-    - uses: pypa/cibuildwheel@v1.12.0
+    - uses: pypa/cibuildwheel@v2.0.0a4
       env:
         CIBW_BUILD: cp${{ matrix.python }}-*
         CIBW_ARCHS: ${{ matrix.arch }}
@@ -113,7 +110,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: pypa/cibuildwheel@v1.12.0
+    - uses: pypa/cibuildwheel@v2.0.0a4
       env:
         CIBW_BUILD: ${{ matrix.build }}
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,9 @@ ignore = [
     "src/boost_histogram/version.py",
     "tests/.pytest_cache/**",
 ]
+
+
+[tool.cibuildwheel]
+test-extras = "test"
+test-command = "pytest {project}/tests"
+test-skip = ["pp*macos*", "pp*win*", "*universal2:arm64"]


### PR DESCRIPTION
Pulling out the working bit from #583. Due to better PyPy support in the 2.x series, this should be superior already to what we have now.
