### PR TITLE
fix(types): support typing if storage= is not passed

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -150,8 +150,8 @@ class Histogram:
     def __init__(
         self,
         *axes: Union[Axis, CppAxis],
-        storage: Storage,
-        metadata: Any = None,
+        storage: Storage = ...,
+        metadata: Any = ...,
     ) -> None:
         ...
 


### PR DESCRIPTION
Oops, storage is optional.
