### PR TITLE
chore: use pip instead of docker for clang-format

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,18 +9,6 @@ on:
     - develop
 
 jobs:
-  pre-commit:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3
-      with:
-        extra_args: -a docker-clang-format --hook-stage manual
-
   clang-tidy:
     name: Clang-Tidy
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,12 +81,7 @@ repos:
     entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
     exclude: .pre-commit-config.yaml
 
-- repo: local
+- repo: https://github.com/henryiii/conda-clang-format
+  rev: v12.0.1
   hooks:
   - id: clang-format
-    name: Clang Format
-    language: conda
-    types: [c++]
-    entry: clang-format
-    args: [-style=file, -i]
-    additional_dependencies: [--channel=conda-forge, clang-format==12.0.1]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,4 +89,4 @@ repos:
     types: [c++]
     entry: clang-format
     args: [-style=file, -i]
-    additional_dependencies: [--channel=conda-forge, clang-tools==12.0.1]
+    additional_dependencies: [--channel=conda-forge, clang-format==12.0.1]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
      types:
      - c++
      entry: clang-format
-     additional_dependencies: [clang-format==1.21.*]
+     additional_dependencies: [clang-format==12.*]
      args:
      - -style=file
      - -i

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,15 @@ repos:
     entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
     exclude: .pre-commit-config.yaml
 
-- repo: https://github.com/henryiii/conda-clang-format
-  rev: v12.0.1
+- repo: local
   hooks:
-  - id: clang-format
+   - id: clang-format
+     name: Clang Format
+     language: python
+     types:
+     - c++
+     entry: clang-format
+     additional_dependencies: [clang-format==1.21.*]
+     args:
+     - -style=file
+     - -i

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,6 @@ repos:
     name: Clang Format
     language: conda
     types: [c++]
-    entry: clang-format-12
+    entry: clang-format
     args: [-style=file, -i]
-    additional_dependencies: [--channel=conda-forge, clang-format-12==12.0.1]
+    additional_dependencies: [--channel=conda-forge, clang-format==12.0.1]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
-  skip:
-  - docker-clang-format
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
 
 repos:
 - repo: https://github.com/psf/black
@@ -83,12 +83,10 @@ repos:
 
 - repo: local
   hooks:
-  - id: docker-clang-format
-    name: Docker Clang Format
-    language: docker_image
-    types:
-    - c++
-    entry: unibeautify/clang-format:latest
-    args:
-    - -style=file
-    - -i
+  - id: clang-format
+    name: Clang Format
+    language: conda
+    types: [c++]
+    entry: clang-format
+    args: [-style=file, -i]
+    additional_dependencies: [--channel=conda-forge, clang-tools==12.0.1]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,15 +81,7 @@ repos:
     entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
     exclude: .pre-commit-config.yaml
 
-- repo: local
+- repo: https://github.com/ssciwr/clang-format-precommit
+  rev: 2976f337d89114b56aa138197ee9bf862978409c
   hooks:
    - id: clang-format
-     name: Clang Format
-     language: python
-     types:
-     - c++
-     entry: clang-format
-     additional_dependencies: [clang-format==12.*]
-     args:
-     - -style=file
-     - -i

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,6 @@ repos:
     exclude: .pre-commit-config.yaml
 
 - repo: https://github.com/ssciwr/clang-format-precommit
-  rev: 2976f337d89114b56aa138197ee9bf862978409c
+  rev: v12.0.1
   hooks:
    - id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,6 @@ repos:
     name: Clang Format
     language: conda
     types: [c++]
-    entry: clang-format
+    entry: clang-format-12
     args: [-style=file, -i]
-    additional_dependencies: [--channel=conda-forge, clang-format==12.0.1]
+    additional_dependencies: [--channel=conda-forge, clang-format-12==12.0.1]

--- a/include/bh_python/make_pickle.hpp
+++ b/include/bh_python/make_pickle.hpp
@@ -60,8 +60,8 @@
 #include <vector>
 
 template <class T,
-          class = decltype(
-              std::declval<T&>().serialize(std::declval<std::nullptr_t&>(), 0))>
+          class = decltype(std::declval<T&>().serialize(std::declval<std::nullptr_t&>(),
+                                                        0))>
 struct has_method_serialize_impl {};
 
 template <class T>

--- a/include/bh_python/make_pickle.hpp
+++ b/include/bh_python/make_pickle.hpp
@@ -60,8 +60,8 @@
 #include <vector>
 
 template <class T,
-          class = decltype(std::declval<T&>().serialize(std::declval<std::nullptr_t&>(),
-                                                        0))>
+          class = decltype(
+              std::declval<T&>().serialize(std::declval<std::nullptr_t&>(), 0))>
 struct has_method_serialize_impl {};
 
 template <class T>


### PR DESCRIPTION
Seeing if pre-commit.ci supports this.
