### PR TITLE
docs: fix typo in Storages

### DIFF
--- a/docs/usage/storage.rst
+++ b/docs/usage/storage.rst
@@ -3,7 +3,7 @@
 Storages
 ========
 
-There are several storage to choose from. To select a storage, pass the
+There are several storages to choose from. To select a storage, pass the
 ``storage=bh.storage.`` argument when making a histogram.
 
 Simple storages


### PR DESCRIPTION
Change `storage` to `storages` in [storages.rst](https://github.com/scikit-hep/boost-histogram/blob/develop/docs/usage/storage.rst).