### PR TITLE
fix: support getattr in custom AxesTuple subclasses

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 #### Bug fixes
 * Support custom setters on AxesTuple subclasses. [#627][]
+* Throw an error when an AxesTuple setter is the wrong length (inspired by zip strict in Python 3.10) [#627][]
 
 [#627]: https://github.com/scikit-hep/boost-histogram/pull/627
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Version 1.1
 
+### Version 1.1.1
+
+#### User changes
+* Python 3.10 officially supported, with wheels.
+
+#### Bug fixes
+* Support custom setters on AxesTuple subclasses. [#627][]
+
+[#627]: https://github.com/scikit-hep/boost-histogram/pull/627
+
+### Version 1.1.0
+
 #### User changes
 * Experimentally support list selection on categorical axes [#577][]
 * Support Python 3.8 on Apple Silicon [#600][]

--- a/src/boost_histogram/_internal/axestuple.py
+++ b/src/boost_histogram/_internal/axestuple.py
@@ -97,7 +97,10 @@ class AxesTuple(tuple):  # type: ignore
         return self.__class__(getattr(s, attr) for s in self)
 
     def __setattr__(self, attr: str, values: Any) -> None:
-        self.__class__(s.__setattr__(attr, v) for s, v in zip(self, values))
+        try:
+            return super().__setattr__(attr, values)
+        except AttributeError:
+            self.__class__(s.__setattr__(attr, v) for s, v in zip(self, values))
 
     value.__doc__ = Axis.value.__doc__
     index.__doc__ = Axis.index.__doc__

--- a/src/boost_histogram/_internal/axestuple.py
+++ b/src/boost_histogram/_internal/axestuple.py
@@ -4,7 +4,7 @@ from typing import Any, List, Tuple, TypeVar
 import numpy as np
 
 from .axis import Axis
-from .utils import set_module
+from .utils import set_module, zip_strict
 
 A = TypeVar("A", bound="ArrayTuple")
 
@@ -100,7 +100,7 @@ class AxesTuple(tuple):  # type: ignore
         try:
             return super().__setattr__(attr, values)
         except AttributeError:
-            self.__class__(s.__setattr__(attr, v) for s, v in zip(self, values))
+            self.__class__(s.__setattr__(attr, v) for s, v in zip_strict(self, values))
 
     value.__doc__ = Axis.value.__doc__
     index.__doc__ = Axis.index.__doc__

--- a/src/boost_histogram/_internal/utils.py
+++ b/src/boost_histogram/_internal/utils.py
@@ -1,5 +1,17 @@
+import itertools
+import sys
 import typing
-from typing import Callable, ClassVar, Iterator, Optional, Set, Type, TypeVar
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Iterator,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+)
 
 import boost_histogram
 
@@ -176,3 +188,16 @@ def _walk_subclasses(cls: Type[object]) -> Iterator[Type[object]]:
         # user subclasses to work
         yield from _walk_subclasses(base)
         yield base
+
+
+def zip_strict(*args: Any) -> Iterator[Tuple[Any, ...]]:
+    if sys.version_info >= (3, 10):
+        yield from zip(*args, strict=True)
+        return
+
+    marker = object()
+    for each in itertools.zip_longest(*args, fillvalue=marker):
+        for val in each:
+            if val is marker:
+                raise ValueError("zip() arguments are not the same length")
+        yield each

--- a/tests/test_minihist_title.py
+++ b/tests/test_minihist_title.py
@@ -41,6 +41,11 @@ class NamedAxesTuple(bh.axis.AxesTuple):
         """
         return tuple(ax.name for ax in self)
 
+    @name.setter
+    def name(self, values):
+        for ax, val in zip(self, values):
+            ax._ax.metadata["name"] = f"test: {val}"
+
 
 # When you subclass Histogram or an Axes, you should register your family so
 # boost-histogram will know what to convert C++ objects into.
@@ -152,3 +157,16 @@ def test_access():
 
     assert hist_conv.axes["a"] == hist_conv.axes[0]
     assert hist_conv.axes["b"] == hist_conv.axes[1]
+
+
+def test_hist_name_set():
+    hist_1 = CustomHist(Regular(10, 0, 1, name="a"), Regular(20, 0, 4, name="b"))
+
+    hist_1.axes.name = ("c", "d")
+    assert hist_1.axes.name == ("test: c", "test: d")
+
+    with pytest.raises(AttributeError):
+        hist_1.axes[0].name = "a"
+
+    hist_1.axes.label = ("one", "two")
+    assert hist_1.axes.label == ("one", "two")

--- a/tests/test_minihist_title.py
+++ b/tests/test_minihist_title.py
@@ -170,3 +170,9 @@ def test_hist_name_set():
 
     hist_1.axes.label = ("one", "two")
     assert hist_1.axes.label == ("one", "two")
+
+    with pytest.raises(ValueError):
+        hist_1.axes.label = ("one",)
+
+    with pytest.raises(ValueError):
+        hist_1.axes.label = ("one", "two", "three")


### PR DESCRIPTION
Fixes an issue we are having to work around in https://github.com/scikit-hep/hist/pull/288 .

The default setter now fails if the iterable is of the wrong length.