### PR TITLE
fix: return False if axis do not support protocol instead of raising

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,8 +10,10 @@
 #### Bug fixes
 * Support custom setters on AxesTuple subclasses. [#627][]
 * Throw an error when an AxesTuple setter is the wrong length (inspired by zip strict in Python 3.10) [#627][]
+* Fix error thrown on comparison with axis and non-axis object [#631][]
 
 [#627]: https://github.com/scikit-hep/boost-histogram/pull/627
+[#631]: https://github.com/scikit-hep/boost-histogram/pull/631
 
 ### Version 1.1.0
 

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -138,10 +138,10 @@ class Axis:
         return self._ax.bin(index)  # type: ignore
 
     def __eq__(self, other: Any) -> bool:
-        return self._ax == other._ax  # type: ignore
+        return hasattr(other, "_ax") and self._ax == other._ax
 
     def __ne__(self, other: Any) -> bool:
-        return self._ax != other._ax  # type: ignore
+        return (not hasattr(other, "_ax")) or self._ax != other._ax
 
     @classmethod
     def _convert_cpp(cls: Type[T], cpp_object: Any) -> T:

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -197,6 +197,8 @@ class TestRegular(Axis):
         assert a != bh.axis.Regular(3, 1.0, 2.0)
         assert a != bh.axis.Regular(4, 1.1, 2.0)
         assert a != bh.axis.Regular(4, 1.0, 2.1)
+        assert a != object()
+        assert not (a == object())  # __eq__ and __ne__ are separately implemented
 
         # metadata compare
         assert bh.axis.Regular(1, 2, 3, metadata=1) == bh.axis.Regular(


### PR DESCRIPTION
Closes #626 

(I removed the type: ignore as mypy complained, if that was needed for something, I'll add it back)