### PR TITLE
feat: add boilerplate sub implementation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,14 +6,24 @@
 
 #### User changes
 * Python 3.10 officially supported, with wheels.
+* Support subtraction on histograms [#636][]
 
 #### Bug fixes
 * Support custom setters on AxesTuple subclasses. [#627][]
 * Throw an error when an AxesTuple setter is the wrong length (inspired by zip strict in Python 3.10) [#627][]
 * Fix error thrown on comparison with axis and non-axis object [#631][]
+* Static typing no longer thinks `storage=` is required [#604][]
 
+#### Developer changes
+* Support NumPy 1.21 for static type checking [#625][]
+* Use newer Boost 1.77 and Boost.Histogram 1.77+1 [#594][]
+
+[#594]: https://github.com/scikit-hep/boost-histogram/pull/594
+[#604]: https://github.com/scikit-hep/boost-histogram/pull/604
+[#625]: https://github.com/scikit-hep/boost-histogram/pull/625
 [#627]: https://github.com/scikit-hep/boost-histogram/pull/627
 [#631]: https://github.com/scikit-hep/boost-histogram/pull/631
+[#636]: https://github.com/scikit-hep/boost-histogram/pull/636
 
 ### Version 1.1.0
 

--- a/include/bh_python/register_histogram.hpp
+++ b/include/bh_python/register_histogram.hpp
@@ -97,6 +97,9 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
     def_optionally(hist,
                    bh::detail::has_operator_rmul<histogram_t, histogram_t>{},
                    py::self *= py::self);
+    def_optionally(hist,
+                   bh::detail::has_operator_rsub<histogram_t, histogram_t>{},
+                   py::self -= py::self);
 #ifdef __clang__
 #pragma GCC diagnostic pop
 #endif

--- a/include/bh_python/storage.hpp
+++ b/include/bh_python/storage.hpp
@@ -22,8 +22,8 @@
 namespace storage {
 
 // Names match Python names
-using int64         = bh::dense_storage<uint64_t>;
-using atomic_int64  = bh::dense_storage<bh::accumulators::count<uint64_t, true>>;
+using int64         = bh::dense_storage<int64_t>;
+using atomic_int64  = bh::dense_storage<bh::accumulators::count<int64_t, true>>;
 using double_       = bh::dense_storage<double>;
 using unlimited     = bh::unlimited_storage<>;
 using weight        = bh::dense_storage<accumulators::weighted_sum<double>>;
@@ -80,7 +80,7 @@ template <class Archive>
 void save(Archive& ar, const storage::atomic_int64& s, unsigned /* version */) {
     // We cannot view the memory as a numpy array, because the internal layout of
     // std::atomic is undefined. So no reinterpret_casts are allowed.
-    py::array_t<std::uint64_t> a(static_cast<py::ssize_t>(s.size()));
+    py::array_t<std::int64_t> a(static_cast<py::ssize_t>(s.size()));
 
     auto in_ptr  = s.begin();
     auto out_ptr = a.mutable_data();
@@ -191,7 +191,7 @@ struct type_caster<storage::atomic_int64::value_type> {
         auto ptr = PyNumber_Long(src.ptr());
         if(!ptr)
             return false;
-        value = PyLong_AsUnsignedLongLong(ptr);
+        value = PyLong_AsLongLong(ptr);
         Py_DECREF(ptr);
         return !PyErr_Occurred();
     }
@@ -199,7 +199,7 @@ struct type_caster<storage::atomic_int64::value_type> {
     static handle cast(storage::atomic_int64::value_type src,
                        return_value_policy /* policy */,
                        handle /* parent */) {
-        return PyLong_FromUnsignedLongLong(src.value());
+        return PyLong_FromLongLong(src.value());
     }
 };
 } // namespace detail

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -337,6 +337,23 @@ class Histogram:
     ) -> H:
         return self + other
 
+    def __sub__(
+        self: H, other: Union["Histogram", "np.typing.NDArray[Any]", float]
+    ) -> H:
+        result = self.copy(deep=False)
+        return result.__isub__(other)
+
+    def __isub__(
+        self: H, other: Union["Histogram", "np.typing.NDArray[Any]", float]
+    ) -> H:
+        if isinstance(other, (int, float)) and other == 0:
+            return self
+        self._compute_inplace_op("__isub__", other)
+
+        self.axes = self._generate_axes_()
+
+        return self
+
     # If these fail, the underlying object throws the correct error
     def __mul__(
         self: H, other: Union["Histogram", "np.typing.NDArray[Any]", float]

--- a/src/boost_histogram/_internal/view.py
+++ b/src/boost_histogram/_internal/view.py
@@ -130,14 +130,14 @@ class WeightedSumView(View):
 
             # Addition of two views
             if input_0.dtype == input_1.dtype:
-                if ufunc in {np.add}:
+                if ufunc in {np.add, np.subtract}:
                     ufunc(
                         input_0["value"],
                         input_1["value"],
                         out=result["value"],
                         **kwargs,
                     )
-                    ufunc(
+                    np.add(
                         input_0["variance"],
                         input_1["variance"],
                         out=result["variance"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-import boost_histogram  # noqa: F401
+import boost_histogram as bh
 
 
 @pytest.fixture(params=(False, True), ids=("no_growth", "growth"))
@@ -28,4 +28,18 @@ def flow(request):
     ids=("no_metadata", "str_metadata", "int_metadata", "dict_metadata"),
 )
 def metadata(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=(
+        bh.storage.Double,
+        bh.storage.Int64,
+        bh.storage.AtomicInt64,
+        bh.storage.Weight,
+        bh.storage.Unlimited,
+    ),
+    ids=("Double", "Int64", "AtomicInt64", "Weight", "Unlimited"),
+)
+def count_storage(request):
     return request.param

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -404,8 +404,6 @@ def test_add_2d_w(flow):
 
 
 def test_sub_2d(flow, count_storage):
-    if count_storage in {bh.storage.AtomicInt64, bh.storage.Weight}:
-        pytest.skip("Storage does not support subtraction")
 
     h0 = bh.Histogram(
         bh.axis.Integer(-1, 2, underflow=flow, overflow=flow),
@@ -423,15 +421,16 @@ def test_sub_2d(flow, count_storage):
 
     m = h0.values(flow=True).copy()
 
-    h = h0.copy()
-    h -= h0
-    assert h.values(flow=True) == approx(m * 0)
+    if count_storage not in {bh.storage.AtomicInt64, bh.storage.Weight}:
+        h = h0.copy()
+        h -= h0
+        assert h.values(flow=True) == approx(m * 0)
 
-    h -= h0
-    assert h.values(flow=True) == approx(-m)
+        h -= h0
+        assert h.values(flow=True) == approx(-m)
 
-    h2 = h0 - (h0 + h0 + h0)
-    assert h2.values(flow=True) == approx(-2 * m)
+        h2 = h0 - (h0 + h0 + h0)
+        assert h2.values(flow=True) == approx(-2 * m)
 
     h3 = h0 - h0.view(flow=True) * 4
     assert h3.values(flow=True) == approx(-3 * m)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -65,9 +65,14 @@ def test_view_add(v):
     assert_allclose(v2.value, [2, 5, 4, 3])
     assert_allclose(v2.variance, [4, 7, 6, 5])
 
-    v += 2
-    assert_allclose(v.value, [2, 5, 4, 3])
-    assert_allclose(v.variance, [4, 7, 6, 5])
+    v2 = v.copy()
+    v2 += 2
+    assert_allclose(v2.value, [2, 5, 4, 3])
+    assert_allclose(v2.variance, [4, 7, 6, 5])
+
+    v2 = v + v
+    assert_allclose(v2.value, v.value * 2)
+    assert_allclose(v2.variance, v.variance * 2)
 
 
 def test_view_sub(v):
@@ -83,9 +88,14 @@ def test_view_sub(v):
     assert_allclose(v2.value, [1, -2, -1, 0])
     assert_allclose(v2.variance, [1, 4, 3, 2])
 
-    v -= 2
-    assert_allclose(v.value, [-2, 1, 0, -1])
-    assert_allclose(v.variance, [4, 7, 6, 5])
+    v2 = v.copy()
+    v2 -= 2
+    assert_allclose(v2.value, [-2, 1, 0, -1])
+    assert_allclose(v2.variance, [4, 7, 6, 5])
+
+    v2 = v - v
+    assert_allclose(v2.value, [0, 0, 0, 0])
+    assert_allclose(v2.variance, v.variance * 2)
 
 
 def test_view_unary(v):


### PR DESCRIPTION
Basic implementation for #632.

TODO:

- [x] Add test for scalar
- [x] Add test for array
- [x] Add test for Histogram (expected to throw unless Boost.Histogram adds or supports sub)
- [x] Add test for int storage < 0 after subtraction (unsigned currently) - should throw, convert to double, or storages should be signed.