### PR TITLE
fix: faster picking when no slices are made

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,8 @@
 # What's new in boost-histogram
 
-## Version 1.1
+## Version 1.2
 
-### Version 1.1.1
+### Version 1.2.0
 
 #### User changes
 * Python 3.10 officially supported, with wheels.
@@ -11,6 +11,7 @@
 
 #### Bug fixes
 * Support custom setters on AxesTuple subclasses. [#627][]
+* Faster picking if slices are not also used [#645][]
 * Throw an error when an AxesTuple setter is the wrong length (inspired by zip strict in Python 3.10) [#627][]
 * Fix error thrown on comparison with axis and non-axis object [#631][]
 * Static typing no longer thinks `storage=` is required [#604][]
@@ -26,7 +27,10 @@
 [#627]: https://github.com/scikit-hep/boost-histogram/pull/627
 [#631]: https://github.com/scikit-hep/boost-histogram/pull/631
 [#636]: https://github.com/scikit-hep/boost-histogram/pull/636
+[#645]: https://github.com/scikit-hep/boost-histogram/pull/645
 [#647]: https://github.com/scikit-hep/boost-histogram/pull/647
+
+## Version 1.1
 
 ### Version 1.1.0
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -841,8 +841,16 @@ class Histogram:
                 assert isinstance(stop, int)
                 slices.append(_core.algorithm.slice_and_rebin(i, start, stop, merge))
 
-        logger.debug("Reduce with %s", slices)
-        reduced = self._hist.reduce(*slices)
+        if slices:
+            logger.debug("Reduce with %s", slices)
+            reduced = self._hist.reduce(*slices)
+        elif pick_set or pick_each or integrations:
+            # Can avoid a copy in these cases, will be copied anyway
+            logger.debug("Reduce is empty, but picking or slicing, so no copy needed")
+            reduced = self._hist
+        else:
+            logger.debug("Reduce is empty, just making a copy")
+            reduced = copy.copy(self._hist)
 
         if pick_set:
             warnings.warn(

--- a/tests/test_benchmark_category_axis.py
+++ b/tests/test_benchmark_category_axis.py
@@ -34,3 +34,39 @@ def test_StrCategory(benchmark, growth, dtype):
         h.fill(data)
 
     benchmark(run, h, tuple(values) if dtype is tuple else values.astype(dtype))
+
+
+@pytest.mark.benchmark(group="Pick")
+def test_pick_only(benchmark):
+
+    h = bh.Histogram(
+        bh.axis.StrCategory([str(i) for i in range(32)]),
+        bh.axis.StrCategory([str(i) for i in range(32)]),
+        bh.axis.StrCategory([str(i) for i in range(32)]),
+        bh.axis.Regular(32, 0, 320),
+    )
+
+    h[...] = 1.0
+
+    def run(h):
+        return h[bh.loc("13"), bh.loc("13"), bh.loc("13"), :].view()
+
+    benchmark(run, h)
+
+
+@pytest.mark.benchmark(group="Pick")
+def test_pick_and_slice(benchmark):
+
+    h = bh.Histogram(
+        bh.axis.StrCategory([str(i) for i in range(32)]),
+        bh.axis.StrCategory([str(i) for i in range(32)]),
+        bh.axis.StrCategory([str(i) for i in range(32)]),
+        bh.axis.Regular(32, 0, 320),
+    )
+
+    h[...] = 1.0
+
+    def run(h):
+        return h[3:29, bh.loc("13"), bh.loc("13"), :].view()
+
+    benchmark(run, h)


### PR DESCRIPTION
Helps with #644. Ideally, I think the order of picking and slicing should be flipped, which would probably be faster. Empty reduce should still be swapped for a copy, though, so this code code is still needed even in that case.
