### PR TITLE
fix: faster picking when slices are made

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 #### Bug fixes
 * Support custom setters on AxesTuple subclasses. [#627][]
-* Faster picking if slices are not also used [#645][]
+* Faster picking if slices are not also used [#645][] or if they are [#648][] (1000x or more in some cases)
 * Throw an error when an AxesTuple setter is the wrong length (inspired by zip strict in Python 3.10) [#627][]
 * Fix error thrown on comparison with axis and non-axis object [#631][]
 * Static typing no longer thinks `storage=` is required [#604][]
@@ -29,6 +29,7 @@
 [#636]: https://github.com/scikit-hep/boost-histogram/pull/636
 [#645]: https://github.com/scikit-hep/boost-histogram/pull/645
 [#647]: https://github.com/scikit-hep/boost-histogram/pull/647
+[#648]: https://github.com/scikit-hep/boost-histogram/pull/648
 
 ## Version 1.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ write_to = "src/boost_histogram/version.py"
 
 [tool.pytest.ini_options]
 junit_family = "xunit2"
-addopts = "--benchmark-disable -Wd --strict-markers"
+addopts = "--benchmark-disable -Wd --strict-markers -ra"
 xfail_strict = true
 testpaths = ["tests"]
 required_plugins = ["pytest-benchmark"]

--- a/src/boost_histogram/_core/algorithm.pyi
+++ b/src/boost_histogram/_core/algorithm.pyi
@@ -2,6 +2,7 @@ import enum
 import typing
 
 class reduce_command:
+    iaxis: int
     def __repr__(self) -> str: ...
 
 class slice_mode(enum.Enum):

--- a/src/register_algorithm.cpp
+++ b/src/register_algorithm.cpp
@@ -10,6 +10,7 @@
 void register_algorithms(py::module& algorithm) {
     py::class_<bh::algorithm::reduce_command>(algorithm, "reduce_command")
         .def(py::init<bh::algorithm::reduce_command>())
+        .def_readwrite("iaxis", &bh::algorithm::reduce_command::iaxis)
         .def("__repr__", [](const bh::algorithm::reduce_command& self) {
             using range_t = bh::algorithm::reduce_command::range_t;
 


### PR DESCRIPTION
This is a followup to #645, and closes #644. Benchmarks:

Before:

```
---------------------------------------------------------------------------------------------- benchmark 'Pick': 2 tests ----------------------------------------------------------------------------------------------
Name (time in us)               Min                     Max                    Mean                 StdDev                  Median                    IQR            Outliers         OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pick_only             469.6110 (1.0)       10,963.2400 (1.0)          548.6303 (1.0)         335.7542 (1.0)          496.3605 (1.0)          58.5930 (1.0)         7;153  1,822.7210 (1.0)        1054           1
test_pick_and_slice    752,036.0140 (>1000.0)  794,440.9860 (72.46)    768,945.9046 (>1000.0)  15,980.4104 (47.60)    764,982.2400 (>1000.0)  18,759.4093 (320.16)        2;0      1.3005 (0.00)          5           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After:

```
--------------------------------------------------------------------------------------- benchmark 'Pick': 2 tests ---------------------------------------------------------------------------------------
Name (time in us)              Min                   Max                  Mean              StdDev                Median                IQR            Outliers         OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pick_only            428.6290 (1.0)      8,381.7100 (3.94)       465.9007 (1.0)      245.5388 (2.86)       448.8950 (1.0)      17.9607 (1.0)         9;107  2,146.3802 (1.0)        1081           1
test_pick_and_slice     1,167.1580 (2.72)     2,127.0860 (1.0)      1,223.6495 (2.63)      85.7735 (1.0)      1,196.0865 (2.66)     59.2490 (3.30)        78;59    817.2275 (0.38)        738           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```

This is almost 1,000 times faster if a slice is made (depending on the size, etc).
