### PR TITLE
style: drop pycln

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,12 +44,6 @@ repos:
   hooks:
   - id: setup-cfg-fmt
 
-- repo: https://github.com/hadialqattan/pycln
-  rev: v1.0.3
-  hooks:
-  - id: pycln
-    args: [--config=pyproject.toml]
-
 - repo: https://github.com/asottile/yesqa
   rev: v1.2.3
   hooks:


### PR DESCRIPTION
PyCln artificially version-caps Python to <3.10, which broke when pre-commit.ci updated to 3.10 earlier today. I hadn't noticed this, because locally I installed with 3.9, then when brew updated pre-commit to 3.10, it just kept working, because pycln actually supports 3.10, it just follows the horrific practice of adding upper version limits as pushed by Poetry. If the version caps are removed, we can restore this to pre-commit. Otherwise, this will cause extra headaches every Python upgrade. hadialqattan/pycln#81
