### PR TITLE
fix: protect Cat indexing from missing values

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
     - master
     - develop
 
+env:
+  FORCE_COLOR: 3
+
 jobs:
   clang-tidy:
     name: Clang-Tidy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,16 @@ if(NOT BH_RULE_LAUNCH_LINK STREQUAL "")
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${BH_RULE_LAUNCH_LINK}")
 endif()
 
+# This will force color output at build time if this env variable is set _at
+# configure time_. This is useful for CI.
+if($ENV{FORCE_COLOR})
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    add_compile_options(-fdiagnostics-color=always)
+  elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    add_compile_options(-fcolor-diagnostics)
+  endif()
+endif()
+
 # This is a standard recipe for setting a default build type
 set(default_build_type "Debug")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,17 +2,25 @@
 
 ## Version 1.2
 
-### Version 1.2.2
+### Version 1.3.0
 
 #### User changes
 
-* PyPy 3.8 now supported. [#677][]
+* PyPy 3.8 now supported with binary wheels. [#677][]
 * The GIL is released a little more often now. [#662][]
 * AxesTuple does not allow construction of non-axes. [#680][]
+* KeyError is now thrown when accessing a non-existent item in a Category Axis [#689][]
+
+#### Developer changes
+
+* Use PyLint in CI to check for some style issues [#690][]
+
 
 [#662]: https://github.com/scikit-hep/boost-histogram/pull/662
 [#677]: https://github.com/scikit-hep/boost-histogram/pull/677
 [#680]: https://github.com/scikit-hep/boost-histogram/pull/680
+[#689]: https://github.com/scikit-hep/boost-histogram/pull/689
+[#690]: https://github.com/scikit-hep/boost-histogram/pull/690
 
 ### Version 1.2.1
 

--- a/include/bh_python/register_axis.hpp
+++ b/include/bh_python/register_axis.hpp
@@ -58,7 +58,7 @@ auto vectorize_index(int (bh::axis::category<T, metadata_t, Options>::*pindex)(c
         if(detail::is_value<T>(arg)) {
             auto index_value = index(self, detail::special_cast<T>(arg));
             if(index_value >= self.size())
-                throw std::out_of_range("index out of range");
+                throw pybind11::key_error(py::str("{!r} not in axis").format(arg));
             return py::cast(index_value);
         }
 
@@ -70,7 +70,7 @@ auto vectorize_index(int (bh::axis::category<T, metadata_t, Options>::*pindex)(c
         for(std::size_t i = 0, n = values.size(); i < n; ++i) {
             ip[i] = index(self, vp[i]);
             if(ip[i] >= self.size())
-                throw std::out_of_range("index out of range");
+                throw pybind11::key_error(py::str("{!r} not in axis").format(vp[i]));
         }
 
         return std::move(indices);

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,5 @@
+import shutil
+
 import nox
 
 ALL_PYTHONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
@@ -10,6 +12,8 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
+
+    shutil.rmtree("build", ignore_errors=True)
     session.install(".[test]")
     session.run("pytest", *session.posargs)
 

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -800,11 +800,20 @@ class TestCategory(Axis):
     )
     def test_index(self, ref, growth):
         Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
-        a = Cat(ref[:-1], growth=growth)
+        a = Cat(ref, growth=growth)
         for i, r in enumerate(ref):
             assert a.index(r) == i
         assert_array_equal(a.index(ref), [0, 1, 2, 3])
         assert_array_equal(a.index(np.reshape(ref, (2, 2))), [[0, 1], [2, 3]])
+
+        if isinstance(ref[0], str):
+            with pytest.raises(IndexError):
+                a.index("E")
+        else:
+            with pytest.raises(IndexError):
+                a.index(5)
+            with pytest.raises(IndexError):
+                a.index(-2)
 
     @pytest.mark.parametrize("ref", ([1, 2, 3], ("A", "B", "C")))
     def test_value(self, ref, growth):

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -807,12 +807,12 @@ class TestCategory(Axis):
         assert_array_equal(a.index(np.reshape(ref, (2, 2))), [[0, 1], [2, 3]])
 
         if isinstance(ref[0], str):
-            with pytest.raises(IndexError):
+            with pytest.raises(KeyError):
                 a.index("E")
         else:
-            with pytest.raises(IndexError):
+            with pytest.raises(KeyError):
                 a.index(5)
-            with pytest.raises(IndexError):
+            with pytest.raises(KeyError):
                 a.index(-2)
 
     @pytest.mark.parametrize("ref", ([1, 2, 3], ("A", "B", "C")))


### PR DESCRIPTION
Category indexing will return `len(index)+1` for missing index, which creates messy error messages down the line.
![image](https://user-images.githubusercontent.com/13226500/149811100-8056af9f-fbf7-437f-8d5a-609f60101f89.png)

This should catch it correctly

![image](https://user-images.githubusercontent.com/13226500/149811430-be79da18-ce9c-404a-a6eb-ff41ac850604.png)

Closes #387.
