### PR TITLE
chore: add pylint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,18 @@ jobs:
     - name: Build
       run: cmake --build build -j 2
 
+  pylint:
+    runs-on: ubuntu-latest
+    name: PyLint
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Run PyLint
+      run: pipx run nox -s pylint
+
 
   cmake:
     runs-on: ubuntu-latest

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,17 @@ def lint(session: nox.Session) -> None:
 
 
 @nox.session
+def pylint(session: nox.Session) -> None:
+    """
+    Run pylint.
+    """
+
+    session.install("pylint")
+    session.install("-e", ".")
+    session.run("pylint", "src")
+
+
+@nox.session
 def make_pickle(session: nox.Session) -> None:
     """
     Make a pickle file for this version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,3 +85,28 @@ manylinux-i686-image = "manylinux2014"
 select = "cp3?-*"
 manylinux-x86_64-image = "manylinux2010"
 manylinux-i686-image = "manylinux2010"
+
+[tool.pylint]
+
+master.py-version = "3.6"
+master.extension-pkg-allow-list = ["boost_histogram._core"]
+similarities.ignore-imports = "yes"
+messages_control.disable = [
+  "fixme",
+  "invalid-name",
+  "line-too-long",
+  "missing-class-docstring",
+  "missing-function-docstring",
+  "missing-module-docstring",
+  "no-member",  # C extensions mess with this
+  "protected-access",
+  "too-few-public-methods",
+  "too-many-arguments",
+  "too-many-branches",
+  "too-many-lines",
+  "too-many-locals",
+  "too-many-return-statements",
+  "too-many-statements",
+  "wrong-import-position",
+  "cyclic-import",  # TODO: move files out of _internal
+]

--- a/src/boost_histogram/__init__.py
+++ b/src/boost_histogram/__init__.py
@@ -1,7 +1,13 @@
 from . import accumulators, axis, numpy, storage
 from ._internal.enum import Kind
 from ._internal.hist import Histogram, IndexingExpr
-from .tag import loc, overflow, rebin, sum, underflow
+from .tag import (  # pylint: disable=redefined-builtin
+    loc,
+    overflow,
+    rebin,
+    sum,
+    underflow,
+)
 from .version import version as __version__
 
 try:

--- a/src/boost_histogram/_internal/axestuple.py
+++ b/src/boost_histogram/_internal/axestuple.py
@@ -18,8 +18,8 @@ class ArrayTuple(tuple):  # type: ignore[type-arg]
     def __getattr__(self, name: str) -> Any:
         if name in self._REDUCTIONS:
             return partial(getattr(np, name), np.broadcast_arrays(*self))  # type: ignore[no-untyped-call]
-        else:
-            return self.__class__(getattr(a, name) for a in self)
+
+        return self.__class__(getattr(a, name) for a in self)
 
     def __dir__(self) -> List[str]:
         names = dir(self.__class__) + dir("np.typing.NDArray[Any]")
@@ -51,6 +51,7 @@ class AxesTuple(tuple):  # type: ignore[type-arg]
                 raise TypeError(
                     f"Only an iterable of Axis supported in AxesTuple, got {item}"
                 )
+        super().__init__()
 
     @property
     def size(self) -> Tuple[int, ...]:
@@ -105,7 +106,7 @@ class AxesTuple(tuple):  # type: ignore[type-arg]
 
     def __setattr__(self, attr: str, values: Any) -> None:
         try:
-            return super().__setattr__(attr, values)
+            super().__setattr__(attr, values)
         except AttributeError:
             for s, v in zip_strict(self, values):
                 s.__setattr__(attr, v)

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -14,7 +14,7 @@ from typing import (
     Union,
 )
 
-import numpy as np
+import numpy as np  # pylint: disable=unused-import
 
 import boost_histogram
 
@@ -31,10 +31,9 @@ def _isstr(value: Any) -> bool:
 
     if isinstance(value, (str, bytes)):
         return True
-    elif hasattr(value, "__iter__"):
+    if hasattr(value, "__iter__"):
         return all(_isstr(v) for v in value)
-    else:
-        return False
+    return False
 
 
 def _opts(**kwargs: bool) -> Set[str]:
@@ -87,7 +86,7 @@ class Axis:
             raise KeyError(
                 "Cannot provide metadata by keyword and __dict__, use __dict__ only"
             )
-        elif __dict__ is not None:
+        if __dict__ is not None:
             self._ax.metadata = __dict__
         elif metadata is not None:
             self._ax.metadata["metadata"] = metadata
@@ -112,14 +111,11 @@ class Axis:
         Return the fractional index(es) given a value (or values) on the axis.
         """
 
-        if not _isstr(value):
-            return self._ax.index(value)  # type: ignore[no-any-return]
-        else:
-            raise TypeError(
-                "index({value}) cannot be a string for a numerical axis".format(
-                    value=value
-                )
-            )
+        if _isstr(value):
+            msg = f"index({value}) cannot be a string for a numerical axis"
+            raise TypeError(msg)
+
+        return self._ax.index(value)  # type: ignore[no-any-return]
 
     def value(self, index: float) -> float:
         """
@@ -486,7 +482,8 @@ class Variable(Axis, family=boost_histogram):
         if len(self) > 20:
             ret = [repr(self.edges)]
         else:
-            ret = ["[{}]".format(", ".join(format(v, "g") for v in self.edges))]
+            args = ", ".join(format(v, "g") for v in self.edges)
+            ret = [f"[{args}]"]
 
         if self.traits.growth:
             ret.append("growth=True")
@@ -670,17 +667,15 @@ class StrCategory(BaseCategory, family=boost_histogram):
 
         if _isstr(value):
             return self._ax.index(value)  # type: ignore[no-any-return]
-        else:
-            raise TypeError(
-                "index({value}) must be a string or iterable of strings for a StrCategory axis".format(
-                    value=value
-                )
-            )
+
+        msg = f"index({value}) must be a string or iterable of strings for a StrCategory axis"
+        raise TypeError(msg)
 
     def _repr_args_(self) -> List[str]:
         "Return inner part of signature for use in repr"
 
-        ret = ["[{}]".format(", ".join(repr(c) for c in self))]
+        args = ", ".join(repr(c) for c in self)
+        ret = [f"[{args}]"]
         ret += super()._repr_args_()
         return ret
 
@@ -732,7 +727,8 @@ class IntCategory(BaseCategory, family=boost_histogram):
     def _repr_args_(self) -> List[str]:
         "Return inner part of signature for use in repr"
 
-        ret = ["[{}]".format(", ".join(format(c, "g") for c in self))]
+        args = ", ".join(format(c, "g") for c in self)
+        ret = [f"[{args}]"]
         ret += super()._repr_args_()
         return ret
 

--- a/src/boost_histogram/_internal/axis_transform.py
+++ b/src/boost_histogram/_internal/axis_transform.py
@@ -33,8 +33,8 @@ class AxisTransform:
     def __repr__(self) -> str:
         if hasattr(self, "_this"):
             return repr(self._this)
-        else:
-            return f"{self.__class__.__name__}() # Missing _this, broken class"
+
+        return f"{self.__class__.__name__}() # Missing _this, broken class"
 
     def _produce(self, bins: int, start: float, stop: float) -> Any:
         # Note: this is an ABC; _type must be defined on children
@@ -62,7 +62,7 @@ class Pow(AxisTransform, family=boost_histogram):
     __slots__ = ()
     _type = ca.regular_pow
 
-    def __init__(self, power: float):
+    def __init__(self, power: float):  # pylint: disable=super-init-not-called
         "Create a new transform instance"
         # Note: this comes from family
         (cpp_class,) = self._types  # type: ignore[attr-defined]
@@ -84,7 +84,7 @@ class Function(AxisTransform, family=boost_histogram):
     __slots__ = ()
     _type = ca.regular_trans
 
-    def __init__(
+    def __init__(  # pylint: disable=super-init-not-called
         self, forward: Any, inverse: Any, *, convert: Any = None, name: str = ""
     ):
         """

--- a/src/boost_histogram/_internal/deprecated.py
+++ b/src/boost_histogram/_internal/deprecated.py
@@ -17,13 +17,11 @@ class deprecated:
         @functools.wraps(func)
         def decorated_func(*args: Any, **kwargs: Any) -> Any:
             warnings.warn(
-                "{} is deprecated: {}".format(
-                    self._name or func.__name__, self._reason
-                ),
+                f"{self._name or func.__name__} is deprecated: {self._reason}",
                 category=FutureWarning,
                 stacklevel=2,
             )
             return func(*args, **kwargs)
 
-        decorated_func.__doc__ = "DEPRECATED: " + self._reason + "\n" + func.__doc__
+        decorated_func.__doc__ = f"DEPRECATED: {self._reason}\n{func.__doc__}"
         return decorated_func

--- a/src/boost_histogram/_internal/utils.py
+++ b/src/boost_histogram/_internal/utils.py
@@ -98,7 +98,7 @@ def _cast_make_object(canidate_class: T, cpp_object: object, is_class: bool) -> 
     if is_class:
         return canidate_class
 
-    elif hasattr(canidate_class, "_convert_cpp"):
+    if hasattr(canidate_class, "_convert_cpp"):
         return canidate_class._convert_cpp(cpp_object)  # type: ignore[attr-defined, no-any-return]
 
     # Casting down does not work in pybind11,
@@ -106,8 +106,7 @@ def _cast_make_object(canidate_class: T, cpp_object: object, is_class: bool) -> 
     # so for now, all non-copy classes must have a
     # _convert_cpp method.
 
-    else:
-        return canidate_class(cpp_object)  # type: ignore[operator, no-any-return]
+    return canidate_class(cpp_object)  # type: ignore[operator, no-any-return]
 
 
 def cast(self: object, cpp_object: object, parent_class: Type[T]) -> T:

--- a/src/boost_histogram/accumulators.py
+++ b/src/boost_histogram/accumulators.py
@@ -1,4 +1,9 @@
-from ._core.accumulators import Mean, Sum, WeightedMean, WeightedSum
+from ._core.accumulators import (  # pylint: disable=import-error
+    Mean,
+    Sum,
+    WeightedMean,
+    WeightedSum,
+)
 from ._internal.typing import Accumulator
 
 __all__ = ("Sum", "Mean", "WeightedSum", "WeightedMean", "Accumulator")

--- a/src/boost_histogram/numpy.py
+++ b/src/boost_histogram/numpy.py
@@ -1,15 +1,15 @@
-from functools import reduce as _reduce
-from operator import mul as _mul
-from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple, Type, Union
+from functools import reduce
+from operator import mul
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Type, Union
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 else:
     ArrayLike = object
 
-import numpy as _np
+import numpy as np
 
-import boost_histogram._core as _core
+from boost_histogram import _core
 
 from . import axis as _axis
 from . import storage as _storage
@@ -19,19 +19,26 @@ from ._internal.utils import cast as _cast
 __all__ = ("histogram", "histogram2d", "histogramdd")
 
 
+def __dir__() -> List[str]:
+    return list(__all__)
+
+
 def histogramdd(
     a: Tuple[ArrayLike, ...],
     bins: Union[int, Tuple[int, ...]] = 10,
-    range: Optional[Sequence[Union[None, Tuple[float, float]]]] = None,
+    range: Optional[  # pylint: disable=redefined-builtin
+        Sequence[Union[None, Tuple[float, float]]]
+    ] = None,
     normed: None = None,
     weights: Optional[ArrayLike] = None,
     density: bool = False,
     *,
-    histogram: Optional[Type[_hist.Histogram]] = None,
+    histogram: Optional[  # pylint: disable=redefined-outer-name
+        Type[_hist.Histogram]
+    ] = None,
     storage: _storage.Storage = _storage.Double(),  # noqa: B008
     threads: Optional[int] = None
 ) -> Any:
-    np = _np  # Hidden to keep module clean
 
     # TODO: Might be a bug in MyPy? This should type
     cls: Type[_hist.Histogram] = _hist.Histogram if histogram is None else histogram  # type: ignore[assignment]
@@ -79,7 +86,7 @@ def histogramdd(
     hist = cls(*axs, storage=storage).fill(*a, weight=weights, threads=threads)
 
     if density:
-        areas = _reduce(_mul, hist.axes.widths)
+        areas = reduce(mul, hist.axes.widths)
         density_val = hist.values() / np.sum(hist.values()) / areas
         return (density_val, hist.to_numpy()[1:])
 
@@ -93,12 +100,16 @@ def histogram2d(
     x: ArrayLike,
     y: ArrayLike,
     bins: Union[int, Tuple[int, int]] = 10,
-    range: Optional[Sequence[Union[None, Tuple[float, float]]]] = None,
+    range: Optional[  # pylint: disable=redefined-builtin
+        Sequence[Union[None, Tuple[float, float]]]
+    ] = None,
     normed: None = None,
     weights: Optional[ArrayLike] = None,
     density: bool = False,
     *,
-    histogram: Optional[Type[_hist.Histogram]] = None,
+    histogram: Optional[  # pylint: disable=redefined-outer-name
+        Type[_hist.Histogram]
+    ] = None,
     storage: _storage.Storage = _storage.Double(),  # noqa: B008
     threads: Optional[int] = None
 ) -> Any:
@@ -124,16 +135,17 @@ def histogram2d(
 def histogram(
     a: ArrayLike,
     bins: int = 10,
-    range: Optional[Tuple[float, float]] = None,
+    range: Optional[Tuple[float, float]] = None,  # pylint: disable=redefined-builtin
     normed: None = None,
     weights: Optional[ArrayLike] = None,
     density: bool = False,
     *,
-    histogram: Optional[Type[_hist.Histogram]] = None,
+    histogram: Optional[  # pylint: disable=redefined-outer-name
+        Type[_hist.Histogram]
+    ] = None,
     storage: Optional[_storage.Storage] = None,
     threads: Optional[int] = None
 ) -> Any:
-    np = _np
 
     # numpy 1d histogram returns integers in some cases
     if storage is None:
@@ -170,9 +182,10 @@ def histogram(
 
 
 # Process docstrings
-for f, n in zip(
+# TODO: make this a decorator
+for f, np_f in zip(
     (histogram, histogram2d, histogramdd),
-    (_np.histogram, _np.histogram2d, _np.histogramdd),
+    (np.histogram, np.histogram2d, np.histogramdd),
 ):
 
     H = """\
@@ -183,6 +196,4 @@ for f, n in zip(
     lets you set the number of threads to fill with (0 for auto, None for 1).
     """
 
-    f.__doc__ = H.format(n.__name__) + (n.__doc__ or "")
-
-del f, n, H
+    f.__doc__ = H.format(np_f.__name__) + (np_f.__doc__ or "")

--- a/src/boost_histogram/tag.py
+++ b/src/boost_histogram/tag.py
@@ -1,5 +1,6 @@
 # bh.sum is just the Python sum, so from boost_histogram import * is safe (but
 # not recommended)
+import copy
 from builtins import sum
 from typing import TypeVar, Union
 
@@ -37,20 +38,16 @@ class Locator:
         self.offset = offset
 
     def __add__(self: T, offset: int) -> T:
-        from copy import copy
-
-        other = copy(self)
+        other = copy.copy(self)
         other.offset += offset
         return other
 
     def __sub__(self: T, offset: int) -> T:
-        from copy import copy
-
-        other = copy(self)
+        other = copy.copy(self)
         other.offset -= offset
         return other
 
-    def _print_self_(self) -> str:
+    def _print_self_(self) -> str:  # pylint: disable=no-self-use
         return ""
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Quick outline of the changes inspired by pylint:

* Use f-strings everywhere possible
* Use guard-style everywhere (simpler control flow)
* Minor import cleanup
* Cleanup of some reused and redefined variables