### PR TITLE
fix: wrong calculation for WeightedMean variance NaN's via UHI

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -1067,11 +1067,12 @@ class Histogram:
             return view if self._variance_known else None
 
         if hasattr(view, "sum_of_weights"):
+            valid = view.sum_of_weights**2 > view.sum_of_weights_squared  # type: ignore[union-attr]
             return np.divide(  # type: ignore[no-any-return]
                 view.variance,  # type: ignore[union-attr]
                 view.sum_of_weights,  # type: ignore[union-attr]
                 out=np.full(view.sum_of_weights.shape, np.nan),  # type: ignore[union-attr]
-                where=view.sum_of_weights > 1,  # type: ignore[union-attr]
+                where=valid,
             )
 
         if hasattr(view, "count"):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
@@ -258,3 +260,20 @@ def test_summing_weighted_mean_storage():
     assert s1.sum_of_weights == approx(s2.sum_of_weights)
     assert s1.sum_of_weights_squared == approx(s2.sum_of_weights_squared)
     assert s1.variance == approx(s2.variance)
+
+
+# Raised on Gitter
+def test_UHI_variance_counts():
+    h = bh.Histogram(
+        bh.axis.Regular(bins=1, start=0, stop=1), storage=bh.storage.WeightedMean()
+    )
+    h.fill(0.5, sample=[1], weight=[0.5])
+    h.fill(0.5, sample=[2], weight=[0.4])
+    assert not math.isnan(h.variances()[0])
+
+    h = bh.Histogram(
+        bh.axis.Regular(bins=1, start=0, stop=1), storage=bh.storage.WeightedMean()
+    )
+    h.fill(0.5, sample=[1], weight=[0.5])
+    h.fill(0.5, sample=[1], weight=[0.5])
+    assert not math.isnan(h.variances()[0])


### PR DESCRIPTION
Brought up on Gitter. The old calculation could not have been right, and was not what is described above from the UHI.
