### PR TITLE
fix: pypy tests fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ write_to = "src/boost_histogram/version.py"
 minversion = "6.0"
 junit_family = "xunit2"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
-filterwarnings = ["error"]
 xfail_strict = true
 testpaths = ["tests"]
 required_plugins = ["pytest-benchmark"]


### PR DESCRIPTION
On PyPy, linux only, there is a UserWarning on NumPy import. This _breaks_ pytest when warnings are turned into errors, even if you ignore this one, becuase it happens in the conftest.py.

```
>>>> import boost_histogram as bh
/opt/_internal/pypy3.8-7.3.7/lib/pypy3.8/site-packages/numpy/core/_add_newdocs.py:2826: UserWarning: add_newdoc was used on a pure-python object <bound method __class_getitem__ of <class 'numpy.ndarray'>>. Prefer to attach it directly to the source.
  add_newdoc('numpy.core.multiarray', 'ndarray', ('__class_getitem__',
/opt/_internal/pypy3.8-7.3.7/lib/pypy3.8/site-packages/numpy/core/_add_newdocs.py:6128: UserWarning: add_newdoc was used on a pure-python object <bound method __class_getitem__ of <class 'numpy.dtype'>>. Prefer to attach it directly to the source.
  add_newdoc('numpy.core.multiarray', 'dtype', ('__class_getitem__',
/opt/_internal/pypy3.8-7.3.7/lib/pypy3.8/site-packages/numpy/core/_add_newdocs.py:6640: UserWarning: add_newdoc was used on a pure-python object <bound method __class_getitem__ of <class 'numpy.number'>>. Prefer to attach it directly to the source.
  add_newdoc('numpy.core.numerictypes', 'number', ('__class_getitem__',
>>>>
```

This was breaking the wheel build, therefore a blocking issue for release.