### PR TITLE
fix: match zero range numpy quirk

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,15 @@
 
 ## Version 1.3
 
+### WIP
+
+* Patch broken sum with fully empty (0 bin) axis [#718][]
+* Fix zero range `bh.numpy.histogram` to match `numpy.histogram` behavior [#721][]
+
+[#718]: https://github.com/scikit-hep/boost-histogram/pull/718
+[#721]: https://github.com/scikit-hep/boost-histogram/pull/721
+
+
 ### Version 1.3.1
 
 #### Bug fixes

--- a/src/boost_histogram/numpy.py
+++ b/src/boost_histogram/numpy.py
@@ -75,6 +75,8 @@ def histogramdd(
             if r is None:
                 # Nextafter may affect bin edges slightly
                 r = (np.amin(a[n]), np.amax(a[n]))
+                if r[0] == r[1]:
+                    r = (r[0] - 0.5, r[1] + 0.5)
             cpp_ax = _core.axis.regular_numpy(b, r[0], r[1])
             new_ax = _cast(None, cpp_ax, _axis.Axis)
             axs.append(new_ax)

--- a/tests/test_numpy_interface.py
+++ b/tests/test_numpy_interface.py
@@ -2,6 +2,7 @@ import copy
 
 import numpy as np
 import pytest
+from pytest import approx
 
 import boost_histogram as bh
 
@@ -165,6 +166,35 @@ def test_histogram_weights():
     x = np.array([0.3, 0.3, 0.1, 0.8, 0.34, 0.03, 0.32, 0.65])
     weights = np.array([0.4, 0.5, 0.22, 0.65, 0.32, 0.01, 0.23, 1.98])
     h1, edges = np.histogram(x, weights=weights)
-    bh_h1, edges = bh.numpy.histogram(x, weights=weights)
+    bh_h1, bh_edges = bh.numpy.histogram(x, weights=weights)
 
-    np.testing.assert_array_almost_equal(h1, bh_h1)
+    assert bh_h1 == approx(h1)
+    assert bh_edges == approx(edges)
+
+
+def test_histogram_nans():
+    x = np.array([0, 1, 2, 3, np.nan])
+
+    with pytest.raises(ValueError):
+        np.histogram(x)
+
+    with pytest.raises(ValueError):
+        bh.numpy.histogram(x)
+
+
+def test_histogram_all_zeros():
+    x = np.array([0, 0, 0, 0, 0, 0])
+    h1, edges = np.histogram(x)
+    bh_h1, bh_edges = bh.numpy.histogram(x)
+
+    assert bh_h1 == approx(h1)
+    assert bh_edges == approx(edges)
+
+
+def test_histogram_all_ones():
+    x = np.array([0, 0, 0, 0, 0, 0])
+    h1, edges = np.histogram(x)
+    bh_h1, bh_edges = bh.numpy.histogram(x)
+
+    assert bh_h1 == approx(h1)
+    assert bh_edges == approx(edges)


### PR DESCRIPTION
Addressing half of https://github.com/scikit-hep/hist/issues/393. The other half (NaN's) is the expected behavior, and can be handled in uproot-browser.
