### PR TITLE
chore: bump numpy used for typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,11 +66,11 @@ repos:
     additional_dependencies: *flake8-dependencies
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.942
+  rev: v0.950
   hooks:
   - id: mypy
     files: ^src
-    additional_dependencies: [numpy==1.21.*, pytest, uhi, types-dataclasses]
+    additional_dependencies: [numpy==1.22.*, pytest, uhi, types-dataclasses]
 
 - repo: https://github.com/mgedmin/check-manifest
   rev: "0.48"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ python_version = "3.6"
 files = ["src"]
 strict = true
 show_error_codes = true
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+warn_unreachable = true
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/src/boost_histogram/_internal/axestuple.py
+++ b/src/boost_histogram/_internal/axestuple.py
@@ -4,9 +4,15 @@ from typing import Any, Iterable, List, Tuple, TypeVar
 import numpy as np
 
 from .axis import Axis
+from .typing import Literal, TypedDict
 from .utils import set_module, zip_strict
 
 A = TypeVar("A", bound="ArrayTuple")
+
+
+class MGridOpts(TypedDict):
+    sparse: bool
+    indexing: Literal["ij", "xy"]
 
 
 @set_module("boost_histogram.axis")
@@ -17,7 +23,7 @@ class ArrayTuple(tuple):  # type: ignore[type-arg]
 
     def __getattr__(self, name: str) -> Any:
         if name in self._REDUCTIONS:
-            return partial(getattr(np, name), np.broadcast_arrays(*self))  # type: ignore[no-untyped-call]
+            return partial(getattr(np, name), np.broadcast_arrays(*self))
 
         return self.__class__(getattr(a, name) for a in self)
 
@@ -34,7 +40,7 @@ class ArrayTuple(tuple):  # type: ignore[type-arg]
         Use this method to broadcast them out into their full memory
         representation.
         """
-        return self.__class__(np.broadcast_arrays(*self))  # type: ignore[no-untyped-call]
+        return self.__class__(np.broadcast_arrays(*self))
 
 
 B = TypeVar("B", bound="AxesTuple")
@@ -43,7 +49,7 @@ B = TypeVar("B", bound="AxesTuple")
 @set_module("boost_histogram.axis")
 class AxesTuple(tuple):  # type: ignore[type-arg]
     __slots__ = ()
-    _MGRIDOPTS = {"sparse": True, "indexing": "ij"}
+    _MGRIDOPTS: MGridOpts = {"sparse": True, "indexing": "ij"}
 
     def __init__(self, __iterable: Iterable[Axis]) -> None:
         for item in self:
@@ -64,17 +70,17 @@ class AxesTuple(tuple):  # type: ignore[type-arg]
     @property
     def centers(self) -> ArrayTuple:
         gen = (s.centers for s in self)
-        return ArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))  # type: ignore[no-untyped-call]
+        return ArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
 
     @property
     def edges(self) -> ArrayTuple:
         gen = (s.edges for s in self)
-        return ArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))  # type: ignore[no-untyped-call]
+        return ArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
 
     @property
     def widths(self) -> ArrayTuple:
         gen = (s.widths for s in self)
-        return ArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))  # type: ignore[no-untyped-call]
+        return ArrayTuple(np.meshgrid(*gen, **self._MGRIDOPTS))
 
     def value(self, *indexes: float) -> Tuple[float, ...]:
         if len(indexes) != len(self):

--- a/src/boost_histogram/_internal/axis.py
+++ b/src/boost_histogram/_internal/axis.py
@@ -335,7 +335,7 @@ class Regular(Axis, family=boost_histogram):
 
             if (
                 not isinstance(transform, AxisTransform)
-                and AxisTransform in transform.__bases__
+                and AxisTransform in transform.__bases__  # type: ignore[unreachable]
             ):
                 raise TypeError(f"You must pass an instance, use {transform}()")
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -72,7 +72,7 @@ def _fill_cast(
     Convert to NumPy arrays. Some buffer objects do not get converted by forcecast.
     If not called by itself (inner=False), then will work through one level of tuple/list.
     """
-    if value is None or isinstance(value, (str, bytes)):
+    if value is None or isinstance(value, (str, bytes)):  # type: ignore[redundant-expr]
         return value  # type: ignore[return-value]
 
     if not inner and isinstance(value, (tuple, list)):
@@ -204,13 +204,13 @@ class Histogram:
             return
 
         if storage is None:
-            storage = Double()
+            storage = Double()  # type: ignore[unreachable]
 
         self.metadata = metadata
 
         # Check for missed parenthesis or incorrect types
         if not isinstance(storage, Storage):
-            msg_storage = (
+            msg_storage = (  # type: ignore[unreachable]
                 "Passing in an initialized storage has been removed. Please add ()."
             )
             msg_unknown = "Only storages allowed in storage argument"
@@ -226,7 +226,7 @@ class Histogram:
         # Check all available histograms, and if the storage matches, return that one
         for h in _histograms:
             if isinstance(storage, h._storage_type):
-                self._hist = h(axes, storage)
+                self._hist = h(axes, storage)  # type: ignore[unreachable]
                 self.axes = self._generate_axes_()
                 return
 
@@ -633,7 +633,7 @@ class Histogram:
         if callable(index):
             return index(self.axes[axis])
 
-        if isinstance(index, float):
+        if isinstance(index, float):  # type: ignore[unreachable]
             raise TypeError(f"Index {index} must be an integer, not float")
 
         if isinstance(index, SupportsIndex):

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -478,19 +478,23 @@ class Histogram:
         }:
             raise RuntimeError("Mean histograms do not support threaded filling")
 
-        data = [np.array_split(a, threads) for a in args_ars]  # type: ignore[no-untyped-call]
+        data: "List[List[np.typing.NDArray[Any]]]" = [
+            np.array_split(a, threads) for a in args_ars
+        ]
 
+        weights: "List[Any]"
         if weight is None or np.isscalar(weight):
             assert threads is not None
             weights = [weight_ars] * threads
         else:
-            weights = np.array_split(weight_ars, threads)  # type: ignore[no-untyped-call]
+            weights = np.array_split(weight_ars, threads)
 
+        samples: "List[Any]"
         if sample_ars is None or np.isscalar(sample_ars):
             assert threads is not None
             samples = [sample_ars] * threads
         else:
-            samples = np.array_split(sample_ars, threads)  # type: ignore[no-untyped-call]
+            samples = np.array_split(sample_ars, threads)
 
         if self._hist._storage_type is _core.storage.atomic_int64:
 
@@ -933,7 +937,7 @@ class Histogram:
         if (
             value.ndim > 0
             and len(view.dtype) > 0  # type: ignore[arg-type]
-            and len(value.dtype) == 0
+            and len(value.dtype) == 0  # type: ignore[arg-type]
             and len(view.dtype) == value.shape[-1]  # type: ignore[arg-type]
         ):
             value_shape = value.shape[:-1]

--- a/src/boost_histogram/_internal/typing.py
+++ b/src/boost_histogram/_internal/typing.py
@@ -2,9 +2,9 @@ import sys
 from typing import TYPE_CHECKING, Any, Tuple, Union
 
 if sys.version_info < (3, 8):
-    from typing_extensions import Protocol, SupportsIndex
+    from typing_extensions import Literal, Protocol, SupportsIndex, TypedDict
 else:
-    from typing import Protocol, SupportsIndex
+    from typing import Literal, Protocol, SupportsIndex, TypedDict
 
 if TYPE_CHECKING:
     from builtins import ellipsis
@@ -32,6 +32,8 @@ __all__ = (
     "Ufunc",
     "StdIndex",
     "StrIndex",
+    "Literal",
+    "TypedDict",
 )
 
 

--- a/src/boost_histogram/_internal/view.py
+++ b/src/boost_histogram/_internal/view.py
@@ -10,7 +10,7 @@ class View(np.ndarray):  # type: ignore[type-arg]
     __slots__ = ()
     _FIELDS: ClassVar[Tuple[str, ...]]
 
-    def __getitem__(self, ind: StrIndex) -> "np.typing.NDArray[Any]":
+    def __getitem__(self, ind: StrIndex) -> "np.typing.NDArray[Any]":  # type: ignore[override]
         sliced = super().__getitem__(ind)
 
         # If the shape is empty, return the parent type
@@ -39,7 +39,7 @@ class View(np.ndarray):  # type: ignore[type-arg]
             super().__setitem__(ind, value)  # type: ignore[no-untyped-call]
             return
 
-        array = np.asarray(value)
+        array: "np.typing.NDArray[Any]" = np.asarray(value)
         if (
             array.ndim == super().__getitem__(ind).ndim + 1
             and len(self._FIELDS) == array.shape[-1]
@@ -122,8 +122,8 @@ class WeightedSumView(View):
             return result.view(self.__class__)  # type: ignore[no-any-return]
 
         if method == "__call__" and len(inputs) == 2:
-            input_0 = np.asarray(inputs[0])
-            input_1 = np.asarray(inputs[1])
+            input_0: "np.typing.NDArray[Any]" = np.asarray(inputs[0])
+            input_1: "np.typing.NDArray[Any]" = np.asarray(inputs[1])
 
             (result,) = kwargs.pop("out", [np.empty(self.shape, self.dtype)])
 
@@ -145,7 +145,7 @@ class WeightedSumView(View):
                     return result.view(self.__class__)  # type: ignore[no-any-return]
 
                 # If unsupported, just pass through (will return not implemented)
-                return super().__array_ufunc__(ufunc, method, *inputs, **kwargs)  # type: ignore[misc, no-any-return]
+                return super().__array_ufunc__(ufunc, method, *inputs, **kwargs)  # type: ignore[no-any-return]
 
             # View with normal value or array
             if ufunc in {np.add, np.subtract}:
@@ -200,7 +200,7 @@ class WeightedSumView(View):
             return result.view(self.__class__)  # type: ignore[no-any-return]
 
         # If unsupported, just pass through (will return not implemented)
-        return super().__array_ufunc__(ufunc, method, *inputs, **kwargs)  # type: ignore[misc, no-any-return]
+        return super().__array_ufunc__(ufunc, method, *inputs, **kwargs)  # type: ignore[no-any-return]
 
 
 @fields(
@@ -220,7 +220,8 @@ class WeightedMeanView(View):
 
     @property
     def variance(self) -> "np.typing.NDArray[Any]":
-        with np.errstate(divide="ignore", invalid="ignore"):
+        # TODO: bug in mypy, perhaps? This should resolve to a literal.
+        with np.errstate(divide="ignore", invalid="ignore"):  # type: ignore[arg-type]
             return self["_sum_of_weighted_deltas_squared"] / (  # type: ignore[no-any-return]
                 self["sum_of_weights"]
                 - self["sum_of_weights_squared"] / self["sum_of_weights"]
@@ -239,7 +240,7 @@ class MeanView(View):
     # Variance is a computation
     @property
     def variance(self) -> "np.typing.NDArray[Any]":
-        with np.errstate(divide="ignore", invalid="ignore"):
+        with np.errstate(divide="ignore", invalid="ignore"):  # type: ignore[arg-type]
             return self["_sum_of_deltas_squared"] / (self["count"] - 1)
 
 

--- a/src/boost_histogram/numpy.py
+++ b/src/boost_histogram/numpy.py
@@ -81,7 +81,7 @@ def histogramdd(
             new_ax = _cast(None, cpp_ax, _axis.Axis)
             axs.append(new_ax)
         else:
-            barr = np.asarray(b, dtype=np.double)
+            barr: "np.typing.NDArray[Any]" = np.asarray(b, dtype=np.double)
             barr[-1] = np.nextafter(barr[-1], np.finfo("d").max)
             axs.append(_axis.Variable(barr))
 


### PR DESCRIPTION
- chore: update typing to numpy 1.22
- chore: more strict typing
