### PR TITLE
Histogram Comparison via allclose

### DIFF
--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -578,6 +578,106 @@ class Histogram(typing.Generic[S]):
 
     __hash__ = None  # type: ignore[assignment]
 
+    def allclose(
+        self,
+        other: object,
+        *,
+        rtol: float = 1e-05,
+        atol: float = 1e-08,
+        equal_nan: bool = False,
+        flow: bool = True,
+        metadata: bool = False,
+    ) -> bool:
+        """
+        Check whether two histograms are close to each other.
+
+        Parameters
+        ----------
+        other : Histogram
+            The histogram to compare against.
+        rtol : float = 1e-05
+            Relative tolerance for comparing edges and bins.
+        atol : float = 1e-08
+            Absolute tolerance for comparing edges and bins.
+        equal_nan : bool = False
+            Whether to compare NaNs as equal.
+        flow : bool = True
+            Whether to include underflow and overflow bins in the comparison.
+        metadata : bool = False
+            Whether to compare histogram and axis metadata.
+
+        Returns
+        -------
+        bool
+            True if the histograms are close, False otherwise.
+        """
+        if not isinstance(other, Histogram):
+            return False
+
+        if self.ndim != other.ndim:
+            return False
+
+        if self.storage_type != other.storage_type:
+            return False
+
+        if metadata and self.__dict__ != other.__dict__:
+            return False
+
+        for i in range(self.ndim):
+            ax1 = self.axes[i]
+            ax2 = other.axes[i]
+
+            if ax1.size != ax2.size:
+                return False
+
+            if metadata and ax1.__dict__ != ax2.__dict__:
+                return False
+
+            if ax1.traits.continuous != ax2.traits.continuous:
+                return False
+
+            if ax1.traits.continuous:
+                if not np.allclose(
+                    ax1.edges,
+                    ax2.edges,
+                    rtol=rtol,
+                    atol=atol,
+                    equal_nan=equal_nan,
+                ):
+                    return False
+            else:
+                if ax1.traits.ordered != ax2.traits.ordered:
+                    return False
+                if list(ax1) != list(ax2):
+                    return False
+
+        v1 = self.view(flow=flow)
+        v2 = other.view(flow=flow)
+
+        if v1.shape != v2.shape:
+            return False
+
+        if v1.dtype.names:
+            for name in v1.dtype.names:
+                if not np.allclose(
+                    v1[name],  # type: ignore[index]
+                    v2[name],  # type: ignore[index]
+                    rtol=rtol,
+                    atol=atol,
+                    equal_nan=equal_nan,
+                ):
+                    return False
+        elif not np.allclose(
+            v1,
+            v2,
+            rtol=rtol,
+            atol=atol,
+            equal_nan=equal_nan,
+        ):
+            return False
+
+        return True
+
     def __eq__(self, other: object) -> bool:
         return hasattr(other, "_hist") and self._hist == other._hist
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1492,3 +1492,173 @@ def test_underfill_growth():
     h.fill(2)
     h.fill(-1)
     assert h.sum() == 2
+
+
+# ---- allclose tests ---------------------------------------------------------
+
+
+def test_allclose_same_histogram():
+    h = bh.Histogram(bh.axis.Regular(5, 0, 1))
+    h.fill(np.random.default_rng(42).random(100))
+
+    assert h.allclose(h)
+    assert h.allclose(h.copy())
+
+
+def test_allclose_different_bins():
+    h1 = bh.Histogram(bh.axis.Regular(5, 0, 1))
+    h2 = bh.Histogram(bh.axis.Regular(5, 0, 1))
+
+    rng = np.random.default_rng(42)
+    h1.fill(rng.random(100))
+    h2.fill(rng.random(100))
+
+    assert not h1.allclose(h2)
+
+
+def test_allclose_edges_within_tol():
+    h1 = bh.Histogram(bh.axis.Regular(5, 0, 1))
+    h2 = bh.Histogram(bh.axis.Regular(5, 0, 1 + 1e-7))
+
+    rng = np.random.default_rng(42)
+    h1.fill(rng.random(100))
+    h2.fill(rng.random(100))
+
+    assert not h1.allclose(h2)
+
+
+def test_allclose_edges_outside_tol():
+    h1 = bh.Histogram(bh.axis.Regular(5, 0, 1))
+    h2 = bh.Histogram(bh.axis.Regular(5, 0, 1 + 0.1))
+
+    assert not h1.allclose(h2)
+
+
+def test_allclose_different_shape():
+    h1 = bh.Histogram(bh.axis.Regular(5, 0, 1))
+    h2 = bh.Histogram(bh.axis.Regular(6, 0, 1))
+
+    assert not h1.allclose(h2)
+
+
+def test_allclose_different_ndim():
+    h1 = bh.Histogram(bh.axis.Regular(5, 0, 1))
+    h2 = bh.Histogram(bh.axis.Regular(5, 0, 1), bh.axis.Regular(3, 0, 1))
+
+    assert not h1.allclose(h2)
+
+
+def test_allclose_different_storage():
+    h1 = bh.Histogram(bh.axis.Regular(5, 0, 1))
+    h2 = bh.Histogram(bh.axis.Regular(5, 0, 1), storage=bh.storage.Weight())
+
+    assert not h1.allclose(h2)
+
+
+def test_allclose_flow_option():
+    h1 = bh.Histogram(bh.axis.Regular(3, 0, 1))
+    h2 = bh.Histogram(bh.axis.Regular(3, 0, 1))
+
+    h1.fill([0.5])  # central bin only
+    h2.fill([0.5])  # central bin only
+    # h1 has flow bins empty, h2 also, so both should match with/without flow
+    assert h1.allclose(h2, flow=True)
+    assert h1.allclose(h2, flow=False)
+
+    # Now put different data in underflow
+    h3 = bh.Histogram(bh.axis.Regular(3, 0, 1))
+    h4 = bh.Histogram(bh.axis.Regular(3, 0, 1))
+    h3.fill([-0.5])
+    h4.fill([-0.5, -0.5])
+
+    assert not h3.allclose(h4, flow=True)
+    assert h3.allclose(h4, flow=False)
+
+
+def test_allclose_metadata():
+    h1 = bh.Histogram(bh.axis.Regular(3, 0, 1), metadata="foo")
+    h2 = bh.Histogram(bh.axis.Regular(3, 0, 1), metadata="foo")
+    h3 = bh.Histogram(bh.axis.Regular(3, 0, 1), metadata="bar")
+
+    assert h1.allclose(h2)
+    assert h1.allclose(h2, metadata=True)
+    assert not h1.allclose(h3, metadata=True)
+    assert h1.allclose(h3, metadata=False)
+
+
+def test_allclose_non_histogram():
+    h = bh.Histogram(bh.axis.Regular(3, 0, 1))
+    assert not h.allclose(42)
+    assert not h.allclose("histogram")
+
+
+def test_allclose_categorical_exact():
+    h1 = bh.Histogram(bh.axis.StrCategory(["a", "b"]))
+    h2 = bh.Histogram(bh.axis.StrCategory(["a", "b"]))
+    h3 = bh.Histogram(bh.axis.StrCategory(["a", "c"]))
+    h4 = bh.Histogram(bh.axis.StrCategory(["b", "a"]))
+
+    assert h1.allclose(h2)
+    assert not h1.allclose(h3)
+    assert not h1.allclose(h4)
+
+
+def test_allclose_intcategory():
+    h1 = bh.Histogram(bh.axis.IntCategory([1, 2, 3]))
+    h2 = bh.Histogram(bh.axis.IntCategory([1, 2, 3]))
+    h3 = bh.Histogram(bh.axis.IntCategory([1, 2, 4]))
+
+    assert h1.allclose(h2)
+    assert not h1.allclose(h3)
+
+
+def test_allclose_boolean():
+    h1 = bh.Histogram(bh.axis.Boolean())
+    h2 = bh.Histogram(bh.axis.Boolean())
+
+    assert h1.allclose(h2)
+
+
+def test_allclose_mean_storage():
+    h1 = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.Mean())
+    h2 = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.Mean())
+
+    rng = np.random.default_rng(42)
+    samples = rng.random(100)
+    h1.fill(samples, sample=samples)
+    h2.fill(samples, sample=samples)
+
+    assert h1.allclose(h2)
+
+
+def test_allclose_weight_storage():
+    h1 = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.Weight())
+    h2 = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.Weight())
+
+    rng = np.random.default_rng(42)
+    data = rng.random(100)
+    w = rng.random(100)
+    h1.fill(data, weight=w)
+    h2.fill(data, weight=w)
+
+    assert h1.allclose(h2)
+
+
+def test_allclose_weighted_mean_storage():
+    h1 = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.WeightedMean())
+    h2 = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.WeightedMean())
+
+    rng = np.random.default_rng(42)
+    data = rng.random(100)
+    w = rng.random(100)
+    h1.fill(data, sample=data, weight=w)
+    h2.fill(data, sample=data, weight=w)
+
+    assert h1.allclose(h2)
+
+
+def test_allclose_different_continuous_traits():
+    h1 = bh.Histogram(bh.axis.Regular(3, 0, 1))
+    h2 = bh.Histogram(bh.axis.Integer(0, 3))
+
+    assert not h1.allclose(h2)

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1513,7 +1513,7 @@ def test_allclose_different_bins():
     vals = rng.random(100)
     h1.fill(vals)
     h2.fill(vals)
-    h2.fill(.7)
+    h2.fill(0.7)
 
     assert not h1.allclose(h2)
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1510,8 +1510,10 @@ def test_allclose_different_bins():
     h2 = bh.Histogram(bh.axis.Regular(5, 0, 1))
 
     rng = np.random.default_rng(42)
-    h1.fill(rng.random(100))
-    h2.fill(rng.random(100))
+    vals = rng.random(100)
+    h1.fill(vals)
+    h2.fill(vals)
+    h2.fill(.7)
 
     assert not h1.allclose(h2)
 
@@ -1520,11 +1522,7 @@ def test_allclose_edges_within_tol():
     h1 = bh.Histogram(bh.axis.Regular(5, 0, 1))
     h2 = bh.Histogram(bh.axis.Regular(5, 0, 1 + 1e-7))
 
-    rng = np.random.default_rng(42)
-    h1.fill(rng.random(100))
-    h2.fill(rng.random(100))
-
-    assert not h1.allclose(h2)
+    assert h1.allclose(h2)
 
 
 def test_allclose_edges_outside_tol():


### PR DESCRIPTION
Addresses https://github.com/scikit-hep/boost-histogram/issues/157 issue. Close #779.

Added:
- Histogram comparison
- ufunc for numpy's allclose mapping to above comparison

![Screenshot (2039)](https://user-images.githubusercontent.com/59703162/184717374-5cc89745-c888-4dc7-b703-302a04eb61fc.png)
