### PR TITLE
Swapped all numpy assert_allclose & assert_array_equal to pytest approx in tests

### DIFF
--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -5,7 +5,6 @@ import copy
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose, assert_array_equal
 from pytest import approx
 
 import boost_histogram as bh
@@ -253,8 +252,8 @@ class TestRegular(Axis):
         a = bh.axis.Regular(2, 1.0, 2.0)
         ref = [1.0, 1.5, 2.0]
         for i in range(2):
-            assert_allclose(a.bin(i), ref[i : i + 2])
-            assert_allclose(a[i], ref[i : i + 2])
+            assert a.bin(i) == approx(ref[i : i + 2])
+            assert a[i] == approx(ref[i : i + 2])
 
         assert a[-1] == a[1]
         with pytest.raises(IndexError):
@@ -263,8 +262,8 @@ class TestRegular(Axis):
         assert a.bin(-1)[0] == -np.inf
         assert a.bin(2)[1] == np.inf
 
-        assert_allclose(a[bh.underflow], a.bin(-1))
-        assert_allclose(a[bh.overflow], a.bin(2))
+        assert a[bh.underflow] == approx(a.bin(-1))
+        assert a[bh.overflow] == approx(a.bin(2))
 
         with pytest.raises(IndexError):
             a.bin(-2)
@@ -274,7 +273,7 @@ class TestRegular(Axis):
     def test_iter(self):
         a = bh.axis.Regular(2, 1.0, 2.0)
         ref = [(1.0, 1.5), (1.5, 2.0)]
-        assert_allclose(a, ref)
+        assert np.asarray(a) == approx(np.array(ref))
 
     def test_index(self):
         a = bh.axis.Regular(4, 1.0, 2.0)
@@ -362,9 +361,9 @@ class TestRegular(Axis):
 
     def test_edges_centers_widths(self):
         a = bh.axis.Regular(2, 0, 1)
-        assert_allclose(a.edges, [0, 0.5, 1])
-        assert_allclose(a.centers, [0.25, 0.75])
-        assert_allclose(a.widths, [0.5, 0.5])
+        assert a.edges == approx([0, 0.5, 1])
+        assert a.centers == approx([0.25, 0.75])
+        assert a.widths == approx([0.5, 0.5])
 
 
 class TestCircular(Axis):
@@ -418,8 +417,8 @@ class TestCircular(Axis):
         a = bh.axis.Regular(2, 1, 1 + np.pi * 2, circular=True)
         ref = [1.0, 1.0 + np.pi, 1.0 + 2.0 * np.pi]
         for i in range(2):
-            assert_allclose(a.bin(i), ref[i : i + 2])
-            assert_allclose(a[i], ref[i : i + 2])
+            assert a.bin(i) == approx(ref[i : i + 2])
+            assert a[i] == approx(ref[i : i + 2])
 
         assert a[-1] == a[1]
         with pytest.raises(IndexError):
@@ -428,7 +427,7 @@ class TestCircular(Axis):
         with pytest.raises(IndexError):
             a[bh.underflow]
 
-        assert_allclose(a[bh.overflow], a.bin(2))
+        assert a[bh.overflow] == approx(a.bin(2))
 
         assert a.bin(2)[0] == approx(1 + 2 * np.pi)
         assert a.bin(2)[1] == approx(1 + 3 * np.pi)
@@ -441,7 +440,7 @@ class TestCircular(Axis):
     def test_iter(self):
         a = bh.axis.Regular(2, 1, 2, circular=True)
         ref = [(1, 1.5), (1.5, 2)]
-        assert_allclose(a, ref)
+        assert np.asarray(a) == approx(np.array(ref))
 
     def test_index(self):
         a = bh.axis.Regular(4, 1, 1 + np.pi * 2, circular=True)
@@ -462,9 +461,9 @@ class TestCircular(Axis):
 
     def test_edges_centers_widths(self):
         a = bh.axis.Regular(2, 0, 1, circular=True)
-        assert_allclose(a.edges, [0, 0.5, 1])
-        assert_allclose(a.centers, [0.25, 0.75])
-        assert_allclose(a.widths, [0.5, 0.5])
+        assert a.edges == approx([0, 0.5, 1])
+        assert a.centers == approx([0.25, 0.75])
+        assert a.widths == approx([0.5, 0.5])
 
 
 class TestVariable(Axis):
@@ -532,15 +531,15 @@ class TestVariable(Axis):
         a = bh.axis.Variable(ref)
 
         for i in range(2):
-            assert_allclose(a.bin(i), ref[i : i + 2])
-            assert_allclose(a[i], ref[i : i + 2])
+            assert a.bin(i) == approx(ref[i : i + 2])
+            assert a[i] == approx(ref[i : i + 2])
 
         assert a[-1] == a[1]
         with pytest.raises(IndexError):
             a[2]
 
-        assert_allclose(a[bh.underflow], a.bin(-1))
-        assert_allclose(a[bh.overflow], a.bin(2))
+        assert a[bh.underflow] == approx(a.bin(-1))
+        assert a[bh.overflow] == approx(a.bin(2))
 
         assert a.bin(-1)[0] == -np.inf
         assert a.bin(-1)[1] == ref[0]
@@ -557,7 +556,7 @@ class TestVariable(Axis):
         ref = [-0.1, 0.2, 0.3]
         a = bh.axis.Variable(ref)
         for i, bin in enumerate(a):
-            assert_array_equal(bin, ref[i : i + 2])
+            assert bin == approx(ref[i : i + 2])
 
     def test_index(self):
         a = bh.axis.Variable([-0.1, 0.2, 0.3])
@@ -575,9 +574,9 @@ class TestVariable(Axis):
 
     def test_edges_centers_widths(self):
         a = bh.axis.Variable([0, 1, 3])
-        assert_allclose(a.edges, [0, 1, 3])
-        assert_allclose(a.centers, [0.5, 2])
-        assert_allclose(a.widths, [1, 2])
+        assert a.edges == approx([0, 1, 3])
+        assert a.centers == approx([0.5, 2])
+        assert a.widths == approx([1, 2])
 
 
 class TestInteger:
@@ -673,13 +672,13 @@ class TestInteger:
         assert a.bin(-1) == -2
         assert a.bin(4) == 3
 
-        assert_allclose(a[bh.underflow], a.bin(-1))
-        assert_allclose(a[bh.overflow], a.bin(4))
+        assert a[bh.underflow] == approx(a.bin(-1))
+        assert a[bh.overflow] == approx(a.bin(4))
 
     def test_iter(self):
         a = bh.axis.Integer(-1, 3)
         ref = (-1, 0, 1, 2)
-        assert_array_equal(a, ref)
+        assert np.asarray(a) == approx(ref)
 
     def test_index(self):
         a = bh.axis.Integer(-1, 3)
@@ -694,9 +693,9 @@ class TestInteger:
 
     def test_edges_centers_widths(self):
         a = bh.axis.Integer(1, 3)
-        assert_allclose(a.edges, [1, 2, 3])
-        assert_allclose(a.centers, [1.5, 2.5])
-        assert_allclose(a.widths, [1, 1])
+        assert a.edges == approx([1, 2, 3])
+        assert a.centers == approx([1.5, 2.5])
+        assert a.widths == approx([1, 1])
 
 
 class TestCategory(Axis):
@@ -799,7 +798,7 @@ class TestCategory(Axis):
     def test_iter(self, ref, growth):
         Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
         a = Cat(ref, growth=growth)
-        assert_array_equal(a, ref)
+        assert np.asarray(a) == approx(ref)
 
     @pytest.mark.parametrize(
         "ref", [[1, 2, 3, 4], ("A", "B", "C", "D")], ids=("int", "str")
@@ -809,8 +808,8 @@ class TestCategory(Axis):
         a = Cat(ref, growth=growth)
         for i, r in enumerate(ref):
             assert a.index(r) == i
-        assert_array_equal(a.index(ref), [0, 1, 2, 3])
-        assert_array_equal(a.index(np.reshape(ref, (2, 2))), [[0, 1], [2, 3]])
+        assert a.index(ref) == approx([0, 1, 2, 3])
+        assert a.index(np.reshape(ref, (2, 2))) == approx(np.array([[0, 1], [2, 3]]))
 
         if isinstance(ref[0], str):
             with pytest.raises(KeyError):
@@ -827,12 +826,10 @@ class TestCategory(Axis):
         a = Cat(ref, growth=growth)
         for i, r in enumerate(ref):
             assert a.value(i) == r
-        assert_array_equal(a.value(range(3)), ref)
+        assert a.value(range(3)) == approx(ref)
         assert a.value(3) is None
-        assert_array_equal(a.value((0, 3)), [ref[0], None])
-        assert_array_equal(
-            a.value(np.array((0, 1, 2, 3))), [ref[0], ref[1], ref[2], None]
-        )
+        assert a.value((0, 3)) == approx([ref[0], None])
+        assert a.value(np.array((0, 1, 2, 3))) == approx([ref[0], ref[1], ref[2], None])
         # may be added in the future
         with pytest.raises(ValueError):
             a.value([[2], [2]])
@@ -841,9 +838,9 @@ class TestCategory(Axis):
     def test_edges_centers_widths(self, ref, growth):
         Cat = bh.axis.StrCategory if isinstance(ref[0], str) else bh.axis.IntCategory
         a = Cat(ref, growth=growth)
-        assert_allclose(a.edges, [0, 1, 2, 3])
-        assert_allclose(a.centers, [0.5, 1.5, 2.5])
-        assert_allclose(a.widths, [1, 1, 1])
+        assert a.edges == approx([0, 1, 2, 3])
+        assert a.centers == approx([0.5, 1.5, 2.5])
+        assert a.widths == approx([1, 1, 1])
 
 
 class TestBoolean(Axis):
@@ -897,7 +894,8 @@ class TestBoolean(Axis):
     def test_iter(self):
         a = bh.axis.Boolean()
         ref = (False, True)
-        assert_array_equal(a, ref)
+        # approx() does not support booleans; compare exactly
+        assert np.asarray(a).tolist() == list(ref)
 
     def test_index(self):
         a = bh.axis.Boolean()
@@ -906,9 +904,9 @@ class TestBoolean(Axis):
 
     def test_edges_centers_widths(self):
         a = bh.axis.Boolean()
-        assert_allclose(a.edges, [0.0, 1.0, 2.0])
-        assert_allclose(a.centers, [0.5, 1.5])
-        assert_allclose(a.widths, [1, 1])
+        assert a.edges == approx([0.0, 1.0, 2.0])
+        assert a.centers == approx([0.5, 1.5])
+        assert a.widths == approx([1, 1])
 
 
 # Issue #1143 regression tests
@@ -944,7 +942,7 @@ def test_index_empty_sequence():
     assert ax.index([]).size == 0
     assert ax.index(np.array([])).size == 0
     assert ax.index("a") == 0
-    assert_array_equal(ax.index(["b", "a"]), [1, 0])
+    assert ax.index(["b", "a"]) == approx([1, 0])
 
     with pytest.raises(TypeError):
         ax.index([1, 2])
@@ -969,32 +967,32 @@ class TestNonContiguousIndex:
     def test_intcategory_fortran_order(self):
         ax = bh.axis.IntCategory([1, 2, 3])
         arr = np.asfortranarray([[1, 2], [3, 1]])
-        assert_array_equal(ax.index(arr), [[0, 1], [2, 0]])
+        assert ax.index(arr) == approx(np.array([[0, 1], [2, 0]]))
 
     def test_intcategory_negative_stride(self):
         ax = bh.axis.IntCategory([1, 2, 3])
         arr = np.array([1, 2, 3, 1])[::-1]
-        assert_array_equal(ax.index(arr), [0, 2, 1, 0])
+        assert ax.index(arr) == approx([0, 2, 1, 0])
 
     def test_intcategory_strided(self):
         ax = bh.axis.IntCategory([1, 2, 3])
         arr = np.array([1, 2, 3, 1])[::2]
-        assert_array_equal(ax.index(arr), [0, 2])
+        assert ax.index(arr) == approx([0, 2])
 
     def test_strcategory_strided(self):
         ax = bh.axis.StrCategory(["a", "b", "c"])
         arr = np.array(["a", "b", "c", "a"])[::2]
-        assert_array_equal(ax.index(arr), [0, 2])
+        assert ax.index(arr) == approx([0, 2])
 
     def test_strcategory_negative_stride(self):
         ax = bh.axis.StrCategory(["a", "b", "c"])
         arr = np.array(["a", "b", "c"])[::-1]
-        assert_array_equal(ax.index(arr), [2, 1, 0])
+        assert ax.index(arr) == approx([2, 1, 0])
 
     def test_strcategory_bytes_strided(self):
         ax = bh.axis.StrCategory(["a", "b", "c"])
         arr = np.array([b"a", b"b", b"c", b"a"])[::2]
-        assert_array_equal(ax.index(arr), [0, 2])
+        assert ax.index(arr) == approx([0, 2])
 
 
 def test_to_numpy_upper_edge_nudge_direction():

--- a/tests/test_benchmark_1d.py
+++ b/tests/test_benchmark_1d.py
@@ -4,7 +4,7 @@ import platform
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose, assert_array_equal
+from pytest import approx
 
 import boost_histogram as bh
 
@@ -33,7 +33,7 @@ answer = {t: np.histogram(vals[t], bins=bins, range=ranges)[0] for t in DTYPES}
 @pytest.mark.parametrize("dtype", vals)
 def test_numpy_1d(benchmark, dtype):
     result, _ = benchmark(np.histogram, vals[dtype], bins=bins, range=ranges)
-    assert_array_equal(result, answer[dtype])
+    assert result == approx(answer[dtype])
 
 
 def make_and_run_hist(flow, storage, vals):
@@ -49,4 +49,4 @@ def make_and_run_hist(flow, storage, vals):
 @pytest.mark.parametrize("storage", STORAGES)
 def test_boost_1d(benchmark, flow, storage, dtype):
     result = benchmark(make_and_run_hist, flow, storage, vals[dtype])
-    assert_allclose(result[:-1], answer[dtype][:-1], atol=2)
+    assert result[:-1] == approx(answer[dtype][:-1], abs=2)

--- a/tests/test_benchmark_2d.py
+++ b/tests/test_benchmark_2d.py
@@ -4,7 +4,7 @@ import platform
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
+from pytest import approx
 
 import boost_histogram as bh
 
@@ -36,7 +36,7 @@ answer = {t: np.histogram2d(*vals[t], bins=bins, range=ranges)[0] for t in DTYPE
 @pytest.mark.parametrize("dtype", vals)
 def test_numpy_perf_2d(benchmark, dtype):
     result, _, _ = benchmark(np.histogram2d, *vals[dtype], bins=bins, range=ranges)
-    assert_array_equal(result, answer[dtype])
+    assert result == approx(answer[dtype])
 
 
 def make_and_run_hist(flow, storage, vals):
@@ -54,4 +54,4 @@ def make_and_run_hist(flow, storage, vals):
 @pytest.mark.parametrize("storage", STORAGES)
 def test_2d(benchmark, flow, storage, dtype):
     result = benchmark(make_and_run_hist, flow, storage, vals[dtype])
-    assert_array_equal(result[:-1, :-1], answer[dtype][:-1, :-1])
+    assert result[:-1, :-1] == approx(answer[dtype][:-1, :-1])

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -13,7 +13,6 @@ from io import BytesIO
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
 from pytest import approx
 
 import boost_histogram as bh
@@ -180,7 +179,7 @@ def test_setting(count_single_storage):
     assert h[9] == 5
     assert h[bh.overflow] == 6
 
-    assert_array_equal(h.view(flow=True), [1, 2, 3, 0, 0, 0, 4, 0, 0, 0, 5, 6])
+    assert h.view(flow=True) == approx([1, 2, 3, 0, 0, 0, 4, 0, 0, 0, 5, 6])
 
 
 def test_growth():
@@ -638,13 +637,13 @@ def test_int_storage_division_promotes_to_double(storage):
     # hist / hist
     result = a / b
     assert result.storage_type is bh.storage.Double
-    assert_array_equal(result.view(), expected)
+    assert result.view() == approx(expected)
     # operands are unchanged
     assert a.storage_type is storage
     assert b.storage_type is storage
 
     # hist / scalar
-    assert_array_equal((a / 2).view(), np.array([5, 3, 7]) / 2)
+    assert (a / 2).view() == approx(np.array([5, 3, 7]) / 2)
     assert (a / 2).storage_type is bh.storage.Double
 
     # in-place division promotes storage but keeps the same object
@@ -652,7 +651,7 @@ def test_int_storage_division_promotes_to_double(storage):
     a /= b
     assert a is a_orig
     assert a.storage_type is bh.storage.Double
-    assert_array_equal(a.view(), expected)
+    assert a.view() == approx(expected)
 
 
 def test_mixed_int_double_division():
@@ -663,8 +662,8 @@ def test_mixed_int_double_division():
     bd[:] = (2, 4, 3)
 
     expected = np.array([5, 3, 7]) / np.array([2, 4, 3])
-    assert_array_equal((ai / bd).view(), expected)
-    assert_array_equal((bd / ai).view(), 1 / expected)
+    assert (ai / bd).view() == approx(expected)
+    assert (bd / ai).view() == approx(1 / expected)
 
 
 def test_project():
@@ -733,11 +732,11 @@ def test_shrink_1d():
     h = bh.Histogram(bh.axis.Regular(20, 1, 5))
     h.fill(1.1)
     hs = h[{0: slice(bh.loc(1), bh.loc(2))}]
-    assert_array_equal(hs.view(), [1, 0, 0, 0, 0])
+    assert hs.view() == approx([1, 0, 0, 0, 0])
 
     d = OrderedDict({0: slice(bh.loc(1), bh.loc(2))})
     hs = h[d]
-    assert_array_equal(hs.view(), [1, 0, 0, 0, 0])
+    assert hs.view() == approx([1, 0, 0, 0, 0])
 
 
 @pytest.mark.parametrize(
@@ -748,33 +747,33 @@ def test_rebin_1d(metadata):
     h.fill([1.1, 2.2, 3.3, 4.4])
 
     hs = h[{0: slice(None, None, bh.rebin(4))}]
-    assert_array_equal(hs.view(), [1, 1, 1, 0, 1])
+    assert hs.view() == approx([1, 1, 1, 0, 1])
     assert h.axes[0].metadata is hs.axes[0].metadata
 
     hs = h[{0: bh.rebin(4)}]
-    assert_array_equal(hs.view(), [1, 1, 1, 0, 1])
+    assert hs.view() == approx([1, 1, 1, 0, 1])
     assert h.axes[0].metadata is hs.axes[0].metadata
 
     hs = h[{0: bh.rebin(groups=[1, 2, 3, 14])}]
-    assert_array_equal(hs.view(), [1, 0, 0, 3])
-    assert_array_equal(hs.axes.edges[0], [1.0, 1.2, 1.6, 2.2, 5.0])
+    assert hs.view() == approx([1, 0, 0, 3])
+    assert hs.axes.edges[0] == approx([1.0, 1.2, 1.6, 2.2, 5.0])
     assert h.axes[0].metadata is hs.axes[0].metadata
 
     exact_edges = [1.0, 1.2, 1.6, 2.2, 5.0]
     hs = h[bh.rebin(edges=exact_edges)]
-    assert_array_equal(hs.view(), [1, 0, 0, 3])
-    assert_array_equal(hs.axes.edges[0], exact_edges)
+    assert hs.view() == approx([1, 0, 0, 3])
+    assert hs.axes.edges[0] == approx(exact_edges)
     assert h.axes[0].metadata is hs.axes[0].metadata
 
     fuzzy_edges = [1.0, 1.200000000000001, 1.6, 2.2, 5.0]
     hs = h[bh.rebin(edges=fuzzy_edges)]
-    assert_array_equal(hs.view(), [1, 0, 0, 3])
-    assert_array_equal(hs.axes.edges[0], exact_edges)
+    assert hs.view() == approx([1, 0, 0, 3])
+    assert hs.axes.edges[0] == approx(exact_edges)
     assert h.axes[0].metadata is hs.axes[0].metadata
 
     hs = h[bh.rebin(axis=bh.axis.Variable([1.0, 1.2, 1.6, 2.2, 5.0], metadata="hi"))]
-    assert_array_equal(hs.view(), [1, 0, 0, 3])
-    assert_array_equal(hs.axes.edges[0], [1.0, 1.2, 1.6, 2.2, 5.0])
+    assert hs.view() == approx([1, 0, 0, 3])
+    assert hs.axes.edges[0] == approx([1.0, 1.2, 1.6, 2.2, 5.0])
     assert hs.axes[0].metadata == "hi"
 
 
@@ -782,47 +781,47 @@ def test_rebin_1d_flow():
     h = bh.Histogram(bh.axis.Regular(5, 0, 5, underflow=True, overflow=True))
     h.fill([-1, 1.1, 2.2, 3.3, 4.4, 5.5])
     hs = h[bh.rebin(edges=[0, 3, 5.0])]
-    assert_array_equal(hs.view(), [2, 2])
-    assert_array_equal(hs.view(flow=True), [1, 2, 2, 1])
-    assert_array_equal(hs.axes.edges[0], [0.0, 3.0, 5.0])
+    assert hs.view() == approx([2, 2])
+    assert hs.view(flow=True) == approx([1, 2, 2, 1])
+    assert hs.axes.edges[0] == approx([0.0, 3.0, 5.0])
 
     # Flow bins are kept from the original
     h = bh.Histogram(bh.axis.Regular(5, 0, 5, underflow=False, overflow=False))
     h.fill([-1, 1.1, 2.2, 3.3, 4.4, 5.5])
     hs = h[bh.rebin(edges=[0, 3, 5.0])]
-    assert_array_equal(hs.view(flow=True), [2, 2])
+    assert hs.view(flow=True) == approx([2, 2])
 
     h = bh.Histogram(bh.axis.Regular(5, 0, 5, underflow=True, overflow=False))
     h.fill([-1, 1.1, 2.2, 3.3, 4.4, 5.5])
     hs = h[bh.rebin(edges=[0, 3, 5.0])]
-    assert_array_equal(hs.view(flow=True), [1, 2, 2])
+    assert hs.view(flow=True) == approx([1, 2, 2])
 
     h = bh.Histogram(bh.axis.Regular(5, 0, 5, underflow=True, overflow=True))
     h.fill([-1, 1.1, 2.2, 3.3, 4.4, 5.5])
     hs = h[
         bh.rebin(axis=bh.axis.Variable([0, 3, 5.0], underflow=False, overflow=False))
     ]
-    assert_array_equal(hs.view(flow=True), [2, 2])
+    assert hs.view(flow=True) == approx([2, 2])
 
 
 def test_rebin_change_axis_int():
     h = bh.Histogram(bh.axis.Regular(5, 0, 5))
     h.fill([-1, 1.1, 2.2, 3.3, 4.4, 5.5])
     hs = h[bh.rebin(edges=[0, 3, 5.0], axis=bh.axis.Integer(10, 12))]
-    assert_array_equal(hs.view(), [2, 2])
-    assert_array_equal(hs.view(flow=True), [1, 2, 2, 1])
-    assert_array_equal(hs.axes.edges[0], [10, 11, 12])
+    assert hs.view() == approx([2, 2])
+    assert hs.view(flow=True) == approx([1, 2, 2, 1])
+    assert hs.axes.edges[0] == approx([10, 11, 12])
 
 
 def test_rebin_change_axis_cat():
     h = bh.Histogram(bh.axis.Regular(5, 0, 5))
     h.fill([-1, 1.1, 2.2, 3.3, 4.4, 5.5])
     hs = h[bh.rebin(groups=[2, 3], axis=bh.axis.StrCategory(["a", "b"]))]
-    assert_array_equal(hs.view(), [1, 3])
+    assert hs.view() == approx([1, 3])
     # Old underflow (1) and old overflow (1) both end up in the new overflow,
     # exactly once each.
-    assert_array_equal(hs.view(flow=True), [1, 3, 2])
-    assert_array_equal(list(hs.axes[0]), ["a", "b"])
+    assert hs.view(flow=True) == approx([1, 3, 2])
+    assert list(hs.axes[0]) == approx(["a", "b"])
 
 
 def test_rebin_groups_flow_to_noflow():
@@ -832,7 +831,7 @@ def test_rebin_groups_flow_to_noflow():
     h = bh.Histogram(bh.axis.Regular(4, 0, 4))
     h.view(flow=True)[:] = [100, 1, 2, 3, 4, 200]
     hs = h[bh.rebin(groups=[2, 2], axis=bh.axis.IntCategory([0, 1]))]
-    assert_array_equal(hs.view(flow=True), [3, 7, 300])
+    assert hs.view(flow=True) == approx([3, 7, 300])
 
 
 def test_rebin_groups_flow_combinations():
@@ -841,15 +840,15 @@ def test_rebin_groups_flow_combinations():
     h.view(flow=True)[:] = [100, 1, 2, 3, 4, 200]
 
     # Old flow -> new flow: flow bins are carried over unchanged
-    assert_array_equal(h[bh.rebin(groups=[2, 2])].view(flow=True), [100, 3, 7, 200])
+    assert h[bh.rebin(groups=[2, 2])].view(flow=True) == approx([100, 3, 7, 200])
 
     # Old underflow dropped on an ordered axis without underflow
     hs = h[bh.rebin(groups=[2, 2], axis=bh.axis.Variable([0, 2, 4], underflow=False))]
-    assert_array_equal(hs.view(flow=True), [3, 7, 200])
+    assert hs.view(flow=True) == approx([3, 7, 200])
 
     # Old overflow dropped on an axis without overflow
     hs = h[bh.rebin(groups=[2, 2], axis=bh.axis.Variable([0, 2, 4], overflow=False))]
-    assert_array_equal(hs.view(flow=True), [100, 3, 7])
+    assert hs.view(flow=True) == approx([100, 3, 7])
 
     # Both flow bins dropped on a flowless ordered axis
     hs = h[
@@ -858,30 +857,30 @@ def test_rebin_groups_flow_combinations():
             axis=bh.axis.Variable([0, 2, 4], underflow=False, overflow=False),
         )
     ]
-    assert_array_equal(hs.view(flow=True), [3, 7])
+    assert hs.view(flow=True) == approx([3, 7])
 
     # Old axis without underflow: new axis copies the traits
     h2 = bh.Histogram(bh.axis.Regular(4, 0, 4, underflow=False))
     h2.view(flow=True)[:] = [1, 2, 3, 4, 200]
-    assert_array_equal(h2[bh.rebin(groups=[2, 2])].view(flow=True), [3, 7, 200])
+    assert h2[bh.rebin(groups=[2, 2])].view(flow=True) == approx([3, 7, 200])
 
     # Old axis without underflow onto a categorical axis: only the old
     # overflow goes to the new overflow
     hs = h2[bh.rebin(groups=[2, 2], axis=bh.axis.IntCategory([0, 1]))]
-    assert_array_equal(hs.view(flow=True), [3, 7, 200])
+    assert hs.view(flow=True) == approx([3, 7, 200])
 
     # Old flowless axis onto an axis with flow: new flow bins stay empty
     h3 = bh.Histogram(bh.axis.Regular(4, 0, 4, underflow=False, overflow=False))
     h3.view(flow=True)[:] = [1, 2, 3, 4]
     hs = h3[bh.rebin(groups=[2, 2], axis=bh.axis.Variable([0, 2, 4]))]
-    assert_array_equal(hs.view(flow=True), [0, 3, 7, 0])
+    assert hs.view(flow=True) == approx([0, 3, 7, 0])
 
 
 def test_shrink_rebin_1d():
     h = bh.Histogram(bh.axis.Regular(20, 0, 4))
     h.fill(1.1)
     hs = h[{0: slice(bh.loc(1), bh.loc(3), bh.rebin(2))}]
-    assert_array_equal(hs.view(), [1, 0, 0, 0, 0])
+    assert hs.view() == approx([1, 0, 0, 0, 0])
 
 
 def test_rebin_nd():
@@ -1034,7 +1033,7 @@ def test_fill_bool_not_bool():
 
     h.fill([0, 1, 1, 7, -3])
 
-    assert_array_equal(h.view(), [1, 4])
+    assert h.view() == approx([1, 4])
 
 
 def test_pick_bool():
@@ -1043,22 +1042,22 @@ def test_pick_bool():
     h.fill([True, True, False, False], [True, False, True, True])
     h.fill([True, True, True], True)
 
-    assert_array_equal(h[True, :].view(), [1, 4])
-    assert_array_equal(h[False, :].view(), [0, 2])
-    assert_array_equal(h[:, False].view(), [0, 1])
-    assert_array_equal(h[:, True].view(), [2, 4])
+    assert h[True, :].view() == approx([1, 4])
+    assert h[False, :].view() == approx([0, 2])
+    assert h[:, False].view() == approx([0, 1])
+    assert h[:, True].view() == approx([2, 4])
 
 
 def test_slice_bool():
     h = bh.Histogram(bh.axis.Boolean())
     h.fill([0, 0, 0, 1, 3, 4, -2])
 
-    assert_array_equal(h.view(), [3, 4])
-    assert_array_equal(h[1:].view(), [4])
-    assert_array_equal(h[:1].view(), [3])
+    assert h.view() == approx([3, 4])
+    assert h[1:].view() == approx([4])
+    assert h[:1].view() == approx([3])
 
-    assert_array_equal(h[:1].axes[0].centers, [0.5])
-    assert_array_equal(h[1:].axes[0].centers, [1.5])
+    assert h[:1].axes[0].centers == approx([0.5])
+    assert h[1:].axes[0].centers == approx([1.5])
 
 
 def test_pickle_bool():
@@ -1086,7 +1085,7 @@ def test_pickle_bool():
     assert repr(a) == repr(b)
     assert str(a) == str(b)
     assert a == b
-    assert_array_equal(a.view(), b.view())
+    assert a.view() == approx(b.view())
 
 
 # NumPy tests
@@ -1102,20 +1101,20 @@ def test_numpy_conversion_0():
 
     for t in (c, v):
         assert t.dtype == np.double  # CLASSIC: np.uint8
-        assert_array_equal(t, (1, 5, 0))
+        assert t == approx((1, 5, 0))
 
     for _ in range(10):
         a.fill(2)
     # copy does not change, but view does
-    assert_array_equal(c, (1, 5, 0))
-    assert_array_equal(v, (1, 5, 10))
+    assert c == approx((1, 5, 0))
+    assert v == approx((1, 5, 10))
 
     for _ in range(255):
         a.fill(1)
     c = np.array(a)
 
     assert c.dtype == np.double  # CLASSIC: np.uint16
-    assert_array_equal(c, (1, 260, 10))
+    assert c == approx((1, 260, 10))
     # view does not follow underlying switch in word size
     # assert not np.all(c, v)
 
@@ -1128,8 +1127,8 @@ def test_numpy_conversion_1():
     c = np.array(h)  # a copy
     v = np.asarray(h)  # a view
     assert c.dtype == np.double  # CLASSIC: np.float64
-    assert_array_equal(c, np.array((0, 30, 0)))
-    assert_array_equal(v, c)
+    assert c == approx(np.array((0, 30, 0)))
+    assert v == approx(c)
 
 
 def test_numpy_conversion_2():
@@ -1152,13 +1151,13 @@ def test_numpy_conversion_2():
             for k in range(a.axes[2].extent):
                 d[i, j, k] = a[i, j, k]
 
-    assert_array_equal(d, r)
+    assert d == approx(r)
 
     c = np.array(a)  # a copy
     v = np.asarray(a)  # a view
 
-    assert_array_equal(c, r)
-    assert_array_equal(v, r)
+    assert c == approx(r)
+    assert v == approx(r)
 
 
 def test_numpy_conversion_3():
@@ -1177,7 +1176,7 @@ def test_numpy_conversion_3():
                 r[i, j, k] = i + j + k
     c = a.view(flow=True)
 
-    assert_array_equal(c, r)
+    assert c == approx(r)
 
     assert a.sum() == approx(144)
     assert a.sum(flow=True) == approx(720)
@@ -1254,7 +1253,7 @@ def test_fill_with_sequence_0():
     a.fill(np.array(1))  # 0-dim arrays work
     a.fill(ia(-1, 0, 1, 2))
     a.fill((2, 1, 0, -1))
-    assert_array_equal(a.view(True), [2, 2, 3, 2])
+    assert a.view(True) == approx([2, 2, 3, 2])
 
     with pytest.raises(ValueError):
         a.fill(np.empty((2, 2)))
@@ -1271,13 +1270,13 @@ def test_fill_with_sequence_0():
     b = bh.Histogram(bh.axis.Regular(3, 0, 3))
     b.fill(fa(0, 0, 1, 2))
     b.fill(ia(1, 0, 2, 2))
-    assert_array_equal(b.view(True), [0, 3, 2, 3, 0])
+    assert b.view(True) == approx([0, 3, 2, 3, 0])
 
     c = bh.Histogram(
         bh.axis.Integer(0, 2, underflow=False, overflow=False), bh.axis.Regular(2, 0, 2)
     )
     c.fill(ia(-1, 0, 1), fa(-1.0, 1.5, 0.5))
-    assert_array_equal(c.view(True), [[0, 0, 1, 0], [0, 1, 0, 0]])
+    assert c.view(True) == approx(np.array([[0, 0, 1, 0], [0, 1, 0, 0]]))
     # we don't support: assert a[[1, 1]].value, 0
 
     with pytest.raises(ValueError):
@@ -1287,11 +1286,11 @@ def test_fill_with_sequence_0():
 
     # this broadcasts
     c.fill([1, 0], -1)
-    assert_array_equal(c.view(True), [[1, 0, 1, 0], [1, 1, 0, 0]])
+    assert c.view(True) == approx(np.array([[1, 0, 1, 0], [1, 1, 0, 0]]))
     c.fill([1, 0], 0)
-    assert_array_equal(c.view(True), [[1, 1, 1, 0], [1, 2, 0, 0]])
+    assert c.view(True) == approx(np.array([[1, 1, 1, 0], [1, 2, 0, 0]]))
     c.fill(0, [-1, 0.5, 1.5, 2.5])
-    assert_array_equal(c.view(True), [[2, 2, 2, 1], [1, 2, 0, 0]])
+    assert c.view(True) == approx(np.array([[2, 2, 2, 1], [1, 2, 0, 0]]))
 
     with pytest.raises(IndexError):
         c[1]
@@ -1370,10 +1369,10 @@ def test_fill_with_sequence_2():
     a.fill("A")
     a.fill(np.array("B"))  # 0-dim array is also accepted
     a.fill(("A", "B", "C"))
-    assert_array_equal(a.view(True), [2, 2, 1])
+    assert a.view(True) == approx([2, 2, 1])
     a.fill(np.array(("D", "B", "A"), dtype="S5"))
     a.fill(np.array(("D", "B", "A"), dtype="U1"))
-    assert_array_equal(a.view(True), [4, 4, 3])
+    assert a.view(True) == approx([4, 4, 3])
 
     with pytest.raises(ValueError):
         a.fill(np.array((("B", "A"), ("C", "A"))))  # ndim == 2 not allowed
@@ -1383,7 +1382,7 @@ def test_fill_with_sequence_2():
         bh.axis.StrCategory(["A", "B"]),
     )
     b.fill((1, 0, 10), ("C", "B", "A"))
-    assert_array_equal(b.view(True), [[0, 1, 0], [0, 0, 1]])
+    assert b.view(True) == approx(np.array([[0, 1, 0], [0, 0, 1]]))
 
 
 def test_fill_with_sequence_3():
@@ -1394,7 +1393,7 @@ def test_fill_with_sequence_3():
     assert h.axes[0].size == 1
     h.fill(["A", "B"])
     assert h.axes[0].size == 2
-    assert_array_equal(h.view(True), [3, 1])
+    assert h.view(True) == approx([3, 1])
 
 
 def test_fill_with_sequence_4():
@@ -1404,7 +1403,7 @@ def test_fill_with_sequence_4():
     h.fill("1", np.arange(2))
     assert h.axes[0].size == 1
     assert h.axes[1].size == 2
-    assert_array_equal(h.view(True), [[1, 1]])
+    assert h.view(True) == approx(np.array([[1, 1]]))
 
     with pytest.raises(ValueError):
         h.fill(["1"], np.arange(2))  # lengths do not match
@@ -1489,7 +1488,7 @@ def test_hist_division():
 
     h1 /= h.axes[0].widths * h.sum()
 
-    assert_array_equal(h1.view(), dens)
+    assert h1.view() == approx(dens)
 
 
 def test_add_hists():
@@ -1508,10 +1507,10 @@ def test_add_hists():
     h3 = h.copy()
     h3 += 5
 
-    assert_array_equal(h, 1)
-    assert_array_equal(h1, 2)
-    assert_array_equal(h2, 3)
-    assert_array_equal(h3, 6)
+    assert np.asarray(h) == approx(1)
+    assert np.asarray(h1) == approx(2)
+    assert np.asarray(h2) == approx(3)
+    assert np.asarray(h3) == approx(6)
 
 
 def test_add_broadcast():
@@ -1561,7 +1560,7 @@ def test_reductions():
     widths_1 = functools.reduce(operator.mul, h.axes.widths)
     widths_2 = np.prod(h.axes.widths, axis=0)
 
-    assert_array_equal(widths_1, widths_2)
+    assert widths_1 == approx(widths_2)
 
 
 # Issue 435
@@ -1810,11 +1809,11 @@ def test_fill_noncontiguous_int_category():
 
     h = bh.Histogram(bh.axis.IntCategory(cat))
     h.fill(np.array([1, 2, 3, 1])[::-1])
-    assert_array_equal(h.view(flow=True), expected.view(flow=True))
+    assert h.view(flow=True) == approx(expected.view(flow=True))
 
     h2 = bh.Histogram(bh.axis.IntCategory(cat))
     h2.fill(np.array([1, 7, 3, 7, 2, 7, 1, 7])[::2])
-    assert_array_equal(h2.view(flow=True), expected.view(flow=True))
+    assert h2.view(flow=True) == approx(expected.view(flow=True))
 
 
 def test_fill_noncontiguous_str_category():
@@ -1825,11 +1824,11 @@ def test_fill_noncontiguous_str_category():
 
     h = bh.Histogram(bh.axis.StrCategory(cat))
     h.fill(np.array(["a", "b", "c", "b", "a"])[::2])
-    assert_array_equal(h.view(flow=True), expected.view(flow=True))
+    assert h.view(flow=True) == approx(expected.view(flow=True))
 
     expected2 = bh.Histogram(bh.axis.StrCategory(cat))
     expected2.fill(["c", "b", "a"])
 
     h2 = bh.Histogram(bh.axis.StrCategory(cat))
     h2.fill(np.array(["a", "b", "c"])[::-1])
-    assert_array_equal(h2.view(flow=True), expected2.view(flow=True))
+    assert h2.view(flow=True) == approx(expected2.view(flow=True))

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
 from pytest import approx
 
 import boost_histogram as bh
@@ -178,8 +177,8 @@ def test_mix_value_with_slice():
     assert h[1, 1, True] == 11
     assert h[3, 4, False] == 0
 
-    assert_array_equal(h[:, :, True].view(), vals[:, :, 0])
-    assert_array_equal(h[:, :, False].view(), 0)
+    assert h[:, :, True].view() == approx(vals[:, :, 0])
+    assert h[:, :, False].view() == approx(0)
 
 
 def test_mix_value_with_slice_2():
@@ -195,11 +194,11 @@ def test_mix_value_with_slice_2():
     assert h[1, 1, True] == 11
     assert h[3, 4, False] == 0
 
-    assert_array_equal(h[:, :, True].view(), vals)
-    assert_array_equal(h[:, :, False].view(), 0)
+    assert h[:, :, True].view() == approx(vals)
+    assert h[:, :, False].view() == approx(0)
 
     h2 = h[bh.rebin(2), bh.rebin(5), :]
-    assert_array_equal(h2.shape, (5, 2, 2))
+    assert h2.shape == approx((5, 2, 2))
 
 
 def test_one_sided_slice():
@@ -210,7 +209,7 @@ def test_one_sided_slice():
     assert h[bh.tag.at(-1) : bh.tag.at(5) : sum] == 6  # keeps underflow, keeps overflow
 
     # check that slicing without bh.sum adds removed counts to flow bins
-    assert_array_equal(h[1:3].view(True), [2, 1, 1, 2])
+    assert h[1:3].view(True) == approx([2, 1, 1, 2])
 
     assert h[0::sum] == 5  # removes underflow, keeps overflow
     assert h[:4:sum] == 5  # removes overflow, keeps underflow
@@ -260,8 +259,8 @@ def test_noflow_slicing():
     assert h[3, 4, False] == 0
     assert h[{0: 3, 1: 4, 2: False}] == 0
 
-    assert_array_equal(h[:, :, True].view(), vals)
-    assert_array_equal(h[:, :, False].view(), 0)
+    assert h[:, :, True].view() == approx(vals)
+    assert h[:, :, False].view() == approx(0)
 
 
 def test_singleflow_slicing():
@@ -277,9 +276,9 @@ def test_singleflow_slicing():
     assert h[1, 0] == 4
     assert h[1, 1] == 5
 
-    assert_array_equal(h[:, 1 : 3 : bh.sum], vals[:, 1:3].sum(axis=1))
-    assert_array_equal(h[{1: slice(1, 3, bh.sum)}], vals[:, 1:3].sum(axis=1))
-    assert_array_equal(h[1 : 3 : bh.sum, :], vals[1:3, :].sum(axis=0))
+    assert np.asarray(h[:, 1 : 3 : bh.sum]) == approx(vals[:, 1:3].sum(axis=1))
+    assert np.asarray(h[{1: slice(1, 3, bh.sum)}]) == approx(vals[:, 1:3].sum(axis=1))
+    assert np.asarray(h[1 : 3 : bh.sum, :]) == approx(vals[1:3, :].sum(axis=0))
 
 
 def test_set_range_with_scalar():
@@ -331,9 +330,9 @@ def test_pick_str_category():
     assert h[1, 1, bh.loc("on")] == 11
     assert h[3, 4, bh.loc("maybe")] == 0
 
-    assert_array_equal(h[:, :, bh.loc("on")].view(), vals)
-    assert_array_equal(h[{2: bh.loc("on")}].view(), vals)
-    assert_array_equal(h[:, :, bh.loc("off")].view(), 0)
+    assert h[:, :, bh.loc("on")].view() == approx(vals)
+    assert h[{2: bh.loc("on")}].view() == approx(vals)
+    assert h[:, :, bh.loc("off")].view() == approx(0)
 
 
 def test_string_requirement():
@@ -375,10 +374,10 @@ def test_pick_int_category():
     assert h[3, 4, bh.loc(7)] == 0
     assert h[3, 4, bh.loc(12)] == 134
 
-    assert_array_equal(h[:, :, bh.loc(3)].view(), vals)
-    assert_array_equal(h[{2: bh.loc(3)}].view(), vals)
-    assert_array_equal(h[:, :, bh.loc(5)].view(), vals + 1)
-    assert_array_equal(h[:, :, bh.loc(7)].view(), 0)
+    assert h[:, :, bh.loc(3)].view() == approx(vals)
+    assert h[{2: bh.loc(3)}].view() == approx(vals)
+    assert h[:, :, bh.loc(5)].view() == approx(vals + 1)
+    assert h[:, :, bh.loc(7)].view() == approx(0)
 
 
 @pytest.mark.parametrize(
@@ -413,7 +412,7 @@ def test_axes_tuple():
     (before,) = h.axes.centers[:1]
     (after,) = h.axes[:1].centers
 
-    assert_array_equal(before, after)
+    assert before == approx(after)
 
 
 def test_axes_tuple_Nd():
@@ -426,8 +425,8 @@ def test_axes_tuple_Nd():
     b1, b2 = h.axes.centers[1:3]
     a1, a2 = h.axes[1:3].centers
 
-    assert_array_equal(b1.flatten(), a1.flatten())
-    assert_array_equal(b2.flatten(), a2.flatten())
+    assert b1.flatten() == approx(a1.flatten())
+    assert b2.flatten() == approx(a2.flatten())
 
     assert b1.ndim == 3
     assert a1.ndim == 2
@@ -588,9 +587,9 @@ def test_setting_histogram_slice_not_at_start():
     h_first[:, :, 2, 2] = h_2D
 
     # Verify that the data was correctly set (use a non-flow slice comparison)
-    np.testing.assert_array_equal(h_first.view()[:, :, 2, 2], h_2D.view())
-    np.testing.assert_array_equal(h_middle.view()[2, :, :, 2], h_2D.view())
-    np.testing.assert_array_equal(h_last.view()[2, 2, :, :], h_2D.view())
+    assert h_first.view()[:, :, 2, 2] == approx(h_2D.view())
+    assert h_middle.view()[2, :, :, 2] == approx(h_2D.view())
+    assert h_last.view()[2, 2, :, :] == approx(h_2D.view())
 
 
 def test_rebin_groups_no_inplace_modification():
@@ -627,7 +626,7 @@ def test_rebin_group_mapping_factor():
     h = bh.Histogram(bh.axis.Regular(5, 0, 5))
     h.view(flow=True)[:] = [100, 1, 2, 3, 4, 5, 200]
     hs = h[:: bh.rebin(2)]
-    assert_array_equal(hs.view(flow=True), [100, 3, 7, 205])
+    assert hs.view(flow=True) == approx([100, 3, 7, 205])
 
 
 def test_rebin_factor_and_axis_raises():
@@ -651,13 +650,13 @@ def test_vectorized_get_basic():
     i2 = np.array([2, 4, 6])
 
     # Full gather (no slice) -> 1D array of values, like view() fancy indexing
-    assert_array_equal(h[i0, i1, i2], h.view()[i0, i1, i2])
+    assert h[i0, i1, i2] == approx(h.view()[i0, i1, i2])
 
     # Arrays plus a trailing slice keep the axis
-    assert_array_equal(h[i0, i1, :], h.view()[i0, i1, :])
+    assert h[i0, i1, :] == approx(h.view()[i0, i1, :])
 
     # Arrays plus an ellipsis expand the remaining axes
-    assert_array_equal(h[i0, i1, ...], h.view()[i0, i1, :])
+    assert h[i0, i1, ...] == approx(h.view()[i0, i1, :])
 
 
 def test_vectorized_get_mixed_scalar_and_loc():
@@ -670,8 +669,8 @@ def test_vectorized_get_mixed_scalar_and_loc():
 
     i1 = np.array([0, 2])
     # Scalar locator + array + slice mix
-    assert_array_equal(h[bh.loc("1"), i1, :], h.view()[1, i1, :])
-    assert_array_equal(h[2, i1, :], h.view()[2, i1, :])
+    assert h[bh.loc("1"), i1, :] == approx(h.view()[1, i1, :])
+    assert h[2, i1, :] == approx(h.view()[2, i1, :])
 
 
 def test_vectorized_get_flow_offset():
@@ -680,7 +679,7 @@ def test_vectorized_get_flow_offset():
     h.view(flow=True)[...] = np.arange(7.0)
 
     idx = np.array([0, 4])
-    assert_array_equal(h[idx], np.array([h[0], h[4]]))
+    assert h[idx] == approx(np.array([h[0], h[4]]))
 
 
 def test_vectorized_get_accumulator_storage():
@@ -690,8 +689,8 @@ def test_vectorized_get_accumulator_storage():
     idx = np.array([0, 1, 3])
     got = h[idx]
     assert isinstance(got, bh.view.WeightedSumView)
-    assert_array_equal(got.value, h.view()[idx].value)
-    assert_array_equal(got.variance, h.view()[idx].variance)
+    assert got.value == approx(h.view()[idx].value)
+    assert got.variance == approx(h.view()[idx].variance)
 
 
 def test_vectorized_get_multicell_storage():
@@ -705,7 +704,7 @@ def test_vectorized_get_multicell_storage():
     i0 = np.array([1, 2])
     i1 = np.array([0, 3])
     # The cell index stays the leading dimension of the result
-    assert_array_equal(h[i0, i1], h.view()[:, i0, i1])
+    assert h[i0, i1] == approx(h.view()[:, i0, i1])
 
 
 def test_vectorized_get_rejects_unsupported():

--- a/tests/test_histogram_set.py
+++ b/tests/test_histogram_set.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
+from pytest import approx
 
 import boost_histogram as bh
 
@@ -37,10 +37,10 @@ def test_1d_set_array():
     h = bh.Histogram(bh.axis.Regular(10, 0, 1))
 
     h[...] = np.arange(10)
-    assert_array_equal(h.view(), np.arange(10))
+    assert h.view() == approx(np.arange(10))
 
     h[...] = np.arange(12)
-    assert_array_equal(h.view(flow=True), np.arange(12))
+    assert h.view(flow=True) == approx(np.arange(12))
 
     with pytest.raises(ValueError):
         h[...] = np.arange(9)
@@ -50,17 +50,17 @@ def test_1d_set_array():
         h[...] = np.arange(13)
 
     h[...] = 1
-    assert_array_equal(h.view(), np.ones(10))
+    assert h.view() == approx(np.ones(10))
 
 
 def test_2d_set_array():
     h = bh.Histogram(bh.axis.Regular(10, 0, 1), bh.axis.Regular(10, 0, 1))
 
     h[...] = np.arange(10).reshape(-1, 1)
-    assert_array_equal(h.view()[:, 2], np.arange(10))
+    assert h.view()[:, 2] == approx(np.arange(10))
 
     h[...] = np.arange(12).reshape(-1, 1)
-    assert_array_equal(h.view(flow=True)[:, 3], np.arange(12))
+    assert h.view(flow=True)[:, 3] == approx(np.arange(12))
 
     with pytest.raises(ValueError):
         h[...] = np.arange(9).reshape(-1, 1)
@@ -70,7 +70,7 @@ def test_2d_set_array():
         h[...] = np.arange(13).reshape(-1, 1)
 
     h[...] = 1
-    assert_array_equal(h.view(), np.ones((10, 10)))
+    assert h.view() == approx(np.ones((10, 10)))
 
 
 def test_weighted_set_shortcut():
@@ -106,27 +106,27 @@ def test_set_special_dtype(storage, default):
 
     arr = np.full((10, 1), default)
     h[...] = arr
-    assert_array_equal(h.view()[:, 1:2], arr)
+    assert h.view()[:, 1:2] == approx(arr)
 
     arr = np.full((12, 1), default)
     h[...] = arr
-    assert_array_equal(h.view(flow=True)[:, 2:3], arr)
+    assert h.view(flow=True)[:, 2:3] == approx(arr)
 
     arr = np.full((10, 10), default)
     h[...] = arr
-    assert_array_equal(h.view(), arr)
+    assert h.view() == approx(arr)
 
     arr = np.full((10, 12), default)
     h[...] = arr
-    assert_array_equal(h.view(flow=True)[1:11, :], arr)
+    assert h.view(flow=True)[1:11, :] == approx(arr)
 
     arr = np.full((12, 10), default)
     h[...] = arr
-    assert_array_equal(h.view(flow=True)[:, 1:11], arr)
+    assert h.view(flow=True)[:, 1:11] == approx(arr)
 
     arr = np.full((12, 12), default)
     h[...] = arr
-    assert_array_equal(h.view(flow=True), arr)
+    assert h.view(flow=True) == approx(arr)
 
     arr = np.full((9, 1), default)
     with pytest.raises(ValueError):
@@ -170,7 +170,7 @@ def test_vectorized_set_basic():
     i1 = np.array([1, 3, 5])
 
     h[i0, i1, :] = 9.0
-    np.testing.assert_array_equal(h.view()[i0, i1, :], 9.0)
+    assert h.view()[i0, i1, :] == approx(9.0)
 
     # Untouched cells remain zero
     assert h.view()[1, 0, 0] == 0.0
@@ -178,7 +178,7 @@ def test_vectorized_set_basic():
     # Per-cell values, broadcasting over the trailing slice
     vals = np.arange(3 * 7).reshape(3, 7).astype(float)
     h[i0, i1, :] = vals
-    np.testing.assert_array_equal(h.view()[i0, i1, :], vals)
+    assert h.view()[i0, i1, :] == approx(vals)
 
 
 def test_vectorized_set_accumulator():
@@ -187,8 +187,8 @@ def test_vectorized_set_accumulator():
     idx = np.array([1, 3])
     # The View accepts a trailing (value, variance) dimension
     h[idx] = np.array([[10.0, 1.0], [20.0, 2.0]])
-    np.testing.assert_array_equal(h.view()[idx].value, [10.0, 20.0])
-    np.testing.assert_array_equal(h.view()[idx].variance, [1.0, 2.0])
+    assert h.view()[idx].value == approx([10.0, 20.0])
+    assert h.view()[idx].variance == approx([1.0, 2.0])
 
 
 def test_vectorized_set_multicell():
@@ -201,7 +201,7 @@ def test_vectorized_set_multicell():
     i0 = np.array([1, 2])
     i1 = np.array([0, 3])
     h[i0, i1] = 7.0
-    np.testing.assert_array_equal(h.view()[:, i0, i1], 7.0)
+    assert h.view()[:, i0, i1] == approx(7.0)
 
 
 def test_set_histogram_with_flow():
@@ -211,7 +211,7 @@ def test_set_histogram_with_flow():
     h2.view(flow=True)[:] = [100, 1, 2, 3, 200]
 
     h[:] = h2
-    assert_array_equal(h.view(flow=True), [100, 1, 2, 3, 200])
+    assert h.view(flow=True) == approx([100, 1, 2, 3, 200])
 
 
 def test_set_histogram_with_flow_2d():
@@ -220,7 +220,7 @@ def test_set_histogram_with_flow_2d():
     h2.view(flow=True)[...] = np.arange(16).reshape(4, 4)
 
     h[:, :] = h2
-    assert_array_equal(h.view(flow=True), np.arange(16).reshape(4, 4))
+    assert h.view(flow=True) == approx(np.arange(16).reshape(4, 4))
 
 
 def test_set_histogram_without_flow():
@@ -230,7 +230,7 @@ def test_set_histogram_without_flow():
     h3[:] = [1, 2, 3]
 
     h[0:3] = h3
-    assert_array_equal(h.view(flow=True), [0, 1, 2, 3, 0])
+    assert h.view(flow=True) == approx([0, 1, 2, 3, 0])
 
 
 def test_set_histogram_flow_mismatch():

--- a/tests/test_internal_histogram.py
+++ b/tests/test_internal_histogram.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose, assert_array_equal
 from pytest import approx
 
 import boost_histogram as bh
@@ -34,9 +33,9 @@ def test_1D_fill_int(storage):
 
     H = np.array([0, 1, 2, 0, 0, 0, 0, 0, 0, 0])
 
-    assert_array_equal(np.asarray(hist), H)
-    assert_array_equal(hist.view(flow=False), H)
-    assert_array_equal(hist.view(flow=True)[1:-1], H)
+    assert np.asarray(hist) == approx(H)
+    assert hist.view(flow=False) == approx(H)
+    assert hist.view(flow=True)[1:-1] == approx(H)
 
     assert hist.axes[0].size == bins
     assert hist.axes[0].extent == bins + 2
@@ -59,9 +58,9 @@ def test_2D_fill_int(storage):
 
     H = np.histogram2d(*vals, bins=bins, range=ranges)[0]
 
-    assert_array_equal(np.asarray(hist), H)
-    assert_array_equal(hist.view(flow=True)[1:-1, 1:-1], H)
-    assert_array_equal(hist.view(flow=False), H)
+    assert np.asarray(hist) == approx(H)
+    assert hist.view(flow=True)[1:-1, 1:-1] == approx(H)
+    assert hist.view(flow=False) == approx(H)
 
     assert hist.axes[0].size == bins[0]
     assert hist.axes[0].extent == bins[0] + 2
@@ -78,9 +77,9 @@ def test_edges_histogram():
     hist.fill(vals)
 
     bins = np.asarray(hist)
-    assert_array_equal(bins, [0, 2, 2])
-    assert_array_equal(hist.view(flow=True), [0, 0, 2, 2, 0])
-    assert_array_equal(hist.view(flow=False), [0, 2, 2])
+    assert bins == approx([0, 2, 2])
+    assert hist.view(flow=True) == approx([0, 0, 2, 2, 0])
+    assert hist.view(flow=False) == approx([0, 2, 2])
 
 
 def test_int_histogram():
@@ -90,9 +89,9 @@ def test_int_histogram():
     hist.fill(vals)
 
     bins = np.asarray(hist)
-    assert_array_equal(bins, [1, 1, 1, 1])
-    assert_array_equal(hist.view(flow=False), [1, 1, 1, 1])
-    assert_array_equal(hist.view(flow=True), [2, 1, 1, 1, 1, 3])
+    assert bins == approx([1, 1, 1, 1])
+    assert hist.view(flow=False) == approx([1, 1, 1, 1])
+    assert hist.view(flow=True) == approx([2, 1, 1, 1, 1, 3])
 
 
 def test_str_categories_histogram():
@@ -154,9 +153,9 @@ def test_numpy_dd():
     h2, x2, y2 = h.to_numpy()
     h1, (x1, y1) = h.to_numpy(dd=True)
 
-    assert_array_equal(h1, h2)
-    assert_array_equal(x1, x2)
-    assert_array_equal(y1, y2)
+    assert h1 == approx(h2)
+    assert x1 == approx(x2)
+    assert y1 == approx(y2)
 
 
 def test_numpy_weights():
@@ -173,16 +172,16 @@ def test_numpy_weights():
     h2, x2, y2 = h.to_numpy(view=False)
     h1, (x1, y1) = h.to_numpy(dd=True, view=False)
 
-    assert_array_equal(h1, h2)
-    assert_array_equal(x1, x2)
-    assert_array_equal(y1, y2)
+    assert h1 == approx(h2)
+    assert x1 == approx(x2)
+    assert y1 == approx(y2)
 
     h1, (x1, y1) = h.to_numpy(dd=True, view=False)
     h2, x2, y2 = h.to_numpy(view=True)
 
-    assert_array_equal(h1, h2.value)
-    assert_array_equal(x1, x2)
-    assert_array_equal(y1, y2)
+    assert h1 == approx(h2.value)
+    assert x1 == approx(x2)
+    assert y1 == approx(y2)
 
 
 def test_numpy_flow():
@@ -199,14 +198,14 @@ def test_numpy_flow():
     flow_true = h.to_numpy(True)[0][1:-1, 1:-1]
     flow_false = h.to_numpy(False)[0]
 
-    assert_array_equal(flow_true, flow_false)
+    assert flow_true == approx(flow_false)
 
     view_flow_true = h.view(flow=True)
     view_flow_false = h.view(flow=False)
     view_flow_default = h.view()
 
-    assert_array_equal(view_flow_true[1:-1, 1:-1], view_flow_false)
-    assert_array_equal(view_flow_default, view_flow_false)
+    assert view_flow_true[1:-1, 1:-1] == approx(view_flow_false)
+    assert view_flow_default == approx(view_flow_false)
 
 
 def test_numpy_compare():
@@ -229,9 +228,9 @@ def test_numpy_compare():
 
     nH, nE1, nE2 = np.histogram2d(xs, ys, bins=(10, 5), range=((0, 1), (0, 1)))
 
-    assert_array_equal(H, nH)
-    assert_allclose(E1, nE1)
-    assert_allclose(E2, nE2)
+    assert approx(nH) == H
+    assert approx(nE1) == E1
+    assert approx(nE2) == E2
 
 
 def test_project():
@@ -257,9 +256,9 @@ def test_project():
     assert h.project(0) == h0
     assert h.project(1) == h1
 
-    assert_array_equal(h.project(0, 1), h)
-    assert_array_equal(h.project(0), h0)
-    assert_array_equal(h.project(1), h1)
+    assert np.asarray(h.project(0, 1)) == approx(np.asarray(h))
+    assert np.asarray(h.project(0)) == approx(np.asarray(h0))
+    assert np.asarray(h.project(1)) == approx(np.asarray(h1))
 
 
 def test_sums():
@@ -277,7 +276,7 @@ def test_int_cat_hist():
     h.fill(2)
     h.fill(3)
 
-    assert_array_equal(h.view(), [1, 1, 1])
+    assert h.view() == approx([1, 1, 1])
     assert h.sum() == 3
 
     with pytest.raises(TypeError):
@@ -432,7 +431,7 @@ def test_to_numpy_edges_match_cpp_helper(axis, flow):
     assert len(cpp_edges) == len(py_edges) == 2
     for cpp_e, py_e in zip(cpp_edges, py_edges, strict=True):
         assert cpp_e.dtype == py_e.dtype
-        assert_array_equal(cpp_e, py_e)
+        assert cpp_e == approx(py_e)
 
 
 @pytest.mark.parametrize("flow", [False, True])
@@ -445,4 +444,4 @@ def test_to_numpy_edges_match_cpp_helper_numpy_axis(flow):
 
     assert len(cpp_edges) == len(py_edges) == 1
     assert cpp_edges[0].dtype == py_edges[0].dtype
-    assert_array_equal(cpp_edges[0], py_edges[0])
+    assert cpp_edges[0] == approx(py_edges[0])

--- a/tests/test_numpy_interface.py
+++ b/tests/test_numpy_interface.py
@@ -208,7 +208,7 @@ def test_histogram_does_not_mutate_input_edges():
 
     bh.numpy.histogram([0.5, 1.5], bins=edges)
 
-    np.testing.assert_array_equal(edges, original)
+    assert edges == approx(original)
 
 
 def test_histogramdd_does_not_mutate_input_edges():
@@ -221,8 +221,8 @@ def test_histogramdd_does_not_mutate_input_edges():
 
     bh.numpy.histogramdd((x, y), bins=(edges_x, edges_y))
 
-    np.testing.assert_array_equal(edges_x, original_x)
-    np.testing.assert_array_equal(edges_y, original_y)
+    assert edges_x == approx(original_x)
+    assert edges_y == approx(original_y)
 
 
 @pytest.mark.parametrize("bad_bins", [(2,), (2, 2, 2), (2, 2, 2, 2)])

--- a/tests/test_plottable_protocol.py
+++ b/tests/test_plottable_protocol.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
-from numpy.testing import assert_allclose
+from pytest import approx
 
 import boost_histogram as bh
 
@@ -16,9 +16,9 @@ def test_plottable_histogram_mean_int():
 
     h[...] = np.stack([COUNTS, VALUES, VARIANCES]).T
 
-    assert_allclose(COUNTS, h.counts())
-    assert_allclose(VALUES, h.values())
-    assert_allclose(VARIANCES / COUNTS, h.variances())
+    assert approx(h.counts()) == COUNTS
+    assert approx(h.values()) == VALUES
+    assert approx(h.variances()) == VARIANCES / COUNTS
 
     assert h.kind == bh.Kind.MEAN
     assert h.kind == "MEAN"
@@ -40,9 +40,9 @@ def test_plottible_histogram_weight_reg():
 
     h[...] = np.stack([VALUES, VARIANCES]).T
 
-    assert_allclose(VALUES, h.counts())
-    assert_allclose(VALUES, h.values())
-    assert_allclose(VARIANCES, h.variances())
+    assert approx(h.counts()) == VALUES
+    assert approx(h.values()) == VALUES
+    assert approx(h.variances()) == VARIANCES
 
     assert h.kind == bh.Kind.COUNT
     assert h.kind == "COUNT"
@@ -50,10 +50,10 @@ def test_plottible_histogram_weight_reg():
     assert len(h.axes) == 1
     assert h.axes[0] == h.axes[0]
 
-    assert_allclose(h.axes[0][0], (0, 1))
-    assert_allclose(h.axes[0][1], (1, 2))
-    assert_allclose(h.axes[0][2], (2, 3))
-    assert_allclose(h.axes[0][3], (3, 4))
+    assert h.axes[0][0] == approx((0, 1))
+    assert h.axes[0][1] == approx((1, 2))
+    assert h.axes[0][2] == approx((2, 3))
+    assert h.axes[0][3] == approx((3, 4))
 
     assert not h.axes[0].traits.discrete
     assert not h.axes[0].traits.circular
@@ -68,9 +68,9 @@ def test_plottible_histogram_simple_var():
     # are doing. At least if you change it inplace.
     h.view()[...] = VALUES
 
-    assert_allclose(VALUES, h.counts())
-    assert_allclose(VALUES, h.values())
-    assert_allclose(VALUES, h.variances())
+    assert approx(h.counts()) == VALUES
+    assert approx(h.values()) == VALUES
+    assert approx(h.variances()) == VALUES
 
     assert h.kind == bh.Kind.COUNT
     assert h.kind == "COUNT"
@@ -78,18 +78,18 @@ def test_plottible_histogram_simple_var():
     assert len(h.axes) == 1
     assert h.axes[0] == h.axes[0]
 
-    assert_allclose(h.axes[0][0], (0, 1))
-    assert_allclose(h.axes[0][1], (1, 2))
-    assert_allclose(h.axes[0][2], (2, 3))
-    assert_allclose(h.axes[0][3], (3, 4))
+    assert h.axes[0][0] == approx((0, 1))
+    assert h.axes[0][1] == approx((1, 2))
+    assert h.axes[0][2] == approx((2, 3))
+    assert h.axes[0][3] == approx((3, 4))
 
     assert not h.axes[0].traits.discrete
     assert not h.axes[0].traits.circular
 
     h.fill([1], weight=0)
 
-    assert_allclose(VALUES, h.counts())
-    assert_allclose(VALUES, h.values())
+    assert approx(h.counts()) == VALUES
+    assert approx(h.values()) == VALUES
     assert h.variances() is None
 
 
@@ -99,16 +99,16 @@ def test_plottible_histogram_simple_var_invalidate_inplace():
 
     h2 = h * 1
 
-    assert_allclose(VALUES, h.counts())
-    assert_allclose(VALUES, h.values())
-    assert_allclose(VALUES, h.variances())
+    assert approx(h.counts()) == VALUES
+    assert approx(h.values()) == VALUES
+    assert approx(h.variances()) == VALUES
 
-    assert_allclose(VALUES, h2.counts())
-    assert_allclose(VALUES, h2.values())
+    assert approx(h2.counts()) == VALUES
+    assert approx(h2.values()) == VALUES
     assert h2.variances() is None
 
     h *= 1
 
-    assert_allclose(VALUES, h.counts())
-    assert_allclose(VALUES, h.values())
+    assert approx(h.counts()) == VALUES
+    assert approx(h.values()) == VALUES
     assert h.variances() is None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -5,7 +5,6 @@ import operator
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
 from pytest import approx
 
 import boost_histogram as bh
@@ -26,7 +25,7 @@ def test_setting(storage):
     assert h[1] == 3
     assert h[9] == 5
 
-    assert_array_equal(h.view(), [2, 3, 0, 0, 0, 0, 0, 0, 0, 5])
+    assert h.view() == approx([2, 3, 0, 0, 0, 0, 0, 0, 0, 5])
 
 
 def test_setting_weight():
@@ -65,8 +64,8 @@ def test_setting_weight():
     assert b["value"][0] == a["value"][0]
     assert b["variance"][0] == a["variance"][0]
 
-    assert_array_equal(a.view().value, b.view()["value"])
-    assert_array_equal(a.view().variance, b.view()["variance"])
+    assert a.view().value == approx(b.view()["value"])
+    assert a.view().variance == approx(b.view()["variance"])
 
 
 def test_sum_weight():
@@ -81,7 +80,8 @@ def test_sum_weight():
     v2 = v + v
     h2 = h + h
 
-    assert_array_equal(h2.view(), v2)
+    assert h2.view().value == approx(v2.value)
+    assert h2.view().variance == approx(v2.variance)
 
 
 def test_setting_profile():
@@ -124,11 +124,9 @@ def test_setting_profile():
     assert b[0]["count"] == a["count"][0]
     assert b[0]["_sum_of_deltas_squared"] == a["_sum_of_deltas_squared"][0]
 
-    assert_array_equal(a.view().value, b.view()["value"])
-    assert_array_equal(a.view().count, b.view()["count"])
-    assert_array_equal(
-        a.view()._sum_of_deltas_squared, b.view()["_sum_of_deltas_squared"]
-    )
+    assert a.view().value == approx(b.view()["value"])
+    assert a.view().count == approx(b.view()["count"])
+    assert a.view()._sum_of_deltas_squared == approx(b.view()["_sum_of_deltas_squared"])
 
 
 def test_mean_storage_rejects_string_sample():
@@ -208,14 +206,11 @@ def test_setting_weighted_profile():
         == a["_sum_of_weighted_deltas_squared"][0]
     )
 
-    assert_array_equal(a.view().value, b.view()["value"])
-    assert_array_equal(a.view().sum_of_weights, b.view()["sum_of_weights"])
-    assert_array_equal(
-        a.view().sum_of_weights_squared, b.view()["sum_of_weights_squared"]
-    )
-    assert_array_equal(
-        a.view()._sum_of_weighted_deltas_squared,
-        b.view()["_sum_of_weighted_deltas_squared"],
+    assert a.view().value == approx(b.view()["value"])
+    assert a.view().sum_of_weights == approx(b.view()["sum_of_weights"])
+    assert a.view().sum_of_weights_squared == approx(b.view()["sum_of_weights_squared"])
+    assert a.view()._sum_of_weighted_deltas_squared == approx(
+        b.view()["_sum_of_weighted_deltas_squared"]
     )
 
 
@@ -326,20 +321,19 @@ def test_non_uniform_rebin_with_weights():
     )
 
     hs = h[{0: slice(None, None, bh.rebin(4))}]
-    assert_array_equal(hs.view(), rslt)
+    assert hs.view() == approx(rslt)
 
     hs = h[{0: bh.rebin(4)}]
-    assert_array_equal(hs.view(), rslt)
+    assert hs.view() == approx(rslt)
 
     hs = h[{0: bh.rebin(groups=[1, 2, 3, 14])}]
-    assert_array_equal(
-        hs.view(),
+    assert hs.view() == approx(
         np.array(
             [(1.0, 1.0), (0.0, 0.0), (0.0, 0.0), (3.0, 3.0)],
             dtype=[("value", "<f8"), ("variance", "<f8")],
-        ),
+        )
     )
-    assert_array_equal(hs.axes.edges[0], [1.0, 1.2, 1.6, 2.2, 5.0])
+    assert hs.axes.edges[0] == approx([1.0, 1.2, 1.6, 2.2, 5.0])
 
     # nD
     h = bh.Histogram(
@@ -420,34 +414,34 @@ def test_multi_cell_arithmetic(nelem):
     base = h.view().copy()
 
     # Histogram + Histogram (and the in-place form)
-    assert_array_equal((h + h).view(), base * 2)
+    assert (h + h).view() == approx(base * 2)
 
     h_iadd = _filled_multi_cell(nelem)
     h_iadd += h
-    assert_array_equal(h_iadd.view(), base * 2)
+    assert h_iadd.view() == approx(base * 2)
 
     # Histogram - Histogram (element-wise on the cells), including the in-place
     # form and a result with negative cells
-    assert_array_equal((h - h).view(), base * 0)
-    assert_array_equal((h + h - h).view(), base)
-    assert_array_equal((h - h - h).view(), -base)
+    assert (h - h).view() == approx(base * 0)
+    assert (h + h - h).view() == approx(base)
+    assert (h - h - h).view() == approx(-base)
 
     h_isub = _filled_multi_cell(nelem)
     h_isub -= h
-    assert_array_equal(h_isub.view(), base * 0)
+    assert h_isub.view() == approx(base * 0)
 
     # Scalar multiplication / division (both orders and in-place)
-    assert_array_equal((h * 2).view(), base * 2)
-    assert_array_equal((2 * h).view(), base * 2)
-    assert_array_equal((h / 2).view(), base / 2)
+    assert (h * 2).view() == approx(base * 2)
+    assert (2 * h).view() == approx(base * 2)
+    assert (h / 2).view() == approx(base / 2)
 
     h_imul = _filled_multi_cell(nelem)
     h_imul *= 2
-    assert_array_equal(h_imul.view(), base * 2)
+    assert h_imul.view() == approx(base * 2)
 
     h_idiv = _filled_multi_cell(nelem)
     h_idiv /= 2
-    assert_array_equal(h_idiv.view(), base / 2)
+    assert h_idiv.view() == approx(base / 2)
 
 
 @pytest.mark.parametrize("nelem", [1, 3])
@@ -507,8 +501,10 @@ def test_multi_cell_rebin_groups():
 
     hs = h[bh.rebin(groups=[2, 2])]
     assert hs.storage.nelem == 2
-    assert_array_equal(hs.view(), [[3, 7], [30, 70]])
-    assert_array_equal(hs.view(flow=True), [[100, 3, 7, 200], [1000, 30, 70, 2000]])
+    assert hs.view() == approx(np.array([[3, 7], [30, 70]]))
+    assert hs.view(flow=True) == approx(
+        np.array([[100, 3, 7, 200], [1000, 30, 70, 2000]])
+    )
 
 
 def test_multi_cell_rebin_groups_2d():
@@ -527,9 +523,9 @@ def test_multi_cell_rebin_groups_2d():
 
     hs = h[:, bh.rebin(groups=[2, 2])]
     assert hs.storage.nelem == 2
-    assert_array_equal(hs.view(), [[[3, 7], [5, 0]], [[30, 70], [50, 0]]])
+    assert hs.view() == approx(np.array([[[3, 7], [5, 0]], [[30, 70], [50, 0]]]))
     # The first axis is untouched
-    assert_array_equal(hs.view().sum(axis=(1, 2)), h.view().sum(axis=(1, 2)))
+    assert hs.view().sum(axis=(1, 2)) == approx(h.view().sum(axis=(1, 2)))
 
 
 @pytest.mark.parametrize("nelem", [1, 3])
@@ -537,8 +533,8 @@ def test_multi_cell_reset(nelem):
     h = _filled_multi_cell(nelem)
     assert h.view().sum() != 0
     h.reset()
-    assert_array_equal(h.view(), np.zeros_like(h.view()))
-    assert_array_equal(h.view(flow=True), np.zeros_like(h.view(flow=True)))
+    assert h.view() == approx(np.zeros_like(h.view()))
+    assert h.view(flow=True) == approx(np.zeros_like(h.view(flow=True)))
 
 
 # Issue #1129
@@ -577,8 +573,8 @@ def test_multi_cell():
 
     # Filling 1-Dim
     h.fill(x, weight=weights)
-    assert_array_equal(h[1], [1, 2, 3])
-    assert_array_equal(h[2], [4, 5, 6])
+    assert h[1] == approx([1, 2, 3])
+    assert h[2] == approx([4, 5, 6])
 
     h = bh.Histogram(
         bh.axis.Regular(5, 0, 5),
@@ -588,8 +584,8 @@ def test_multi_cell():
 
     # Filling 2-Dim
     h.fill(x, y, weight=weights)
-    assert_array_equal(h[1, 0], [1, 2, 3])
-    assert_array_equal(h[2, 1], [4, 5, 6])
+    assert h[1, 0] == approx([1, 2, 3])
+    assert h[2, 1] == approx([4, 5, 6])
 
     # View and values
 
@@ -635,47 +631,47 @@ def test_multi_cell():
 
     expected_view = expected_view_with_flow[:, 1:-1, 1:-1]
 
-    assert_array_equal(h.view(), expected_view)
-    assert_array_equal(h.view(flow=True), expected_view_with_flow)
+    assert h.view() == approx(expected_view)
+    assert h.view(flow=True) == approx(expected_view_with_flow)
 
-    assert_array_equal(h.values(), expected_view)
-    assert_array_equal(h.values(flow=True), expected_view_with_flow)
+    assert h.values() == approx(expected_view)
+    assert h.values(flow=True) == approx(expected_view_with_flow)
 
     # Modify view
     expected_view[0, 1, 0] = 10
     expected_view_with_flow[0, 2, 1] = 10
     h.view()[0, 1, 0] = 10
 
-    assert_array_equal(h.view(), expected_view)
-    assert_array_equal(h.view(flow=True), expected_view_with_flow)
+    assert h.view() == approx(expected_view)
+    assert h.view(flow=True) == approx(expected_view_with_flow)
 
-    assert_array_equal(h.values(), expected_view)
-    assert_array_equal(h.values(flow=True), expected_view_with_flow)
+    assert h.values() == approx(expected_view)
+    assert h.values(flow=True) == approx(expected_view_with_flow)
 
     # Slice histogram
     ## via reduce() (only use real slices)
-    assert_array_equal(h[1:3, 1:3].view(), expected_view[:, 1:3, 1:3])
+    assert h[1:3, 1:3].view() == approx(expected_view[:, 1:3, 1:3])
 
     ## Without reduce() (only slices and single elements)
-    assert_array_equal(h[2, 1:3].view(), expected_view[:, 2, 1:3])
+    assert h[2, 1:3].view() == approx(expected_view[:, 2, 1:3])
 
     # Project histogram
-    assert_array_equal(
-        h.project(1).view(), np.sum(expected_view_with_flow, axis=1)[:, 1:-1]
+    assert h.project(1).view() == approx(
+        np.sum(expected_view_with_flow, axis=1)[:, 1:-1]
     )
-    assert_array_equal(
-        h.project(0).view(), np.sum(expected_view_with_flow, axis=2)[:, 1:-1]
+    assert h.project(0).view() == approx(
+        np.sum(expected_view_with_flow, axis=2)[:, 1:-1]
     )
 
     # Sum histogram
-    assert_array_equal(h.sum(), np.sum(expected_view, axis=(1, 2)))
-    assert_array_equal(h.sum(flow=True), np.sum(expected_view_with_flow, axis=(1, 2)))
+    assert h.sum() == approx(np.sum(expected_view, axis=(1, 2)))
+    assert h.sum(flow=True) == approx(np.sum(expected_view_with_flow, axis=(1, 2)))
 
     # __setitem__ for histogram
     sub_array_to_set = np.array([[20, 30], [21, 31], [22, 32]])
     expected_view[:, 2:4, 1] = sub_array_to_set
     h[2:4, 1] = sub_array_to_set
-    assert_array_equal(h.view(), expected_view)
+    assert h.view() == approx(expected_view)
 
     sub_array_to_set = np.array(
         [
@@ -686,4 +682,4 @@ def test_multi_cell():
     )
     expected_view[:, 2:4, 0:3] = sub_array_to_set
     h[2:4, 0:3] = sub_array_to_set
-    assert_array_equal(h.view(), expected_view)
+    assert h.view() == approx(expected_view)

--- a/tests/test_threaded_fill.py
+++ b/tests/test_threaded_fill.py
@@ -4,7 +4,7 @@ import sys
 
 import numpy as np
 import pytest
-from numpy.testing import assert_almost_equal, assert_array_equal
+from pytest import approx
 
 import boost_histogram as bh
 
@@ -31,7 +31,7 @@ def test_threads(benchmark, threads, storage):
     hist_linear.fill(vals)
     hist_result = benchmark(fillit, hist_atomic, vals, threads=threads)
 
-    assert_array_equal(hist_linear, hist_result)
+    assert np.asarray(hist_linear) == approx(np.asarray(hist_result))
 
 
 @pytest.mark.parametrize("threads", [1, 4, 7], ids=lambda x: f"threads={x}")
@@ -48,7 +48,7 @@ def test_threaded_builtin(threads, storage):
     hist_atomic1.fill(vals)
     hist_atomic2.fill(vals, threads=threads)
 
-    assert_array_equal(hist_atomic1, hist_atomic2)
+    assert np.asarray(hist_atomic1) == approx(np.asarray(hist_atomic2))
 
 
 @pytest.mark.parametrize("threads", [1, 4, 7], ids=lambda x: f"threads={x}")
@@ -58,7 +58,7 @@ def test_threaded_numpy(threads):
     hist_1, _ = bh.numpy.histogram(vals)
     hist_2, _ = bh.numpy.histogram(vals, threads=threads)
 
-    assert_array_equal(hist_1, hist_2)
+    assert np.asarray(hist_1) == approx(np.asarray(hist_2))
 
 
 @pytest.mark.parametrize("threads", [1, 4, 7], ids=lambda x: f"threads={x}")
@@ -71,7 +71,7 @@ def test_threaded_weights(threads):
     hist_1.fill(x, y, weight=weights)
     hist_2.fill(x, y, weight=weights, threads=threads)
 
-    assert_almost_equal(hist_1.view(), hist_2.view())
+    assert hist_1.view() == approx(hist_2.view())
 
 
 @pytest.mark.parametrize("threads", [1, 4, 7], ids=lambda x: f"threads={x}")
@@ -88,8 +88,8 @@ def test_threaded_weight_storage(threads):
     hist_1.fill(x, y, weight=weights)
     hist_2.fill(x, y, weight=weights, threads=threads)
 
-    assert_almost_equal(hist_1.view().value, hist_2.view().value)
-    assert_almost_equal(hist_1.view().variance, hist_2.view().variance)
+    assert hist_1.view().value == approx(hist_2.view().value)
+    assert hist_1.view().variance == approx(hist_2.view().variance)
 
 
 @pytest.mark.parametrize("threads", [2, 4, 7], ids=lambda x: f"threads={x}")
@@ -102,7 +102,7 @@ def test_threaded_scalar_broadcast(threads):
     hist_1.fill(0.5, y)
     hist_2.fill(0.5, y, threads=threads)
 
-    assert_array_equal(hist_1.view(flow=True), hist_2.view(flow=True))
+    assert hist_1.view(flow=True) == approx(hist_2.view(flow=True))
 
 
 @pytest.mark.parametrize("threads", [2, 4, 7], ids=lambda x: f"threads={x}")
@@ -116,8 +116,8 @@ def test_threaded_scalar_weight(threads):
     hist_1.fill(x, weight=np.array(2.0))
     hist_2.fill(x, weight=np.array(2.0), threads=threads)
 
-    assert_almost_equal(hist_1.view().value, hist_2.view().value)
-    assert_almost_equal(hist_1.view().variance, hist_2.view().variance)
+    assert hist_1.view().value == approx(hist_2.view().value)
+    assert hist_1.view().variance == approx(hist_2.view().variance)
 
 
 @pytest.mark.parametrize("threads", [2, 4])

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 from pytest import approx
 
 import boost_histogram as bh
@@ -16,36 +15,36 @@ def v():
 
 
 def test_basic_view(v):
-    assert_allclose(v.value, [0, 3, 2, 1])
-    assert_allclose(v.variance, [0, 3, 2, 1])
+    assert v.value == approx([0, 3, 2, 1])
+    assert v.variance == approx([0, 3, 2, 1])
 
 
 def test_view_mul(v):
     v2 = v * 2
-    assert_allclose(v2.value, [0, 6, 4, 2])
-    assert_allclose(v2.variance, [0, 12, 8, 4])
+    assert v2.value == approx([0, 6, 4, 2])
+    assert v2.variance == approx([0, 12, 8, 4])
 
     v2 = 2 * v
-    assert_allclose(v2.value, [0, 6, 4, 2])
-    assert_allclose(v2.variance, [0, 12, 8, 4])
+    assert v2.value == approx([0, 6, 4, 2])
+    assert v2.variance == approx([0, 12, 8, 4])
 
     v2 = v * (-2)
-    assert_allclose(v2.value, [0, -6, -4, -2])
-    assert_allclose(v2.variance, [0, 12, 8, 4])
+    assert v2.value == approx([0, -6, -4, -2])
+    assert v2.variance == approx([0, 12, 8, 4])
 
     v *= 2
-    assert_allclose(v.value, [0, 6, 4, 2])
-    assert_allclose(v.variance, [0, 12, 8, 4])
+    assert v.value == approx([0, 6, 4, 2])
+    assert v.variance == approx([0, 12, 8, 4])
 
 
 def test_view_div(v):
     v2 = v / 2
-    assert_allclose(v2.value, [0, 1.5, 1, 0.5])
-    assert_allclose(v2.variance, [0, 0.75, 0.5, 0.25])
+    assert v2.value == approx([0, 1.5, 1, 0.5])
+    assert v2.variance == approx([0, 0.75, 0.5, 0.25])
 
     v2 = v / (-0.5)
-    assert_allclose(v2.value, [0, -6, -4, -2])
-    assert_allclose(v2.variance, [0, 12, 8, 4])
+    assert v2.value == approx([0, -6, -4, -2])
+    assert v2.variance == approx([0, 12, 8, 4])
 
     # Issue #1143 (B11): the reciprocal of a weighted sum has no meaningful
     # variance, so dividing by a view is rejected.
@@ -53,79 +52,79 @@ def test_view_div(v):
         1 / v[1:]
 
     v /= 0.5
-    assert_allclose(v.value, [0, 6, 4, 2])
-    assert_allclose(v.variance, [0, 12, 8, 4])
+    assert v.value == approx([0, 6, 4, 2])
+    assert v.variance == approx([0, 12, 8, 4])
 
 
 def test_view_add(v):
     v2 = v + 1
-    assert_allclose(v2.value, [1, 4, 3, 2])
-    assert_allclose(v2.variance, [1, 4, 3, 2])
+    assert v2.value == approx([1, 4, 3, 2])
+    assert v2.variance == approx([1, 4, 3, 2])
 
     v2 = v + 2
-    assert_allclose(v2.value, [2, 5, 4, 3])
-    assert_allclose(v2.variance, [4, 7, 6, 5])
+    assert v2.value == approx([2, 5, 4, 3])
+    assert v2.variance == approx([4, 7, 6, 5])
 
     v2 = 2 + v
-    assert_allclose(v2.value, [2, 5, 4, 3])
-    assert_allclose(v2.variance, [4, 7, 6, 5])
+    assert v2.value == approx([2, 5, 4, 3])
+    assert v2.variance == approx([4, 7, 6, 5])
 
     v2 = v.copy()
     v2 += 2
-    assert_allclose(v2.value, [2, 5, 4, 3])
-    assert_allclose(v2.variance, [4, 7, 6, 5])
+    assert v2.value == approx([2, 5, 4, 3])
+    assert v2.variance == approx([4, 7, 6, 5])
 
     v2 = v + v
-    assert_allclose(v2.value, v.value * 2)
-    assert_allclose(v2.variance, v.variance * 2)
+    assert v2.value == approx(v.value * 2)
+    assert v2.variance == approx(v.variance * 2)
 
 
 def test_view_sub(v):
     v2 = v - 1
-    assert_allclose(v2.value, [-1, 2, 1, 0])
-    assert_allclose(v2.variance, [1, 4, 3, 2])
+    assert v2.value == approx([-1, 2, 1, 0])
+    assert v2.variance == approx([1, 4, 3, 2])
 
     v2 = v - 2
-    assert_allclose(v2.value, [-2, 1, 0, -1])
-    assert_allclose(v2.variance, [4, 7, 6, 5])
+    assert v2.value == approx([-2, 1, 0, -1])
+    assert v2.variance == approx([4, 7, 6, 5])
 
     v2 = 1 - v
-    assert_allclose(v2.value, [1, -2, -1, 0])
-    assert_allclose(v2.variance, [1, 4, 3, 2])
+    assert v2.value == approx([1, -2, -1, 0])
+    assert v2.variance == approx([1, 4, 3, 2])
 
     v2 = v.copy()
     v2 -= 2
-    assert_allclose(v2.value, [-2, 1, 0, -1])
-    assert_allclose(v2.variance, [4, 7, 6, 5])
+    assert v2.value == approx([-2, 1, 0, -1])
+    assert v2.variance == approx([4, 7, 6, 5])
 
     v2 = v - v
-    assert_allclose(v2.value, [0, 0, 0, 0])
-    assert_allclose(v2.variance, v.variance * 2)
+    assert v2.value == approx([0, 0, 0, 0])
+    assert v2.variance == approx(v.variance * 2)
 
 
 def test_view_unary(v):
     v2 = +v
-    assert_allclose(v.value, v2.value)
-    assert_allclose(v.variance, v2.variance)
+    assert v.value == approx(v2.value)
+    assert v.variance == approx(v2.variance)
 
     v2 = -v
-    assert_allclose(-v.value, v2.value)
-    assert_allclose(v.variance, v2.variance)
+    assert -v.value == approx(v2.value)
+    assert v.variance == approx(v2.variance)
 
 
 def test_view_add_same(v):
     v2 = v + v
 
-    assert_allclose(v.value * 2, v2.value)
-    assert_allclose(v.variance * 2, v2.variance)
+    assert v.value * 2 == approx(v2.value)
+    assert v.variance * 2 == approx(v2.variance)
 
     v2 = v + v[1]
-    assert_allclose(v.value + 3, v2.value)
-    assert_allclose(v.variance + 3, v2.variance)
+    assert v.value + 3 == approx(v2.value)
+    assert v.variance + 3 == approx(v2.variance)
 
     v2 = v + bh.accumulators.WeightedSum(5, 6)
-    assert_allclose(v.value + 5, v2.value)
-    assert_allclose(v.variance + 6, v2.variance)
+    assert v.value + 5 == approx(v2.value)
+    assert v.variance + 6 == approx(v2.variance)
 
     with pytest.raises(TypeError):
         v2 = v + bh.accumulators.WeightedMean(1, 2, 5, 6)
@@ -134,8 +133,8 @@ def test_view_add_same(v):
 def test_view_assign(v):
     v[...] = [[4, 1], [5, 2], [6, 1], [7, 2]]
 
-    assert_allclose(v.value, [4, 5, 6, 7])
-    assert_allclose(v.variance, [1, 2, 1, 2])
+    assert v.value == approx([4, 5, 6, 7])
+    assert v.variance == approx([1, 2, 1, 2])
 
 
 def test_view_assign_mean():
@@ -143,9 +142,9 @@ def test_view_assign_mean():
     m = h.copy().view()
 
     h[...] = [[10, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
-    assert_allclose(h.view().count, [10, 4, 7, 10])
-    assert_allclose(h.view().value, [2, 5, 8, 11])
-    assert_allclose(h.view().variance, [3, 6, 9, 12])
+    assert h.view().count == approx([10, 4, 7, 10])
+    assert h.view().value == approx([2, 5, 8, 11])
+    assert h.view().variance == approx([3, 6, 9, 12])
 
     # Make sure this really was a copy
     assert m.count[0] != 10
@@ -153,9 +152,9 @@ def test_view_assign_mean():
     # Assign directly on view
     m[...] = [[10, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
 
-    assert_allclose(m.count, [10, 4, 7, 10])
-    assert_allclose(m.value, [2, 5, 8, 11])
-    assert_allclose(m.variance, [3, 6, 9, 12])
+    assert m.count == approx([10, 4, 7, 10])
+    assert m.value == approx([2, 5, 8, 11])
+    assert m.variance == approx([3, 6, 9, 12])
     # Note: if counts <= 1, variance is undefined
 
 
@@ -166,10 +165,10 @@ def test_view_assign_wmean():
 
     h[...] = [[10, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]
 
-    assert_allclose(h.view().sum_of_weights, [10, 5, 9, 13])
-    assert_allclose(h.view().sum_of_weights_squared, [2, 6, 10, 14])
-    assert_allclose(h.view().value, [3, 7, 11, 15])
-    assert_allclose(h.view().variance, [4, 8, 12, 16])
+    assert h.view().sum_of_weights == approx([10, 5, 9, 13])
+    assert h.view().sum_of_weights_squared == approx([2, 6, 10, 14])
+    assert h.view().value == approx([3, 7, 11, 15])
+    assert h.view().variance == approx([4, 8, 12, 16])
 
     # Make sure this really was a copy
     assert w.sum_of_weights[0] != 10
@@ -177,10 +176,10 @@ def test_view_assign_wmean():
     # Assign directly on view
     w[...] = [[10, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]
 
-    assert_allclose(w.sum_of_weights, [10, 5, 9, 13])
-    assert_allclose(w.sum_of_weights_squared, [2, 6, 10, 14])
-    assert_allclose(w.value, [3, 7, 11, 15])
-    assert_allclose(w.variance, [4, 8, 12, 16])
+    assert w.sum_of_weights == approx([10, 5, 9, 13])
+    assert w.sum_of_weights_squared == approx([2, 6, 10, 14])
+    assert w.value == approx([3, 7, 11, 15])
+    assert w.variance == approx([4, 8, 12, 16])
     # Note: if sum_of_weights <= 1, variance is undefined
 
     w[0] = [9, 1, 2, 3]
@@ -254,8 +253,8 @@ def test_view_rdiv_rejected(v):
         np.ones(4) / v
 
     # Scaling in the other direction must keep working.
-    assert_allclose((v / 2).value, v.value / 2)
-    assert_allclose((2 * v).value, v.value * 2)
+    assert (v / 2).value == approx(v.value / 2)
+    assert (2 * v).value == approx(v.value * 2)
 
 
 # Issue #1143 (B2): a caller-supplied ``out=`` used to be forwarded into the
@@ -271,8 +270,8 @@ def test_view_reduce_out_matching_dtype(v2d):
 
     assert np.shares_memory(result, out)
     assert isinstance(result, type(v2d))
-    assert_allclose(out["value"], np.sum(v2d["value"], axis=0))
-    assert_allclose(out["variance"], np.sum(v2d["variance"], axis=0))
+    assert out["value"] == approx(np.sum(v2d["value"], axis=0))
+    assert out["variance"] == approx(np.sum(v2d["variance"], axis=0))
 
 
 def test_view_reduce_out_full(v2d):
@@ -286,8 +285,8 @@ def test_view_reduce_out_full(v2d):
 
 def test_view_reduce_axis(v2d):
     result = np.sum(v2d, axis=0)
-    assert_allclose(result["value"], [2, 3])
-    assert_allclose(result["variance"], [2, 5])
+    assert result["value"] == approx([2, 3])
+    assert result["variance"] == approx([2, 5])
 
 
 # Issue #1143 (B12): binary ops used to preallocate the result with the view's
@@ -297,8 +296,8 @@ def test_view_broadcast_add(v):
     for result in (v + arr, arr + v):
         assert result.shape == (2, 4)
         assert isinstance(result, type(v))
-        assert_allclose(result.value, np.broadcast_to(v.value + 1, (2, 4)))
-        assert_allclose(result.variance, np.broadcast_to(v.variance + 1, (2, 4)))
+        assert result.value == approx(np.broadcast_to(v.value + 1, (2, 4)))
+        assert result.variance == approx(np.broadcast_to(v.variance + 1, (2, 4)))
 
 
 def test_view_broadcast_mul(v):
@@ -306,8 +305,8 @@ def test_view_broadcast_mul(v):
     for result in (v * arr, arr * v):
         assert result.shape == (2, 4)
         assert isinstance(result, type(v))
-        assert_allclose(result.value, np.broadcast_to(v.value * 2, (2, 4)))
-        assert_allclose(result.variance, np.broadcast_to(v.variance * 4, (2, 4)))
+        assert result.value == approx(np.broadcast_to(v.value * 2, (2, 4)))
+        assert result.variance == approx(np.broadcast_to(v.variance * 4, (2, 4)))
 
 
 @pytest.fixture
@@ -337,9 +336,9 @@ def test_mean_view_combine_matches_hist(mean_pair):
 
     assert isinstance(summed, type(h1.view()))
     for field in combined.dtype.names:
-        assert_allclose(summed[field], combined[field])
-    assert_allclose(summed.value, combined.value)
-    assert_allclose(summed.variance, combined.variance, equal_nan=True)
+        assert summed[field] == approx(combined[field])
+    assert summed.value == approx(combined.value)
+    assert summed.variance == approx(combined.variance, nan_ok=True)
 
 
 def test_weighted_mean_view_combine_matches_hist(weighted_mean_pair):
@@ -348,11 +347,11 @@ def test_weighted_mean_view_combine_matches_hist(weighted_mean_pair):
     summed = h1.view() + h2.view()
 
     for field in combined.dtype.names:
-        assert_allclose(summed[field], combined[field])
-    assert_allclose(summed.sum_of_weights, combined.sum_of_weights)
-    assert_allclose(summed.sum_of_weights_squared, combined.sum_of_weights_squared)
-    assert_allclose(summed.value, combined.value)
-    assert_allclose(summed.variance, combined.variance, equal_nan=True)
+        assert summed[field] == approx(combined[field])
+    assert summed.sum_of_weights == approx(combined.sum_of_weights)
+    assert summed.sum_of_weights_squared == approx(combined.sum_of_weights_squared)
+    assert summed.value == approx(combined.value)
+    assert summed.variance == approx(combined.variance, nan_ok=True)
 
 
 def test_mean_view_iadd(mean_pair):
@@ -361,7 +360,7 @@ def test_mean_view_iadd(mean_pair):
     v = h1.view().copy()
     v += h2.view()
     for field in expected.dtype.names:
-        assert_allclose(v[field], expected[field])
+        assert v[field] == approx(expected[field])
 
 
 def test_mean_view_zero_count_bins():
@@ -369,9 +368,9 @@ def test_mean_view_zero_count_bins():
     # divide/invalid warning.
     empty = bh.Histogram(bh.axis.Integer(0, 3), storage=bh.storage.Mean()).view()
     result = empty + empty
-    assert_allclose(result.count, [0, 0, 0])
-    assert_allclose(result.value, [0, 0, 0])
-    assert_allclose(result._sum_of_deltas_squared, [0, 0, 0])
+    assert result.count == approx([0, 0, 0])
+    assert result.value == approx([0, 0, 0])
+    assert result._sum_of_deltas_squared == approx([0, 0, 0])
     assert not np.any(np.isnan(result.value))
 
     # Empty in one operand only -> result equals the other operand bin-for-bin.
@@ -380,8 +379,8 @@ def test_mean_view_zero_count_bins():
     left = empty + h.view()
     right = h.view() + empty
     for field in h.view().dtype.names:
-        assert_allclose(left[field], h.view()[field])
-        assert_allclose(right[field], h.view()[field])
+        assert left[field] == approx(h.view()[field])
+        assert right[field] == approx(h.view()[field])
 
 
 def test_mean_view_add_accumulator(mean_pair):
@@ -395,7 +394,7 @@ def test_mean_view_add_accumulator(mean_pair):
     other[...] = [[3.0, 5.0, 2.0]] * 4  # count, value, variance (matches acc)
     expected = v + other.view()
     for field in v.dtype.names:
-        assert_allclose(result[field], expected[field])
+        assert result[field] == approx(expected[field])
 
 
 def test_weighted_mean_view_add_accumulator(weighted_mean_pair):
@@ -410,7 +409,7 @@ def test_weighted_mean_view_add_accumulator(weighted_mean_pair):
     other[...] = [[2.0, 1.5, 5.0, 2.0]] * 4
     expected = v + other.view()
     for field in v.dtype.names:
-        assert_allclose(result[field], expected[field])
+        assert result[field] == approx(expected[field])
 
 
 def test_weighted_mean_view_combine_empty_bin():
@@ -422,7 +421,7 @@ def test_weighted_mean_view_combine_empty_bin():
     ).view()
     result = h.view() + empty
     for field in h.view().dtype.names:
-        assert_allclose(result[field], h.view()[field])
+        assert result[field] == approx(h.view()[field])
     assert not np.any(np.isnan(result.value))
 
 
@@ -432,33 +431,32 @@ def test_mean_view_scalar_scale():
     v = h.view()
 
     for scaled in (v * 3, 3 * v):
-        assert_allclose(scaled.count, v.count)  # weights unchanged
-        assert_allclose(scaled.value, v.value * 3)
-        assert_allclose(scaled._sum_of_deltas_squared, v._sum_of_deltas_squared * 9)
+        assert scaled.count == approx(v.count)  # weights unchanged
+        assert scaled.value == approx(v.value * 3)
+        assert scaled._sum_of_deltas_squared == approx(v._sum_of_deltas_squared * 9)
 
     divided = v / 2
-    assert_allclose(divided.count, v.count)
-    assert_allclose(divided.value, v.value / 2)
-    assert_allclose(divided._sum_of_deltas_squared, v._sum_of_deltas_squared / 4)
+    assert divided.count == approx(v.count)
+    assert divided.value == approx(v.value / 2)
+    assert divided._sum_of_deltas_squared == approx(v._sum_of_deltas_squared / 4)
 
     v2 = v.copy()
     v2 *= 3
-    assert_allclose(v2.value, v.value * 3)
+    assert v2.value == approx(v.value * 3)
     v2 = v.copy()
     v2 /= 2
-    assert_allclose(v2.value, v.value / 2)
+    assert v2.value == approx(v.value / 2)
 
 
 def test_weighted_mean_view_scalar_scale(weighted_mean_pair):
     h1, _ = weighted_mean_pair
     v = h1.view()
     scaled = v * 2
-    assert_allclose(scaled.sum_of_weights, v.sum_of_weights)
-    assert_allclose(scaled.sum_of_weights_squared, v.sum_of_weights_squared)
-    assert_allclose(scaled.value, v.value * 2)
-    assert_allclose(
-        scaled._sum_of_weighted_deltas_squared,
-        v._sum_of_weighted_deltas_squared * 4,
+    assert scaled.sum_of_weights == approx(v.sum_of_weights)
+    assert scaled.sum_of_weights_squared == approx(v.sum_of_weights_squared)
+    assert scaled.value == approx(v.value * 2)
+    assert scaled._sum_of_weighted_deltas_squared == approx(
+        v._sum_of_weighted_deltas_squared * 4
     )
 
 
@@ -501,7 +499,7 @@ def test_mean_view_reduce_keepdims():
     assert plain.shape == (2,)
     assert kept.shape == (1, 2)
     for field in v.dtype.names:
-        assert_allclose(kept[field][0], plain[field])
+        assert kept[field][0] == approx(plain[field])
 
 
 # Issue #1143 (B2): mean reductions used to silently ignore reduction


### PR DESCRIPTION
Addresses https://github.com/scikit-hep/boost-histogram/commit/2c81964d8f422396963fbbcaece650f5d787eefc commit further.

I realized that there are other asserts that are imported directly which I missed in previous commit, so this covers all of them.