### PR TITLE
Storage function to fetch storage type

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2019, macos-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-2019, macos-latest, ubuntu-latest]
         arch: [auto64]
         build: ["*"]
 
@@ -116,7 +116,7 @@ jobs:
             arch: universal2
             build: "*"
 
-          - os: windows-latest
+          - os: windows-2019
             arch: auto32
             build: "*"
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ histograms can be plotted via any compatible library, such as [mplhep][].
   * `*=`: Multiply by a scaler (not all storages) (`hist * scalar` and `scalar * hist` supported too)
   * `/=`: Divide by a scaler (not all storages) (`hist / scalar` supported too)
   * `.kind`: Either `bh.Kind.COUNT` or `bh.Kind.MEAN`, depending on storage
-  * `.storageType`: Fetch the histogram storage type in string
+  * `.storage_type`: Fetch the histogram storage type in string
   * `.sum(flow=False)`: The total count of all bins
   * `.project(ax1, ax2, ...)`: Project down to listed axis (numbers). Can also reorder axes.
   * `.to_numpy(flow=False, view=False)`: Convert to a NumPy style tuple (with or without under/overflow bins)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ histograms can be plotted via any compatible library, such as [mplhep][].
   * `*=`: Multiply by a scaler (not all storages) (`hist * scalar` and `scalar * hist` supported too)
   * `/=`: Divide by a scaler (not all storages) (`hist / scalar` supported too)
   * `.kind`: Either `bh.Kind.COUNT` or `bh.Kind.MEAN`, depending on storage
-  * `.storage_type`: Fetch the histogram storage type in string
+  * `.storage_type`: Fetch the histogram storage type
   * `.sum(flow=False)`: The total count of all bins
   * `.project(ax1, ax2, ...)`: Project down to listed axis (numbers). Can also reorder axes.
   * `.to_numpy(flow=False, view=False)`: Convert to a NumPy style tuple (with or without under/overflow bins)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ histograms can be plotted via any compatible library, such as [mplhep][].
   * `*=`: Multiply by a scaler (not all storages) (`hist * scalar` and `scalar * hist` supported too)
   * `/=`: Divide by a scaler (not all storages) (`hist / scalar` supported too)
   * `.kind`: Either `bh.Kind.COUNT` or `bh.Kind.MEAN`, depending on storage
+  * `.storageType`: Fetch the histogram storage type in string
   * `.sum(flow=False)`: The total count of all bins
   * `.project(ax1, ax2, ...)`: Project down to listed axis (numbers). Can also reorder axes.
   * `.to_numpy(flow=False, view=False)`: Convert to a NumPy style tuple (with or without under/overflow bins)

--- a/src/boost_histogram/_core/hist.pyi
+++ b/src/boost_histogram/_core/hist.pyi
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="_BaseHistogram")
 _axes_limit: int
 
 class _BaseHistogram:
-    storage_type: ClassVar[Type[storage._BaseStorage]]
+    _storage_type: ClassVar[Type[storage._BaseStorage]]
     # Note that storage has a default simply because subclasses always handle it.
     def __init__(
         self, axis: list[axis._BaseAxis], storage: storage._BaseStorage = ...

--- a/src/boost_histogram/_core/hist.pyi
+++ b/src/boost_histogram/_core/hist.pyi
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="_BaseHistogram")
 _axes_limit: int
 
 class _BaseHistogram:
-    _storage_type: ClassVar[Type[storage._BaseStorage]]
+    storage_type: ClassVar[Type[storage._BaseStorage]]
     # Note that storage has a default simply because subclasses always handle it.
     def __init__(
         self, axis: list[axis._BaseAxis], storage: storage._BaseStorage = ...

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -596,7 +596,7 @@ class Histogram:
     @property
     def storage_type(self) -> Type[Storage]:
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
-        
+
     # Backward compat
     _storage_type = storage_type
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -231,7 +231,7 @@ class Histogram:
 
         # Check all available histograms, and if the storage matches, return that one
         for h in _histograms:
-            if isinstance(storage, h._storage_type):
+            if isinstance(storage, h.storage_type):
                 self._hist = h(axes, storage)  # type: ignore[unreachable]
                 self.axes = self._generate_axes_()
                 return
@@ -344,9 +344,6 @@ class Histogram:
         Return a view into the data, optionally with overflow turned on.
         """
         return _to_view(self._hist.view(flow))
-
-    def storageType(self) -> str:
-        return str(self._storage_type).rsplit(".", maxsplit=1)[-1][:-2]
 
     def __array__(self) -> "np.typing.NDArray[Any]":
         return self.view(False)
@@ -597,7 +594,7 @@ class Histogram:
         return cast(self, self._hist.axis(i), Axis)
 
     @property
-    def _storage_type(self) -> Type[Storage]:
+    def storage_type(self) -> Type[Storage]:
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
 
     def _reduce(self: H, *args: Any) -> H:
@@ -653,7 +650,7 @@ class Histogram:
         sep = "," if len(self.axes) > 0 else ""
         ret = f"{self.__class__.__name__}({first_newline}"
         ret += f",{newline}".join(repr(ax) for ax in self.axes)
-        ret += f"{sep}{storage_newline}storage={self._storage_type()}"  # pylint: disable=not-callable
+        ret += f"{sep}{storage_newline}storage={self.storage_type()}"  # pylint: disable=not-callable
         ret += ")"
         outer = self.sum(flow=True)
         if outer:
@@ -792,7 +789,7 @@ class Histogram:
         Compute the sum over the histogram bins (optionally including the flow bins).
         """
         if any(x == 0 for x in (self.axes.extent if flow else self.axes.size)):
-            return self._storage_type.accumulator()
+            return self.storage_type.accumulator()
 
         return self._hist.sum(flow)  # type: ignore[no-any-return]
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -344,7 +344,10 @@ class Histogram:
         Return a view into the data, optionally with overflow turned on.
         """
         return _to_view(self._hist.view(flow))
-
+    
+    def storageType(self) -> str:
+        return str(self._storage_type).rsplit('.', maxsplit=1)[-1][:-2]
+    
     def __array__(self) -> "np.typing.NDArray[Any]":
         return self.view(False)
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -231,7 +231,7 @@ class Histogram:
 
         # Check all available histograms, and if the storage matches, return that one
         for h in _histograms:
-            if isinstance(storage, h.storage_type):
+            if isinstance(storage, h._storage_type):
                 self._hist = h(axes, storage)  # type: ignore[unreachable]
                 self.axes = self._generate_axes_()
                 return

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -344,10 +344,10 @@ class Histogram:
         Return a view into the data, optionally with overflow turned on.
         """
         return _to_view(self._hist.view(flow))
-    
+
     def storageType(self) -> str:
-        return str(self._storage_type).rsplit('.', maxsplit=1)[-1][:-2]
-    
+        return str(self._storage_type).rsplit(".", maxsplit=1)[-1][:-2]
+
     def __array__(self) -> "np.typing.NDArray[Any]":
         return self.view(False)
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -596,6 +596,9 @@ class Histogram:
     @property
     def storage_type(self) -> Type[Storage]:
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
+        
+    # Backward compat
+    _storage_type = storage_type
 
     def _reduce(self: H, *args: Any) -> H:
         return self._new_hist(self._hist.reduce(*args))

--- a/tests/test_internal_histogram.py
+++ b/tests/test_internal_histogram.py
@@ -27,7 +27,7 @@ def test_1D_fill_int(storage):
     vals = (0.15, 0.25, 0.25)
 
     hist = bh.Histogram(bh.axis.Regular(bins, *ranges), storage=storage())
-    assert hist._storage_type == storage
+    assert hist.storage_type == storage
     hist.fill(vals)
 
     H = np.array([0, 1, 2, 0, 0, 0, 0, 0, 0, 0])
@@ -52,7 +52,7 @@ def test_2D_fill_int(storage):
         bh.axis.Regular(bins[1], *ranges[1]),
         storage=storage(),
     )
-    assert hist._storage_type == storage
+    assert hist.storage_type == storage
     hist.fill(*vals)
 
     H = np.histogram2d(*vals, bins=bins, range=ranges)[0]

--- a/tests/test_pickles.py
+++ b/tests/test_pickles.py
@@ -21,11 +21,11 @@ def test_read_pickle(version):
     h2 = d["h2"]
     h3 = d["h3"]
 
-    assert h1._storage_type == (
+    assert h1.storage_type == (
         bh.storage.Double if version[0] == "0" else bh.storage.Int64
     )
-    assert h2._storage_type == bh.storage.Weight
-    assert h3._storage_type == bh.storage.Double
+    assert h2.storage_type == bh.storage.Weight
+    assert h3.storage_type == bh.storage.Double
 
     assert h1[bh.loc(-5)] == 1
     assert h1[bh.loc(1)] == 2

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -297,5 +297,5 @@ def test_empty_axis_histogram(storage):
         bh.axis.StrCategory([], growth=True),
         storage=storage(),
     )
-    assert h2d.sum() == h2d._storage_type.accumulator()
-    assert h2d.sum(flow=True) == h2d._storage_type.accumulator()
+    assert h2d.sum() == h2d.storage_type.accumulator()
+    assert h2d.sum(flow=True) == h2d.storage_type.accumulator()

--- a/tests/test_subclassing.py
+++ b/tests/test_subclassing.py
@@ -19,7 +19,7 @@ def test_subclass():
     h = MyHist(MyRegular(10, 0, 2, transform=MyPowTransform(2)), storage=MyIntStorage())
 
     assert type(h) == MyHist
-    assert h._storage_type == MyIntStorage
+    assert h.storage_type == MyIntStorage
     assert type(h.axes[0]) == MyRegular
     assert type(h.axes[0].transform) == MyPowTransform
 


### PR DESCRIPTION
Addresses issue faced while solving https://github.com/scikit-hep/boost-histogram/issues/157 issue.

Simply added a call function that returns storage type.

This is also needed to correctly create an empty copy an arbitrary histogram:


```python
new_hist = bh.Histogram(*old_hist.axes, storage=old_hist.storage_type())
```

Backward compatibility shim needed for a few releases since things like Hist already are having to use this; it needs to be officially public API.