### PR TITLE
Better error for empty AND incorrect sample

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -89,14 +89,12 @@ def meanStorageSampleCheck(sample: Optional[ArrayLike]) -> None:
     if sample is None:
         raise TypeError("Sample key-argument (sample=) needs to be provided.")
     seqs = (collections.abc.Sequence, np.ndarray)
+    msg1 = f"Sample key-argument needs to be a sequence, {sample.__class__.__name__} given."
     if isinstance(sample, str) and not isinstance(sample, seqs):
-        raise ValueError(
-            f"Sample key-argument needs to be a sequence, {sample.__class__.__name__} given."
-        )
+        raise ValueError(msg1)
+    msg2 = f"Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given."
     if np.array(sample).ndim != 1:
-        raise ValueError(
-            f"Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given."
-        )
+        raise ValueError(msg2)
 
 
 def _arg_shortcut(item: Union[Tuple[int, float, float], Axis, CppAxis]) -> CppAxis:

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -24,7 +24,7 @@ from typing import (
 )
 
 import numpy as np
-import pytest
+
 import boost_histogram
 from boost_histogram import _core
 
@@ -84,10 +84,21 @@ def _fill_cast(
 
     return value
 
+
 def meanStorageSampleCheck(sample):
-    assert type(sample)!=type(None), 'Sample key-argument (sample=) needs to be provided.'
-    assert (isinstance(sample, (collections.abc.Sequence, np.ndarray)) and not isinstance(sample, (str))), f'Sample key-argument needs to be a sequence, {sample.__class__.__name__} given.'
-    assert (np.array(sample).ndim)==1, f'Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given.'
+    assert type(sample) != type(
+        None
+    ), "Sample key-argument (sample=) needs to be provided."
+    assert isinstance(
+        sample, (collections.abc.Sequence, np.ndarray)
+    ) and not isinstance(
+        sample, (str)
+    ), f"Sample key-argument needs to be a sequence, {sample.__class__.__name__} given."
+    assert (
+        np.array(sample).ndim
+    ) == 1, (
+        f"Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given."
+    )
 
 
 def _arg_shortcut(item: Union[Tuple[int, float, float], Axis, CppAxis]) -> CppAxis:
@@ -494,12 +505,9 @@ class Histogram:
             available threads (usually two per core).
         """
 
-        if (
-            self._hist._storage_type
-            in {
-                _core.storage.mean,
-            }
-        ):
+        if self._hist._storage_type in {
+            _core.storage.mean,
+        }:
             meanStorageSampleCheck(sample)
 
         if (

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -92,7 +92,9 @@ def meanStorageSampleCheck(sample: Optional[ArrayLike]) -> None:
     msg1 = f"Sample key-argument needs to be a sequence, {sample.__class__.__name__} given."
     if isinstance(sample, str) and not isinstance(sample, seqs):
         raise ValueError(msg1)
-    msg2 = f"Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given."
+    msg2 = (
+        f"Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given."
+    )
     if np.array(sample).ndim != 1:
         raise ValueError(msg2)
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -90,9 +90,13 @@ def meanStorageSampleCheck(sample: Optional[ArrayLike]) -> None:
         raise TypeError("Sample key-argument (sample=) needs to be provided.")
     seqs = (collections.abc.Sequence, np.ndarray)
     if isinstance(sample, str) and not isinstance(sample, seqs):
-        raise ValueError(f"Sample key-argument needs to be a sequence, {sample.__class__.__name__} given.")
+        raise ValueError(
+            f"Sample key-argument needs to be a sequence, {sample.__class__.__name__} given."
+        )
     if np.array(sample).ndim != 1:
-        raise ValueError(f"Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given.")
+        raise ValueError(
+            f"Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given."
+        )
 
 
 def _arg_shortcut(item: Union[Tuple[int, float, float], Axis, CppAxis]) -> CppAxis:

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -86,17 +86,13 @@ def _fill_cast(
 
 
 def meanStorageSampleCheck(sample: Optional[ArrayLike]) -> None:
-    assert sample is not None, "Sample key-argument (sample=) needs to be provided."
-    assert isinstance(
-        sample, (collections.abc.Sequence, np.ndarray)
-    ) and not isinstance(
-        sample, (str)
-    ), f"Sample key-argument needs to be a sequence, {sample.__class__.__name__} given."
-    assert (
-        np.array(sample).ndim
-    ) == 1, (
-        f"Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given."
-    )
+    if sample is None:
+        raise TypeError("Sample key-argument (sample=) needs to be provided.")
+    seqs = (collections.abc.Sequence, np.ndarray)
+    if isinstance(sample, str) and not isinstance(sample, seqs):
+        raise ValueError(f"Sample key-argument needs to be a sequence, {sample.__class__.__name__} given.")
+    if np.array(sample).ndim != 1:
+        raise ValueError(f"Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given.")
 
 
 def _arg_shortcut(item: Union[Tuple[int, float, float], Axis, CppAxis]) -> CppAxis:

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -24,7 +24,7 @@ from typing import (
 )
 
 import numpy as np
-
+import pytest
 import boost_histogram
 from boost_histogram import _core
 
@@ -83,6 +83,11 @@ def _fill_cast(
         return np.asarray(value)
 
     return value
+
+def meanStorageSampleCheck(sample):
+    assert type(sample)!=type(None), 'Sample key-argument (sample=) needs to be provided.'
+    assert (isinstance(sample, (collections.abc.Sequence, np.ndarray)) and not isinstance(sample, (str))), f'Sample key-argument needs to be a sequence, {sample.__class__.__name__} given.'
+    assert (np.array(sample).ndim)==1, f'Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given.'
 
 
 def _arg_shortcut(item: Union[Tuple[int, float, float], Axis, CppAxis]) -> CppAxis:
@@ -488,6 +493,14 @@ class Histogram:
             threaded filling.  Using 0 will automatically pick the number of
             available threads (usually two per core).
         """
+
+        if (
+            self._hist._storage_type
+            in {
+                _core.storage.mean,
+            }
+        ):
+            meanStorageSampleCheck(sample)
 
         if (
             self._hist._storage_type

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -92,10 +92,9 @@ def meanStorageSampleCheck(sample: Optional[ArrayLike]) -> None:
     msg1 = f"Sample key-argument needs to be a sequence, {sample.__class__.__name__} given."
     if isinstance(sample, str) and not isinstance(sample, seqs):
         raise ValueError(msg1)
-    msg2 = (
-        f"Sample key-argument needs to be 1 dimensional, {np.array(sample).ndim} given."
-    )
-    if np.array(sample).ndim != 1:
+    sample_dim = np.array(sample).ndim
+    msg2 = f"Sample key-argument needs to be 1 dimensional, {sample_dim} given."
+    if sample_dim != 1:
         raise ValueError(msg2)
 
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -85,7 +85,7 @@ def _fill_cast(
     return value
 
 
-def meanStorageSampleCheck(sample: Optional[ArrayLike]) -> None:
+def mean_storage_sample_check(sample: Optional[ArrayLike]) -> None:
     if sample is None:
         raise TypeError("Sample key-argument (sample=) needs to be provided.")
     seqs = (collections.abc.Sequence, np.ndarray)
@@ -502,10 +502,8 @@ class Histogram:
             available threads (usually two per core).
         """
 
-        if self._hist._storage_type in {
-            _core.storage.mean,
-        }:
-            meanStorageSampleCheck(sample)
+        if self._hist._storage_type is _core.storage.mean:
+            mean_storage_sample_check(sample)
 
         if (
             self._hist._storage_type

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -85,10 +85,8 @@ def _fill_cast(
     return value
 
 
-def meanStorageSampleCheck(sample):
-    assert type(sample) != type(
-        None
-    ), "Sample key-argument (sample=) needs to be provided."
+def meanStorageSampleCheck(sample: Optional[ArrayLike]) -> None:
+    assert sample is not None, "Sample key-argument (sample=) needs to be provided."
     assert isinstance(
         sample, (collections.abc.Sequence, np.ndarray)
     ) and not isinstance(


### PR DESCRIPTION
Addresses https://github.com/scikit-hep/boost-histogram/issues/734 issue.

Added better error message for
- empty sample
- incompatible type sample
- incorrect dimension sample
