### PR TITLE
Added DeprecationWarning for storage type

### DIFF
--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -597,8 +597,9 @@ class Histogram:
     def storage_type(self) -> Type[Storage]:
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
 
-    # Backward compat
-    _storage_type = storage_type
+    def _storage_type(self) -> Type[Storage]:
+        warnings.warn("Accessing storage type has changed from _storage_type to storage_type, and will be removed in future.", DeprecationWarning)
+        return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
 
     def _reduce(self: H, *args: Any) -> H:
         return self._new_hist(self._hist.reduce(*args))

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -597,6 +597,7 @@ class Histogram:
     def storage_type(self) -> Type[Storage]:
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
 
+    @property
     def _storage_type(self) -> Type[Storage]:
         warnings.warn(
             "Accessing storage type has changed from _storage_type to storage_type, and will be removed in future.",

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -602,6 +602,7 @@ class Histogram:
         warnings.warn(
             "Accessing storage type has changed from _storage_type to storage_type, and will be removed in future.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -598,7 +598,10 @@ class Histogram:
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
 
     def _storage_type(self) -> Type[Storage]:
-        warnings.warn("Accessing storage type has changed from _storage_type to storage_type, and will be removed in future.", DeprecationWarning)
+        warnings.warn(
+            "Accessing storage type has changed from _storage_type to storage_type, and will be removed in future.",
+            DeprecationWarning,
+        )
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
 
     def _reduce(self: H, *args: Any) -> H:


### PR DESCRIPTION
As _storage_type has changed to storage_type, accessing the previous one still works (backward compatibility) but raises a deprecation warning as suggested by @HDembinski [here](https://github.com/scikit-hep/boost-histogram/pull/781#discussion_r953496647).