### PR TITLE
fix: pending deprecation warning

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -29,14 +29,8 @@ def hist(session: nox.Session) -> None:
     session.chdir(tmpdir)
     session.run("git", "clone", "https://github.com/scikit-hep/hist", external=True)
     session.chdir("hist")
-    with open("setup.cfg", encoding="utf-8") as f:
-        lines = f.readlines()
-    with open("setup.cfg", "w", encoding="utf-8") as f:
-        for line in lines:
-            if "boost-histogram" not in line:
-                f.write(line)
-
     session.install(".[test,plot]")
+    session.run("pip", "list")
     session.run("pytest", *session.posargs)
 
 

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -1,6 +1,7 @@
 import collections.abc
 import copy
 import logging
+import sys
 import threading
 import typing
 import warnings
@@ -100,8 +101,8 @@ def mean_storage_sample_check(sample: Optional[ArrayLike]) -> None:
 
 def _arg_shortcut(item: Union[Tuple[int, float, float], Axis, CppAxis]) -> CppAxis:
     if isinstance(item, tuple) and len(item) == 3:
-        msg = "Developer shortcut: will be removed in a future version"
-        warnings.warn(msg, FutureWarning)
+        msg = "Using () directly in constructor is a developer shortcut and will be removed in a future version"
+        warnings.warn(msg, FutureWarning, stacklevel=4)
         return _core.axis.regular_uoflow(item[0], item[1], item[2])  # type: ignore[return-value]
 
     if isinstance(item, Axis):
@@ -615,11 +616,12 @@ class Histogram:
 
     @property
     def _storage_type(self) -> Type[Storage]:
-        warnings.warn(
-            "Accessing storage type has changed from _storage_type to storage_type, and will be removed in future.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        if sys.version_info >= (3, 7):
+            warnings.warn(
+                "Accessing storage type has changed from _storage_type to storage_type, and will be removed in future.",
+                PendingDeprecationWarning,
+                stacklevel=2,
+            )
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
 
     def _reduce(self: H, *args: Any) -> H:


### PR DESCRIPTION
Let's adjust this warning a bit so we can make a 1.3.2 release. It will be reverted to a full deprecation warning when 3.6 is dropped for 1.4 development.


- chore: fix hist downstream check in nox
- fix: PendingDep warning for Python 3.7 + _storage_type
