### PR TITLE
ci: update to Python 3.11 final

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.9", "3.11-dev", "pypy3.8"]
+        python-version: ["3.7", "3.9", "3.11", "pypy3.8"]
         include:
         - python-version: "3.8"
           cmake-extras: "-DCMAKE_CXX_STANDARD=17"


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos