### PR TITLE
feat: Add -latomic link arg for armv7l machines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import sys
 from pathlib import Path
 
@@ -48,6 +49,7 @@ ext_modules = [
         cxx_std=cxx_std,
         include_pybind11=False,
         extra_compile_args=["/d2FH4-"] if sys.platform.startswith("win32") else [],
+        extra_link_args=["-latomic"] if platform.machine() == "armv7l" else [],
     )
 ]
 


### PR DESCRIPTION
Resolves #822

Required if building on 32-bit Raspberry Pi. c.f. https://github.com/piwheels/packages/issues/341

Note from the [setuptools v65.6.3 docs](https://setuptools.pypa.io/en/stable/userguide/ext_modules.html#compiler-and-linker-options) 

> The linker options appear in the command line in the following order:
>
> * first, the options provided by environment variables and sysconfig variables,
> * then, a -L option for each element of Extension.library_dirs,
> * then, a linker-specific option like -Wl,-rpath for each element of Extension.runtime_library_dirs,
> * finally, the options provided by Extension.extra_link_args.

Here `extra_link_args` is used as this seems the most straightforward.