### PR TITLE
chore: prepare for 1.82

### DIFF
--- a/include/bh_python/array_like.hpp
+++ b/include/bh_python/array_like.hpp
@@ -7,7 +7,7 @@
 
 #include <bh_python/pybind11.hpp>
 
-#include <boost/histogram/detail/span.hpp>
+#include <boost/core/span.hpp>
 #include <vector>
 
 /// Generate empty array with same shape and strides as argument
@@ -29,7 +29,7 @@ py::array_t<T> array_like(py::object obj) {
         strides.emplace_back(arr.strides()[i] / arr.itemsize()
                              * static_cast<py::ssize_t>(sizeof(T)));
     }
-    return py::array_t<T>{bh::detail::span<const py::ssize_t>{
+    return py::array_t<T>{boost::span<const py::ssize_t>{
                               arr.shape(), static_cast<std::size_t>(arr.ndim())},
                           strides};
 }

--- a/include/bh_python/make_pickle.hpp
+++ b/include/bh_python/make_pickle.hpp
@@ -48,6 +48,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/core/nvp.hpp>
+#include <boost/core/span.hpp>
 #include <boost/histogram/detail/array_wrapper.hpp>
 #include <boost/mp11/function.hpp> // mp_or
 #include <boost/mp11/utility.hpp>  // mp_valid
@@ -58,6 +59,14 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+
+// Available as make_span in boost/core/make_span.hpp in 1.82+
+namespace {
+template <class T>
+inline constexpr boost::span<T> make_span(T* begin, std::size_t size) noexcept {
+    return boost::span<T>{begin, size};
+}
+} // namespace
 
 template <class T,
           class = decltype(std::declval<T&>().serialize(std::declval<std::nullptr_t&>(),
@@ -225,7 +234,7 @@ class tuple_oarchive {
     std::enable_if_t<std::is_arithmetic<T>::value == false, tuple_oarchive&>
     operator<<(const bh::detail::array_wrapper<T>& w) {
         // generic version
-        for(auto&& item : bh::detail::make_span(w.ptr, w.size))
+        for(auto&& item : ::make_span(w.ptr, w.size))
             this->operator<<(item);
         return *this;
     }
@@ -342,7 +351,7 @@ class tuple_iarchive {
     std::enable_if_t<std::is_arithmetic<T>::value == false, tuple_iarchive&>
     operator>>(bh::detail::array_wrapper<T>& w) {
         // generic version
-        for(auto&& item : bh::detail::make_span(w.ptr, w.size))
+        for(auto&& item : ::make_span(w.ptr, w.size))
             this->operator>>(item);
         return *this;
     }

--- a/include/bh_python/register_axis.hpp
+++ b/include/bh_python/register_axis.hpp
@@ -15,7 +15,6 @@
 #include <boost/histogram/axis/ostream.hpp>
 #include <boost/histogram/axis/traits.hpp>
 #include <boost/histogram/detail/iterator_adaptor.hpp>
-#include <boost/histogram/detail/span.hpp>
 
 #include <pybind11/eval.h>
 #include <pybind11/numpy.h>


### PR DESCRIPTION
This should fix the weekly job checking development branches. `<boost/histogram/detail/span.hpp>` has disappeared in the same release `<boost/core/make_span.hpp>` was added - we can just not depend on either.