### PR TITLE
fix: better error messages for C++ failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ ext_modules = [
         include_pybind11=False,
         extra_compile_args=["/d2FH4-"] if sys.platform.startswith("win32") else [],
         extra_link_args=["-latomic"] if platform.machine() == "armv7l" else [],
+        define_macros=[("PYBIND11_DETAILED_ERROR_MESSAGES", "1")],
     )
 ]
 


### PR DESCRIPTION
Fixed while working on something else; new(ish) feature in pybind11.
