### PR TITLE
ci: drop 32-bit linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
 
     - uses: pypa/cibuildwheel@v2.12.3
       env:
-        CIBW_BUILD: cp38-win_amd64 cp310-manylinux_i686 cp37-macosx_x86_64
+        CIBW_BUILD: cp38-win32 cp310-manylinux_x86_64 cp37-macosx_x86_64
         CIBW_BUILD_VERBOSITY: 1
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -98,9 +98,6 @@ jobs:
         arch: [auto64]
 
         include:
-          - os: ubuntu-latest
-            arch: auto32
-
           - os: macos-latest
             arch: universal2
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ platforms have wheels provided in boost-histogram:
 
 | System | Arch | Python versions | PyPy versions |
 |---------|-----|------------------|--------------|
-| ManyLinux2014 | 32 & 64-bit | 3.7, 3.8, 3.9, 3.10, 3.11  | 3.7, 3.8, 3.9 |
+| ManyLinux2014 | 64-bit | 3.7, 3.8, 3.9, 3.10, 3.11  | 3.7, 3.8, 3.9 |
 | ManyLinux2014 | ARM64 | 3.7, 3.8, 3.9, 3.10, 3.11 | 3.7, 3.8, 3.9 |
 | MuslLinux_1_1 | 64-bit | 3.7, 3.8, 3.9, 3.10, 3.11 | |
 | macOS 10.9+ | 64-bit | 3.7, 3.8, 3.9, 3.10, 3.11 | 3.7, 3.8, 3.9 |


### PR DESCRIPTION
NumPy doesn't support 32-bit linux, so let's drop it too. Can be manually built if someone really needs it, or we can restore it if it causes problems. But pretty sure it won't.

Should drop the slowest CI test from 10 minutes to 6 minutes.
