### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -29,7 +29,7 @@ jobs:
         python-version: "3.11"
 
     - name: Install pyodide-build
-      run: pip install pyodide-build==0.23.1 pydantic<2
+      run: pip install pyodide-build==0.23.1 "pydantic<2"
 
     - name: Compute emsdk version
       id: compute-emsdk-version

--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -29,7 +29,7 @@ jobs:
         python-version: "3.11"
 
     - name: Install pyodide-build
-      run: pip install pyodide-build==0.23.1
+      run: pip install pyodide-build==0.23.1 pydantic<2
 
     - name: Compute emsdk version
       id: compute-emsdk-version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
   - id: setup-cfg-fmt
     args: [--include-version-classifiers, --max-py-version=3.11]
 
-- repo: https://github.com/charliermarsh/ruff-pre-commit
+- repo: https://github.com/astral-sh/ruff-pre-commit
   rev: "v0.0.272"
   hooks:
     - id: ruff


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/pull/200.

Committed via https://github.com/asottile/all-repos