### PR TITLE
fix: (better) error when filling an int with a float

### DIFF
--- a/docs/user-guide/storage.rst
+++ b/docs/user-guide/storage.rst
@@ -84,7 +84,7 @@ Mean
 
 This storage tracks a "Profile", that is, the mean value of the accumulation instead of the sum.
 It stores the count (as a double), the mean, and a term that is used to compute the variance. When
-filling, you can add a ``sample=`` term.
+filling, you must add a ``sample=`` term.
 
 
 WeightedMean

--- a/include/bh_python/fill.hpp
+++ b/include/bh_python/fill.hpp
@@ -110,7 +110,7 @@ inline decltype(auto) special_cast<int>(py::handle x) {
 template <>
 inline decltype(auto) special_cast<c_array_t<int>>(py::handle x) {
     auto np     = py::module_::import("numpy");
-    auto to_int = np.attr("floor")(x);
+    auto to_int = np.attr("floor")(np.attr("asarray")(x));
 
     return py::cast<c_array_t<int>>(to_int);
 }

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -119,15 +119,14 @@ def test_fill_int_1d():
 
 def test_fill_int_with_float_single_1d():
     h = bh.Histogram(bh.axis.Integer(-1, 2))
-    h.fill(0.3)
-    h.fill(-0.3)
-    assert h.values() == approx(np.array([1, 1, 0]))
+    with pytest.raises(TypeError):
+        h.fill(0.3)
 
 
 def test_fill_int_with_float_array_1d():
     h = bh.Histogram(bh.axis.Integer(-1, 2))
-    h.fill([-0.3, 0.3])
-    assert h.values() == approx(np.array([1, 1, 0]))
+    with pytest.raises(TypeError):
+        h.fill([-0.3, 0.3])
 
 
 def test_fill_1d(flow):
@@ -948,7 +947,7 @@ def test_fill_with_sequence_0():
         a.fill(np.empty(2), 1)
     with pytest.raises(ValueError):
         a.fill(np.empty(2), np.empty(3))
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         a.fill("abc")
 
     with pytest.raises(IndexError):
@@ -989,12 +988,9 @@ def test_fill_with_sequence_0():
     platform.machine() == "ppc64le", reason="ppc64le bug (TBD)", strict=False
 )
 def test_fill_with_sequence_1():
-    def fa(*args):
-        return np.array(args, dtype=float)
-
     a = bh.Histogram(bh.axis.Integer(0, 3), storage=bh.storage.Weight())
-    v = fa(-1, 0, 1, 2, 3, 4)
-    w = fa(2, 3, 4, 5, 6, 7)
+    v = np.array([-1, 0, 1, 2, 3, 4], dtype=int)
+    w = np.array([2, 3, 4, 5, 6, 7], dtype=float)
     a.fill(v, weight=w)
     a.fill((0, 1), weight=(2, 3))
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -117,6 +117,19 @@ def test_fill_int_1d():
         h[-3]
 
 
+def test_fill_int_with_float_single_1d():
+    h = bh.Histogram(bh.axis.Integer(-1, 2))
+    h.fill(0.3)
+    h.fill(-0.3)
+    assert h.values() == approx(np.array([1, 1, 0]))
+
+
+def test_fill_int_with_float_array_1d():
+    h = bh.Histogram(bh.axis.Integer(-1, 2))
+    h.fill([-0.3, 0.3])
+    assert h.values() == approx(np.array([1, 1, 0]))
+
+
 def test_fill_1d(flow):
     h = bh.Histogram(bh.axis.Regular(3, -1, 2, underflow=flow, overflow=flow))
     with pytest.raises(ValueError):

--- a/tests/test_internal_histogram.py
+++ b/tests/test_internal_histogram.py
@@ -280,7 +280,7 @@ def test_int_cat_hist():
     assert_array_equal(h.view(), [1, 1, 1])
     assert h.sum() == 3
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         h.fill(0.5)
 
 


### PR DESCRIPTION
Fix #843.

Currently, only single fills error when using a float on an int axis - this expands the error to arrays too. It's important to error since `-.9` and `.9` both become 0 when converting from floats to ints. And explicit is better than implicit.