### PR TITLE
Add missing API docs for `bh.Histogram`

### DIFF
--- a/docs/api/boost_histogram.rst
+++ b/docs/api/boost_histogram.rst
@@ -1,8 +1,8 @@
 boost\_histogram
 ================
 
-.. automodule:: boost_histogram
-   :members:
+.. automodule:: boost_histogram._internal.hist
+   :members: Histogram
    :undoc-members:
    :show-inheritance:
 


### PR DESCRIPTION
For some reason, the API doc of `Histogram` is missing from the documentation website. `Histogram` is in a private module, but it is exported in `__init__.py`. Furthermore, the module `boost_histogram` itself has no docstrings to display.

This was briefly mentioned in https://github.com/scikit-hep/hist/issues/445.