### PR TITLE
ci: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -138,6 +138,8 @@ jobs:
       url: https://pypi.org/p/boost-histogram
     permissions:
       id-token: write
+      attestations: write
+      contents: read
 
     steps:
       - uses: actions/download-artifact@v4
@@ -148,5 +150,10 @@ jobs:
 
       - name: List all files
         run: ls -lh dist
+
+      - name: Generate artifact attestation for sdist and wheels
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-path: "dist/boost_histogram-*"
 
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.2
+    rev: 0.28.4
     hooks:
       - id: check-readthedocs
       - id: check-github-workflows


### PR DESCRIPTION
* Add generation of GitHub artifact attestations to built sdist and wheel before upload.
  c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
* Update `python-jsonschema/check-jsonschema` pre-commit hook to recognize `attestations` `permissions` key.