### PR TITLE
fix: make non-uniform rebinning work for `Weight()` and friends

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,12 +42,12 @@ specific jobs:
 ```console
 $ nox -l # List all the defined sessions
 $ nox -s lint  # Lint only
-$ nox -s tests-3.9  # Python 3.9 tests only
+$ nox -s tests  # Tests only
 $ nox -s docs -- serve  # Build and serve the docs
 $ nox -s make_pickle  # Make a pickle file for this version
 ```
 
-Nox handles everything for you, including setting up an temporary virtual
+Nox handles everything for you, including setting up a temporary virtual
 environment for each run.
 
 ### Pip

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 ## Version 1.5
 
+### Version 1.5.1
+
+Make non-uniform rebinning work for Weight() and friends [#972][]
+
+[#972]: https://github.com/scikit-hep/boost-histogram/pull/972
+
 ### Version 1.5.0
 
 #### Features

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -830,7 +830,7 @@ class Histogram:
         reduced: CppHistogram | None = None
 
         # Compute needed slices and projections
-        for i, ind in enumerate(indexes):
+        for i, ind in enumerate(indexes):  # pylint: disable=too-many-nested-blocks
             if isinstance(ind, SupportsIndex):
                 pick_each[i] = ind.__index__() + (
                     1 if self.axes[i].traits.underflow else 0

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -830,7 +830,7 @@ class Histogram:
         reduced: CppHistogram | None = None
 
         # Compute needed slices and projections
-        for i, ind in enumerate(indexes):  # pylint: disable=too-many-nested-blocks
+        for i, ind in enumerate(indexes):
             if isinstance(ind, SupportsIndex):
                 pick_each[i] = ind.__index__() + (
                     1 if self.axes[i].traits.underflow else 0
@@ -921,15 +921,9 @@ class Histogram:
                     for new_j, group in enumerate(groups):
                         for _ in range(group):
                             pos = [slice(None)] * (i)
-                            if new_view.dtype.names:
-                                for field in new_view.dtype.names:
-                                    new_view[(*pos, new_j + 1, ...)][field] += (
-                                        reduced_view[(*pos, j, ...)][field]
-                                    )
-                            else:
-                                new_view[(*pos, new_j + 1, ...)] += reduced_view[
-                                    (*pos, j, ...)
-                                ]
+                            new_view[(*pos, new_j + 1, ...)] += _to_view(
+                                reduced_view[(*pos, j, ...)]
+                            )
                             j += 1
 
                     reduced = new_reduced

--- a/src/boost_histogram/_internal/hist.py
+++ b/src/boost_histogram/_internal/hist.py
@@ -921,9 +921,15 @@ class Histogram:
                     for new_j, group in enumerate(groups):
                         for _ in range(group):
                             pos = [slice(None)] * (i)
-                            new_view[(*pos, new_j + 1, ...)] += reduced_view[
-                                (*pos, j, ...)
-                            ]
+                            if new_view.dtype.names:
+                                for field in new_view.dtype.names:
+                                    new_view[(*pos, new_j + 1, ...)][field] += (
+                                        reduced_view[(*pos, j, ...)][field]
+                                    )
+                            else:
+                                new_view[(*pos, new_j + 1, ...)] += reduced_view[
+                                    (*pos, j, ...)
+                                ]
                             j += 1
 
                     reduced = new_reduced


### PR DESCRIPTION
Fixes #971 

Now the code loops over every `dtype.name` if the `view()` of a `Histogram` is a structured NumPy array.