### PR TITLE
refactor: rename to raw_metadata for C++

### DIFF
--- a/include/bh_python/register_axis.hpp
+++ b/include/bh_python/register_axis.hpp
@@ -189,10 +189,10 @@ py::class_<A> register_axis(py::module& m, Args&&... args) {
             [](const A& self) { return bh::axis::traits::ordered(self); })
 
         .def_property(
-            "metadata",
+            "raw_metadata",
             [](const A& self) { return self.metadata(); },
             [](A& self, const metadata_t& label) { self.metadata() = label; },
-            "Set the axis label")
+            "Set the metadata")
 
         .def_property_readonly(
             "size",

--- a/src/boost_histogram/axis/__init__.py
+++ b/src/boost_histogram/axis/__init__.py
@@ -91,7 +91,7 @@ class Axis:
 
     def __setattr__(self, attr: str, value: Any) -> None:
         if attr == "__dict__":
-            self._ax.metadata = value
+            self._ax.raw_metadata = value
         object.__setattr__(self, attr, value)
 
     def __getattr__(self, attr: str) -> Any:
@@ -120,15 +120,15 @@ class Axis:
                 "Cannot provide metadata by keyword and __dict__, use __dict__ only"
             )
         if __dict__ is not None:
-            self._ax.metadata = __dict__
+            self._ax.raw_metadata = __dict__
         elif metadata is not None:
-            self._ax.metadata["metadata"] = metadata
+            self._ax.raw_metadata["metadata"] = metadata
 
-        self.__dict__ = self._ax.metadata
+        self.__dict__ = self._ax.raw_metadata
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self._ax = state["_ax"]
-        self.__dict__ = self._ax.metadata
+        self.__dict__ = self._ax.raw_metadata
 
     def __getstate__(self) -> dict[str, Any]:
         return {"_ax": self._ax}
@@ -136,7 +136,7 @@ class Axis:
     def __copy__(self: T) -> T:
         other: T = self.__class__.__new__(self.__class__)
         other._ax = copy.copy(self._ax)
-        other.__dict__ = other._ax.metadata
+        other.__dict__ = other._ax.raw_metadata
         return other
 
     def index(self, value: float | str) -> int:
@@ -176,7 +176,7 @@ class Axis:
     def _convert_cpp(cls: type[T], cpp_object: Any) -> T:
         nice_ax: T = cls.__new__(cls)
         nice_ax._ax = cpp_object
-        nice_ax.__dict__ = cpp_object.metadata
+        nice_ax.__dict__ = cpp_object.raw_metadata
         return nice_ax
 
     def __len__(self) -> int:

--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -333,9 +333,9 @@ class Histogram:
 
         for ax in self.axes:
             if memo is NOTHING:
-                ax.__dict__ = copy.copy(ax._ax.metadata)
+                ax.__dict__ = copy.copy(ax._ax.raw_metadata)
             else:
-                ax.__dict__ = copy.deepcopy(ax._ax.metadata, memo)
+                ax.__dict__ = copy.deepcopy(ax._ax.raw_metadata, memo)
         return self
 
     def _new_hist(self: H, _hist: CppHistogram, memo: Any = NOTHING) -> H:
@@ -362,7 +362,7 @@ class Histogram:
         self.__dict__ = copy.copy(other.__dict__)
         self.axes = self._generate_axes_()
         for ax in self.axes:
-            ax.__dict__ = copy.copy(ax._ax.metadata)
+            ax.__dict__ = copy.copy(ax._ax.raw_metadata)
 
         # Allow custom behavior on either "from" or "to"
         other._export_bh_(self)
@@ -696,7 +696,7 @@ class Histogram:
             self._variance_known = True
             self.metadata = state.get("metadata", None)
             for i in range(self._hist.rank()):
-                self._hist.axis(i).metadata = {"metadata": self._hist.axis(i).metadata}
+                self._hist.axis(i).raw_metadata = {"metadata": self._hist.axis(i).raw_metadata}
 
         self.axes = self._generate_axes_()
 
@@ -959,7 +959,7 @@ class Histogram:
                         j += group
 
                     variable_axis = Variable(
-                        new_axes_indices, __dict__=axes[i].metadata
+                        new_axes_indices, __dict__=axes[i].raw_metadata
                     )
                     axes[i] = variable_axis._ax
 
@@ -1027,7 +1027,7 @@ class Histogram:
                     selection.append(ax.size)
 
                 new_axis = axes[i].__class__([axes[i].value(j) for j in pick_set[i]])  # type: ignore[call-arg]
-                new_axis.metadata = axes[i].metadata
+                new_axis.raw_metadata = axes[i].raw_metadata
                 axes[i] = new_axis
                 reduced_view = np.take(reduced_view, selection, axis=i)
 

--- a/tests/test_minihist_title.py
+++ b/tests/test_minihist_title.py
@@ -46,7 +46,7 @@ class NamedAxesTuple(bh.axis.AxesTuple):
     @name.setter
     def name(self, values):
         for ax, val in zip(self, values):
-            ax._ax.metadata["name"] = f"test: {val}"
+            ax._ax.raw_metadata["name"] = f"test: {val}"
 
 
 # When you subclass Histogram or an Axes, you should register your family so
@@ -65,7 +65,7 @@ class AxesMixin:
         """
         Get the name for the Regular axis
         """
-        return self._ax.metadata.get("name", "")
+        return self._ax.raw_metadata.get("name", "")
 
 
 # The order of the mixin is important here - it must be first
@@ -78,7 +78,7 @@ class Regular(bh.axis.Regular, AxesMixin, family=CUSTOM_FAMILY):
 
     def __init__(self, bins, start, stop, name):
         super().__init__(bins, start, stop)
-        self._ax.metadata["name"] = name
+        self._ax.raw_metadata["name"] = name
 
 
 class Integer(AxesMixin, bh.axis.Integer, family=CUSTOM_FAMILY):
@@ -86,7 +86,7 @@ class Integer(AxesMixin, bh.axis.Integer, family=CUSTOM_FAMILY):
 
     def __init__(self, start, stop, name):
         super().__init__(start, stop)
-        self._ax.metadata["name"] = name
+        self._ax.raw_metadata["name"] = name
 
 
 class CustomHist(bh.Histogram, family=CUSTOM_FAMILY):


### PR DESCRIPTION
This should reduce confusion with `ax.metadata`, which caused the bug in #978.
