### PR TITLE
fix: axis passthrough

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,9 +2,31 @@
 
 ## Version 1.5
 
+### Version 1.5.2
+
+Fix for axis metadata not passing though non-uniform rebinning correctly. Flow
+bins are now preserved when doing a non-uniform rebinning. Also adds the
+ability to rebin by edges or an existing axis.
+
+#### Features
+
+- Support `edges=` and `axis=` in `bh.rebin` [#977][]
+- Allow axis to be passed through `bh.rebin` [#980][]
+
+#### Bug fixes
+
+- Axis metadata was broken when rebinning [#978][]
+- Flow bins were lost when using variable rebinning [#977][]
+
+[#977]: https://github.com/scikit-hep/boost-histogram/pull/977
+[#978]: https://github.com/scikit-hep/boost-histogram/pull/978
+[#980]: https://github.com/scikit-hep/boost-histogram/pull/980
+
 ### Version 1.5.1
 
-Make non-uniform rebinning work for Weight() and friends [#972][]
+#### Bug fixes
+
+- Make non-uniform rebinning work for Weight() and friends [#972][]
 
 [#972]: https://github.com/scikit-hep/boost-histogram/pull/972
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "numpy",
     "setuptools_scm",
     "typer",
+    "uhi",
 ]
 docs = [
     "ipython",
@@ -112,13 +113,11 @@ sdist.exclude = [
   "extern/*/README.md",
 ]
 
-
 [[tool.scikit-build.generate]]
 path = "boost_histogram/version.py"
 template = '''
 __version__ = version = "$version"
 '''
-
 
 [tool.setuptools_scm]
 

--- a/src/boost_histogram/tag.py
+++ b/src/boost_histogram/tag.py
@@ -158,6 +158,15 @@ class rebin:
                 break
         return return_str
 
+    # Note: this preserves the input type of `self.axis`, so is safe within a
+    # single UHI library, but not cross-library. Returns None for the axis if
+    # an axis is not provided, the caller should make an axis if that's the
+    # case.
+    def axis_mapping(
+        self, axis: PlottableAxis
+    ) -> tuple[Sequence[int], PlottableAxis | None]:
+        return (self.group_mapping(axis), self.axis)
+
     def group_mapping(self, axis: PlottableAxis) -> Sequence[int]:
         if self.groups is not None:
             if sum(self.groups) != len(axis):

--- a/src/boost_histogram/typing.py
+++ b/src/boost_histogram/typing.py
@@ -4,9 +4,11 @@ from typing import TYPE_CHECKING, Any, Protocol, Tuple, Union
 
 if TYPE_CHECKING:
     from builtins import ellipsis
+    from collections.abc import Sequence
 
     from numpy import ufunc as Ufunc
     from numpy.typing import ArrayLike
+    from uhi.typing.plottable import PlottableAxis
 
     from boost_histogram._core.accumulators import Mean, WeightedMean, WeightedSum
     from boost_histogram._core.hist import _BaseHistogram as CppHistogram
@@ -23,6 +25,7 @@ __all__ = (
     "ArrayLike",
     "AxisLike",
     "CppHistogram",
+    "RebinProtocol",
     "StdIndex",
     "StrIndex",
     "Ufunc",
@@ -39,3 +42,9 @@ StdIndex = Union[int, slice, "ellipsis", Tuple[Union[slice, int, "ellipsis"], ..
 StrIndex = Union[
     int, slice, str, "ellipsis", Tuple[Union[slice, int, str, "ellipsis"], ...]
 ]
+
+
+class RebinProtocol(Protocol):
+    def axis_mapping(
+        self, axis: PlottableAxis
+    ) -> tuple[Sequence[int], PlottableAxis | None]: ...

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -653,10 +653,12 @@ def test_rebin_1d(metadata):
     hs = h[bh.rebin(edges=[1.0, 1.2, 1.6, 2.2, 5.0])]
     assert_array_equal(hs.view(), [1, 0, 0, 3])
     assert_array_equal(hs.axes.edges[0], [1.0, 1.2, 1.6, 2.2, 5.0])
+    assert h.axes[0].metadata is hs.axes[0].metadata
 
-    hs = h[bh.rebin(axis=bh.axis.Variable([1.0, 1.2, 1.6, 2.2, 5.0]))]
+    hs = h[bh.rebin(axis=bh.axis.Variable([1.0, 1.2, 1.6, 2.2, 5.0], metadata="hi"))]
     assert_array_equal(hs.view(), [1, 0, 0, 3])
     assert_array_equal(hs.axes.edges[0], [1.0, 1.2, 1.6, 2.2, 5.0])
+    assert hs.axes[0].metadata == "hi"
 
 
 def test_rebin_1d_flow():
@@ -667,15 +669,23 @@ def test_rebin_1d_flow():
     assert_array_equal(hs.view(flow=True), [1, 2, 2, 1])
     assert_array_equal(hs.axes.edges[0], [0.0, 3.0, 5.0])
 
+    # Flow bins are kept from the original
     h = bh.Histogram(bh.axis.Regular(5, 0, 5, underflow=False, overflow=False))
     h.fill([-1, 1.1, 2.2, 3.3, 4.4, 5.5])
     hs = h[bh.rebin(edges=[0, 3, 5.0])]
-    assert_array_equal(hs.view(flow=True), [0, 2, 2, 0])
+    assert_array_equal(hs.view(flow=True), [2, 2])
 
     h = bh.Histogram(bh.axis.Regular(5, 0, 5, underflow=True, overflow=False))
     h.fill([-1, 1.1, 2.2, 3.3, 4.4, 5.5])
     hs = h[bh.rebin(edges=[0, 3, 5.0])]
-    assert_array_equal(hs.view(flow=True), [1, 2, 2, 0])
+    assert_array_equal(hs.view(flow=True), [1, 2, 2])
+
+    h = bh.Histogram(bh.axis.Regular(5, 0, 5, underflow=True, overflow=True))
+    h.fill([-1, 1.1, 2.2, 3.3, 4.4, 5.5])
+    hs = h[
+        bh.rebin(axis=bh.axis.Variable([0, 3, 5.0], underflow=False, overflow=False))
+    ]
+    assert_array_equal(hs.view(flow=True), [2, 2])
 
 
 def test_shrink_rebin_1d():


### PR DESCRIPTION
Followup to #977. Uses the new axes if one is provided.

I wonder if we should allow axis + other args, if someone wants to use a new axis with a custom mapping?

We'll have to work out the correct mapping for flow bins for the four cases.
