### PR TITLE
chore: bump scikit-build-core to 0.11

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -19,12 +19,17 @@ def dependency_groups(pyproject: dict[str, Any], *names: str) -> list[str]:
     return [item for name in names for item in _get_group(name, groups)]
 
 
+@nox.session
 def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
+    opts = (
+        ["--reinstall-package=boost-histogram"] if session.venv_backend == "uv" else []
+    )
     pyproject = nox.project.load_toml("pyproject.toml")
-    session.install(".", *dependency_groups(pyproject, "test"))
+    session.install(*dependency_groups(pyproject, "test"))
+    session.install("-v", ".", *opts, silent=False)
     session.run("pytest", *session.posargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11>=2.13.3"]
+requires = ["scikit-build-core>=0.11", "pybind11>=2.13.3"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/src/boost_histogram/view.py
+++ b/src/boost_histogram/view.py
@@ -38,7 +38,7 @@ class View(np.ndarray):  # type: ignore[type-arg]
         my_fields = ", ".join(self._FIELDS)
         return f"{self.__class__.__name__}: ({my_fields})\n{self.view(np.ndarray)}"
 
-    def __setitem__(self, ind: StrIndex, value: ArrayLike) -> None:
+    def __setitem__(self, ind: StrIndex, value: ArrayLike) -> None:  # type: ignore[override]
         # `.value` really is ["value"] for an record array
         if isinstance(ind, str):
             super().__setitem__(ind, value)


### PR DESCRIPTION
Bumping to 0.11, including METADATA 2.2.
