### PR TITLE
ci: use uv pip install --group in rtd

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,8 +13,9 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - touch extern/histogram/LICENSE
-    - uv run --only-group docs sphinx-build -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+    - uv venv
+    - uv pip install --group docs
+    - .venv/bin/sphinx-build -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 
 submodules:
   exclude: all


### PR DESCRIPTION
This was added in 0.6.7.
