### PR TITLE
fix: use simple function pointer to avoid potential PyCapsule change in pybind11

### DIFF
--- a/src/boost_histogram/axis/transform.py
+++ b/src/boost_histogram/axis/transform.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import copy
+import ctypes
 from typing import Any, ClassVar, TypeVar
 
 import boost_histogram
 
+from .. import _core
 from .._core import axis as ca
 from .._utils import register
 
 T = TypeVar("T", bound="AxisTransform")
 
 __all__ = ["AxisTransform", "Function", "Pow", "log", "sqrt"]
+
+LIB = ctypes.CDLL(_core.__file__)
 
 
 def __dir__() -> list[str]:
@@ -150,7 +154,8 @@ class Function(AxisTransform, family=boost_histogram):
 
 
 def _internal_conversion(name: str) -> Any:
-    return getattr(ca.transform, name)
+    ftype = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double)
+    return ctypes.cast(getattr(LIB, name), ftype)
 
 
 sqrt = Function("_sqrt_fn", "_sq_fn", convert=_internal_conversion, name="sqrt")

--- a/src/register_transforms.cpp
+++ b/src/register_transforms.cpp
@@ -32,10 +32,10 @@ py::class_<T> register_transform(py::module& mod, Args&&... args) {
 }
 
 extern "C" {
-double _log_fn(double v) { return std::log(v); }
-double _exp_fn(double v) { return std::exp(v); }
-double _sqrt_fn(double v) { return std::sqrt(v); }
-double _sq_fn(double v) { return v * v; }
+PYBIND11_EXPORT double _log_fn(double v) { return std::log(v); }
+PYBIND11_EXPORT double _exp_fn(double v) { return std::exp(v); }
+PYBIND11_EXPORT double _sqrt_fn(double v) { return std::sqrt(v); }
+PYBIND11_EXPORT double _sq_fn(double v) { return v * v; }
 }
 
 void register_transforms(py::module& mod) {


### PR DESCRIPTION
Using a simple function pointer instead of a Pybind11 object. Let's see if this works everywhere, like Wasm. Also need to make sure picked histograms with transforms still work. Due to the transform function changing, I think they do.

https://github.com/pybind/pybind11/pull/5580
