### PR TITLE
fix: Account for fuzzy edge values in rebinning with edges

### DIFF
--- a/src/boost_histogram/tag.py
+++ b/src/boost_histogram/tag.py
@@ -192,15 +192,14 @@ class rebin:
                     msg = "Edges must end at last bin"
                     raise ValueError(msg)
                 matched_ixes = [np.abs(axis.edges - edge).argmin() for edge in newedges]
-                all_close = all(
-                    np.isclose(
-                        axis.edges[ix],
-                        edge,
-                    )
+                missing_edges = [
+                    edge
                     for ix, edge in zip(matched_ixes, newedges)
-                )
-                if not all_close:
-                    msg = "Edges must be in the axis"
+                    if not np.isclose(axis.edges[ix], edge)
+                ]
+                if missing_edges:
+                    missing_edges_repr = ", ".join(map(str, missing_edges))
+                    msg = f"Edge(s) {missing_edges_repr} not found in axis"
                     raise ValueError(msg)
                 return [
                     int(ix - matched_ixes[i]) for i, ix in enumerate(matched_ixes[1:])

--- a/src/boost_histogram/tag.py
+++ b/src/boost_histogram/tag.py
@@ -185,21 +185,23 @@ class rebin:
                 newedges = self.axis.edges
 
             if newedges is not None and hasattr(axis, "edges"):
-                assert newedges[0] == axis.edges[0], "Edges must start at first bin"
-                assert newedges[-1] == axis.edges[-1], "Edges must end at last bin"
-                assert all(
+                if newedges[0] != axis.edges[0]:
+                    msg = "Edges must start at first bin"
+                    raise ValueError(msg)
+                if newedges[-1] != axis.edges[-1]:
+                    msg = "Edges must end at last bin"
+                    raise ValueError(msg)
+                matched_ixes = [np.abs(axis.edges - edge).argmin() for edge in newedges]
+                all_close = all(
                     np.isclose(
-                        axis.edges[np.abs(axis.edges - edge).argmin()],
+                        axis.edges[ix],
                         edge,
                     )
-                    for edge in newedges
-                ), "Edges must be in the axis"
-                matched_ixes = np.where(
-                    np.isin(
-                        axis.edges,
-                        newedges,
-                    )
-                )[0]
+                    for ix, edge in zip(matched_ixes, newedges)
+                )
+                if not all_close:
+                    msg = "Edges must be in the axis"
+                    raise ValueError(msg)
                 return [
                     int(ix - matched_ixes[i]) for i, ix in enumerate(matched_ixes[1:])
                 ]

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -655,6 +655,12 @@ def test_rebin_1d(metadata):
     assert_array_equal(hs.axes.edges[0], [1.0, 1.2, 1.6, 2.2, 5.0])
     assert h.axes[0].metadata is hs.axes[0].metadata
 
+    fuzzy_edges = [1.0, 1.200000000000001, 1.6, 2.2, 5.0]
+    hs = h[bh.rebin(edges=fuzzy_edges)]
+    assert_array_equal(hs.view(), [1, 0, 0, 3])
+    assert_array_equal(hs.axes.edges[0], fuzzy_edges)
+    assert h.axes[0].metadata is hs.axes[0].metadata
+
     hs = h[bh.rebin(axis=bh.axis.Variable([1.0, 1.2, 1.6, 2.2, 5.0], metadata="hi"))]
     assert_array_equal(hs.view(), [1, 0, 0, 3])
     assert_array_equal(hs.axes.edges[0], [1.0, 1.2, 1.6, 2.2, 5.0])

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -650,15 +650,16 @@ def test_rebin_1d(metadata):
     assert_array_equal(hs.axes.edges[0], [1.0, 1.2, 1.6, 2.2, 5.0])
     assert h.axes[0].metadata is hs.axes[0].metadata
 
-    hs = h[bh.rebin(edges=[1.0, 1.2, 1.6, 2.2, 5.0])]
+    exact_edges = [1.0, 1.2, 1.6, 2.2, 5.0]
+    hs = h[bh.rebin(edges=exact_edges)]
     assert_array_equal(hs.view(), [1, 0, 0, 3])
-    assert_array_equal(hs.axes.edges[0], [1.0, 1.2, 1.6, 2.2, 5.0])
+    assert_array_equal(hs.axes.edges[0], exact_edges)
     assert h.axes[0].metadata is hs.axes[0].metadata
 
     fuzzy_edges = [1.0, 1.200000000000001, 1.6, 2.2, 5.0]
     hs = h[bh.rebin(edges=fuzzy_edges)]
     assert_array_equal(hs.view(), [1, 0, 0, 3])
-    assert_array_equal(hs.axes.edges[0], fuzzy_edges)
+    assert_array_equal(hs.axes.edges[0], exact_edges)
     assert h.axes[0].metadata is hs.axes[0].metadata
 
     hs = h[bh.rebin(axis=bh.axis.Variable([1.0, 1.2, 1.6, 2.2, 5.0], metadata="hi"))]


### PR DESCRIPTION
This PR fixes the rebinning of axes given a sequence of new edges that was recently added by #977.

# Background

We recently discovered the new rebinning feature that only requires new edges values rather than bin count "groups", which is great! It requires that the requested edges *coincide* (that's where the problem is) with old ones so that bin content merging is logically unambiguous. However, we ran into an edge case where a single, new edge value is subject to float precision effects (e.g. `1.200000000000001`).

# The issue

Currently, this causes a bug in that the newly computed edges are missing an entry, resulting in axes dropping a bin. I extended the `test_rebin_1d` test case to use a fuzzy edge value, showing that the assertion in

https://github.com/scikit-hep/boost-histogram/blob/fdfdae17926ab8b760323e822521aa58d0666b05/src/boost_histogram/tag.py#L190-L202

passes due to `np.isclose`, but the subsequent index lookup via an exact `np.isin` fails: N edges were requested, but the rebinned axis only has N - 1.

# Fix

I already prepared and tested a working fix,

```python
matched_ixes = [np.abs(axis.edges - edge).argmin() for edge in newedges]
assert all(
    np.isclose(
        axis.edges[ix],
        edge,
    )
    for ix, edge in zip(matched_ixes, newedges)
), "Edges must be in the axis"
```

essentially storing the argmin results, doing the assertion, and then computing new edges with them.

If you agree, I can add the commit to this PR, but I thought it might be easier to run the test case and see that it indeed fails where it should/shouldn't.
