### PR TITLE
fix: setting a range with a scalar

### DIFF
--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -1157,12 +1157,8 @@ class Histogram:
                 request_len = stop - start
 
                 # If set to a scalar, then treat it like broadcasting without flow bins
-                if value_ndim == 0:
-                    start = 0 + has_overflow
-                    stop = len(self.axes[n]) + has_underflow
-
-                # Normal setting
-                elif request_len == value_shape[value_n]:
+                # Normal requests here too
+                if value_ndim == 0 or request_len == value_shape[value_n]:
                     start += has_underflow
                     stop += has_underflow
 

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -284,6 +284,26 @@ def test_singleflow_slicing():
     assert_array_equal(h[1 : 3 : bh.sum, :], vals[1:3, :].sum(axis=0))
 
 
+def test_set_range_with_scalar():
+    h = bh.Histogram(bh.axis.Integer(0, 10))
+    h[2:5] = 42
+
+    assert h[1] == 0
+    assert h[2] == 42
+    assert h[3] == 42
+    assert h[4] == 42
+    assert h[5] == 0
+
+
+def test_set_all_with_scalar():
+    h = bh.Histogram(bh.axis.Integer(0, 10))
+    h[:] = 42
+
+    assert h[0] == 42
+    assert h[9] == 42
+    assert h[::sum] == 42 * 10
+
+
 def test_pick_str_category():
     noflow = {"underflow": False, "overflow": False}
 


### PR DESCRIPTION
Fix an issue found in https://github.com/scikit-hep/uhi/pull/150; setting a range with a scalar disregards the range.
