### PR TITLE
chore: performance clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@ Checks: "
   modernize-*,
   readability-*,
   bugprone-*,
+  performance-*,
   -bugprone-easily-swappable-parameters,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-arrays,

--- a/include/bh_python/array_like.hpp
+++ b/include/bh_python/array_like.hpp
@@ -12,7 +12,7 @@
 
 /// Generate empty array with same shape and strides as argument
 template <class T>
-py::array_t<T> array_like(py::object obj) {
+py::array_t<T> array_like(const py::object& obj) {
     if(!py::isinstance<py::array>(obj)) {
         py::ssize_t shape[1] = {0}; // if scalar
         if(py::isinstance<py::sequence>(obj) && !py::isinstance<py::str>(obj)) {

--- a/include/bh_python/fill.hpp
+++ b/include/bh_python/fill.hpp
@@ -215,7 +215,7 @@ void fill_impl(bh::detail::accumulator_traits_holder<true, const double&>,
 } // namespace detail
 
 template <class Histogram>
-Histogram& fill(Histogram& self, py::args args, py::kwargs kwargs) {
+Histogram& fill(Histogram& self, const py::args& args, py::kwargs kwargs) {
     using value_type = typename Histogram::value_type;
     detail::fill_impl(bh::detail::accumulator_traits<value_type>{},
                       self,

--- a/include/bh_python/make_pickle.hpp
+++ b/include/bh_python/make_pickle.hpp
@@ -375,7 +375,7 @@ decltype(auto) make_pickle() {
             oa << obj;
             return tup;
         },
-        [](py::tuple tup) {
+        [](const py::tuple& tup) {
             tuple_iarchive ia{tup};
             T obj;
             ia >> obj;

--- a/include/bh_python/register_accumulator.hpp
+++ b/include/bh_python/register_accumulator.hpp
@@ -30,7 +30,7 @@ std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>&
 
 template <class A, class... Args>
 py::class_<A> register_accumulator(py::module acc, Args&&... args) {
-    return py::class_<A>(acc, std::forward<Args>(args)...)
+    return py::class_<A>(std::move(acc), std::forward<Args>(args)...)
         .def(py::init<>())
 
         .def(py::self += py::self)
@@ -62,14 +62,14 @@ py::class_<A> register_accumulator(py::module acc, Args&&... args) {
 
         // The c++ name is replaced with the Python name here
         .def("__repr__",
-             [](py::object self) {
+             [](const py::object& self) {
                  const A& item = py::cast<const A&>(self);
                  py::str str   = shift_to_string(item);
                  return py::str("{0.__class__.__name__}({1})").format(self, str);
              })
 
         .def("__copy__", [](const A& self) { return A(self); })
-        .def("__deepcopy__", [](const A& self, py::object) { return A(self); })
+        .def("__deepcopy__", [](const A& self, const py::object&) { return A(self); })
 
         .def(make_pickle<A>());
 }

--- a/include/bh_python/register_axis.hpp
+++ b/include/bh_python/register_axis.hpp
@@ -72,7 +72,7 @@ template <class T, class Options>
 auto vectorize_index(int (bh::axis::category<T, metadata_t, Options>::*pindex)(const T&)
                          const BHP_NOEXCEPT_17) {
     return [pindex](const bh::axis::category<T, metadata_t, Options>& self,
-                    py::object arg) -> py::object {
+                    const py::object& arg) -> py::object {
         auto index = std::mem_fn(pindex);
 
         if(detail::is_value<T>(arg)) {
@@ -107,7 +107,7 @@ template <class R, class U, class Options>
 auto vectorize_value(R (bh::axis::category<U, metadata_t, Options>::*pvalue)(int)
                          const) {
     return [pvalue](const bh::axis::category<U, metadata_t, Options>& self,
-                    py::object arg) -> py::object {
+                    const py::object& arg) -> py::object {
         auto value = std::mem_fn(pvalue);
 
         if(detail::is_value<int>(arg)) {
@@ -206,7 +206,7 @@ py::class_<A> register_axis(py::module& m, Args&&... args) {
 
         .def("__copy__", [](const A& self) { return A(self); })
         .def("__deepcopy__",
-             [](const A& self, py::object memo) {
+             [](const A& self, const py::object& memo) {
                  A* a            = new A(self);
                  py::module copy = py::module::import("copy");
                  a->metadata()   = copy.attr("deepcopy")(a->metadata(), memo);

--- a/include/bh_python/register_histogram.hpp
+++ b/include/bh_python/register_histogram.hpp
@@ -48,7 +48,7 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
 
         .def("__copy__", [](const histogram_t& self) { return histogram_t(self); })
         .def("__deepcopy__",
-             [](const histogram_t& self, py::object memo) {
+             [](const histogram_t& self, const py::object& memo) {
                  auto* a         = new histogram_t(self);
                  py::module copy = py::module::import("copy");
                  for(unsigned i = 0; i < a->rank(); i++) {
@@ -79,7 +79,7 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
 
         .def_property_readonly_static(
             "_storage_type",
-            [](py::object) {
+            [](const py::object&) {
                 return py::type::of<typename histogram_t::storage_type>();
             })
 
@@ -123,7 +123,7 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
 
         .def(
             "view",
-            [](py::object self, bool flow) {
+            [](const py::object& self, bool flow) {
                 auto& h = py::cast<histogram_t&>(self);
                 return py::array(make_buffer(h, flow), self);
             },
@@ -186,7 +186,7 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
             "flow"_a = false)
 
         .def("reduce",
-             [](const histogram_t& self, py::args args) {
+             [](const histogram_t& self, const py::args& args) {
                  auto commands
                      = py::cast<std::vector<bh::algorithm::reduce_command>>(args);
                  py::gil_scoped_release release;
@@ -194,7 +194,7 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
              })
 
         .def("project",
-             [](const histogram_t& self, py::args values) {
+             [](const histogram_t& self, const py::args& values) {
                  auto cpp_values = py::cast<std::vector<unsigned>>(values);
                  py::gil_scoped_release release;
                  return bh::algorithm::project(self, cpp_values);

--- a/include/bh_python/register_storage.hpp
+++ b/include/bh_python/register_storage.hpp
@@ -34,7 +34,7 @@ py::class_<A> register_storage(py::module& m, const char* name, const char* desc
              })
         .def(make_pickle<A>())
         .def("__copy__", [](const A& self) { return A(self); })
-        .def("__deepcopy__", [](const A& self, py::object) { return A(self); });
+        .def("__deepcopy__", [](const A& self, const py::object&) { return A(self); });
 
     return storage;
 }
@@ -66,7 +66,7 @@ register_storage(py::module& m, const char* name, const char* desc) {
              })
         .def(make_pickle<A>())
         .def("__copy__", [](const A& self) { return A(self); })
-        .def("__deepcopy__", [](const A& self, py::object) { return A(self); });
+        .def("__deepcopy__", [](const A& self, const py::object&) { return A(self); });
 
     return storage;
 }

--- a/include/bh_python/regular_numpy.hpp
+++ b/include/bh_python/regular_numpy.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/core/nvp.hpp>
 #include <boost/histogram/axis/regular.hpp>
+#include <utility>
 
 namespace bh = boost::histogram;
 
@@ -23,7 +24,7 @@ class regular_numpy : public bh::axis::regular<double, bh::use_default, metadata
 
   public:
     regular_numpy(unsigned n, value_type start, value_type stop, metadata_t meta = {})
-        : regular(n, start, stop, meta)
+        : regular(n, start, stop, std::move(meta))
         , stop_(stop) {}
 
     regular_numpy(const regular_numpy& a, index_type i, index_type j, unsigned n)

--- a/include/bh_python/storage.hpp
+++ b/include/bh_python/storage.hpp
@@ -196,7 +196,7 @@ struct type_caster<storage::atomic_int64::value_type> {
         return PyErr_Occurred() == nullptr;
     }
 
-    static handle cast(storage::atomic_int64::value_type src,
+    static handle cast(const storage::atomic_int64::value_type& src,
                        return_value_policy /* policy */,
                        handle /* parent */) {
         return PyLong_FromLongLong(src.value());

--- a/include/bh_python/transform.hpp
+++ b/include/bh_python/transform.hpp
@@ -54,7 +54,7 @@ struct func_transform {
             // ctypes.cast(in, ctypes.c_void_p).value
             py::object addr_obj = cast(src, c_void_p);
             auto addr           = py::cast<std::uintptr_t>(addr_obj.attr("value"));
-            auto ptr            = reinterpret_cast<raw_t*>(addr);
+            auto ptr            = reinterpret_cast<raw_t*>(addr);  // NOLINT(performance-no-int-to-ptr)
             return std::make_tuple(ptr, src);
         }
 
@@ -134,7 +134,7 @@ inline const char* axis_suffix(const ::func_transform&) { return "_trans"; }
 
 /// Simple deep copy for any class *without* a python component
 template <class T>
-T deep_copy(const T& input, py::object) {
+T deep_copy(const T& input, py::object&) {
     return T(input);
 }
 
@@ -142,7 +142,7 @@ T deep_copy(const T& input, py::object) {
 /// (Function transform in this case)
 template <>
 inline func_transform deep_copy<func_transform>(const func_transform& input,
-                                                py::object memo) {
+                                                py::object& memo) {
     py::module copy = py::module::import("copy");
 
     py::object forward = copy.attr("deepcopy")(input._forward_ob, memo);

--- a/include/bh_python/transform.hpp
+++ b/include/bh_python/transform.hpp
@@ -54,7 +54,8 @@ struct func_transform {
             // ctypes.cast(in, ctypes.c_void_p).value
             py::object addr_obj = cast(src, c_void_p);
             auto addr           = py::cast<std::uintptr_t>(addr_obj.attr("value"));
-            auto ptr            = reinterpret_cast<raw_t*>(addr);  // NOLINT(performance-no-int-to-ptr)
+            auto ptr
+                = reinterpret_cast<raw_t*>(addr); // NOLINT(performance-no-int-to-ptr)
             return std::make_tuple(ptr, src);
         }
 

--- a/include/bh_python/vector_string_caster.hpp
+++ b/include/bh_python/vector_string_caster.hpp
@@ -38,7 +38,7 @@ struct type_caster<std::vector<std::string>>
         return n;
     }
 
-    bool load_from_array_s(array src) {
+    bool load_from_array_s(const array& src) {
         const auto step = static_cast<std::size_t>(src.itemsize());
         const auto size = static_cast<std::size_t>(src.size());
         const auto* p   = static_cast<const char*>(src.data());
@@ -49,7 +49,7 @@ struct type_caster<std::vector<std::string>>
         return true;
     }
 
-    bool load_from_array_u(array src) {
+    bool load_from_array_u(const array& src) {
         const auto step
             = static_cast<std::size_t>(src.itemsize()) / sizeof(std::uint32_t);
         const auto size = static_cast<std::size_t>(src.size());

--- a/src/register_accumulators.cpp
+++ b/src/register_accumulators.cpp
@@ -17,7 +17,7 @@
 /// The mean fill can be implemented once. (sum fill varies slightly)
 template <class T>
 decltype(auto) make_mean_fill() {
-    return [](T& self, py::object value, py::object weight) {
+    return [](T& self, const py::object& value, const py::object& weight) {
         if(weight.is_none()) {
             py::vectorize([](T& self, double val) { self(val); })(self, value);
         } else {
@@ -32,7 +32,7 @@ decltype(auto) make_mean_fill() {
 /// The mean call can be implemented once. (sum uses +=)
 template <class T>
 decltype(auto) make_mean_call() {
-    return [](T& self, double value, py::object weight) {
+    return [](T& self, double value, const py::object& weight) {
         if(weight.is_none())
             self(value);
         else
@@ -87,7 +87,7 @@ void register_accumulators(py::module& accumulators) {
 
         .def(
             "fill",
-            [](weighted_sum& self, py::object value, py::object variance) {
+            [](weighted_sum& self, const py::object& value, const py::object& variance) {
                 if(variance.is_none()) {
                     py::vectorize([](weighted_sum& self, double val) {
                         self += bh::weight(val);
@@ -115,7 +115,7 @@ void register_accumulators(py::module& accumulators) {
                     }))
 
         .def("__getitem__",
-             [](const weighted_sum& self, py::str key) {
+             [](const weighted_sum& self, const py::str& key) {
                  if(key.equal(py::str("value")))
                      return self.value;
                  if(key.equal(py::str("variance")))
@@ -124,7 +124,7 @@ void register_accumulators(py::module& accumulators) {
                      py::str("{0} not one of value, variance").format(key));
              })
         .def("__setitem__",
-             [](weighted_sum& self, py::str key, double value) {
+             [](weighted_sum& self, const py::str& key, double value) {
                  if(key.equal(py::str("value")))
                      self.value = value;
                  else if(key.equal(py::str("variance")))
@@ -135,7 +135,7 @@ void register_accumulators(py::module& accumulators) {
              })
 
         .def("_ipython_key_completions_",
-             [](py::object /* self */) { return py::make_tuple("value", "variance"); })
+             [](const py::object& /* self */) { return py::make_tuple("value", "variance"); })
 
         ;
 
@@ -150,7 +150,7 @@ void register_accumulators(py::module& accumulators) {
 
         .def(
             "fill",
-            [](sum& self, py::object value) {
+            [](sum& self, const py::object& value) {
                 py::vectorize([](sum& self, double v) { self += v; })(self, value);
                 return self;
             },
@@ -217,7 +217,7 @@ void register_accumulators(py::module& accumulators) {
                 }))
 
         .def("__getitem__",
-             [](const weighted_mean& self, py::str key) {
+             [](const weighted_mean& self, const py::str& key) {
                  if(key.equal(py::str("value")))
                      return self.value;
                  if(key.equal(py::str("sum_of_weights")))
@@ -232,7 +232,7 @@ void register_accumulators(py::module& accumulators) {
                          .format(key));
              })
         .def("__setitem__",
-             [](weighted_mean& self, py::str key, double value) {
+             [](weighted_mean& self, const py::str& key, double value) {
                  if(key.equal(py::str("value")))
                      self.value = value;
                  else if(key.equal(py::str("sum_of_weights")))
@@ -250,7 +250,7 @@ void register_accumulators(py::module& accumulators) {
              })
 
         .def("_ipython_key_completions_",
-             [](py::object /* self */) {
+             [](const py::object& /* self */) {
                  return py::make_tuple("value",
                                        "sum_of_weights",
                                        "sum_of_weights_squared",
@@ -303,7 +303,7 @@ void register_accumulators(py::module& accumulators) {
             }))
 
         .def("__getitem__",
-             [](const mean& self, py::str key) {
+             [](const mean& self, const py::str& key) {
                  if(key.equal(py::str("count")))
                      return self.count;
                  if(key.equal(py::str("value")))
@@ -315,7 +315,7 @@ void register_accumulators(py::module& accumulators) {
                          .format(key));
              })
         .def("__setitem__",
-             [](mean& self, py::str key, double value) {
+             [](mean& self, const py::str& key, double value) {
                  if(key.equal(py::str("count")))
                      self.count = value;
                  else if(key.equal(py::str("value")))
@@ -329,7 +329,7 @@ void register_accumulators(py::module& accumulators) {
              })
 
         .def("_ipython_key_completions_",
-             [](py::object /* self */) {
+             [](const py::object& /* self */) {
                  return py::make_tuple("count", "value", "_sum_of_deltas_squared");
              })
 

--- a/src/register_accumulators.cpp
+++ b/src/register_accumulators.cpp
@@ -87,7 +87,9 @@ void register_accumulators(py::module& accumulators) {
 
         .def(
             "fill",
-            [](weighted_sum& self, const py::object& value, const py::object& variance) {
+            [](weighted_sum& self,
+               const py::object& value,
+               const py::object& variance) {
                 if(variance.is_none()) {
                     py::vectorize([](weighted_sum& self, double val) {
                         self += bh::weight(val);
@@ -135,7 +137,9 @@ void register_accumulators(py::module& accumulators) {
              })
 
         .def("_ipython_key_completions_",
-             [](const py::object& /* self */) { return py::make_tuple("value", "variance"); })
+             [](const py::object& /* self */) {
+                 return py::make_tuple("value", "variance");
+             })
 
         ;
 

--- a/src/register_transforms.cpp
+++ b/src/register_transforms.cpp
@@ -47,7 +47,7 @@ void register_transforms(py::module& mod) {
     register_transform<bh::axis::transform::id>(mod, "id")
         .def(py::init<>())
         .def("__repr__",
-             [](py::object self) {
+             [](const py::object& self) {
                  return py::str("{}()").format(self.attr("__class__").attr("__name__"));
              })
 
@@ -56,7 +56,7 @@ void register_transforms(py::module& mod) {
     register_transform<bh::axis::transform::sqrt>(mod, "sqrt")
         .def(py::init<>())
         .def("__repr__",
-             [](py::object self) {
+             [](const py::object& self) {
                  return py::str("{}()").format(self.attr("__class__").attr("__name__"));
              })
 
@@ -65,7 +65,7 @@ void register_transforms(py::module& mod) {
     register_transform<bh::axis::transform::log>(mod, "log")
         .def(py::init<>())
         .def("__repr__",
-             [](py::object self) {
+             [](const py::object& self) {
                  return py::str("{}()").format(self.attr("__class__").attr("__name__"));
              })
 
@@ -75,7 +75,7 @@ void register_transforms(py::module& mod) {
         .def(py::init<double>(), "power"_a)
         .def_readonly("power", &bh::axis::transform::pow::power)
         .def("__repr__",
-             [](py::object self) {
+             [](const py::object& self) {
                  double power = py::cast<bh::axis::transform::pow>(self).power;
                  return py::str("{}({:g})")
                      .format(self.attr("__class__").attr("__name__"), power);
@@ -90,7 +90,7 @@ void register_transforms(py::module& mod) {
              "convert"_a,
              "name"_a)
         .def("__repr__",
-             [](py::object self) {
+             [](const py::object& self) {
                  auto& s = py::cast<func_transform&>(self);
                  if(s._name.equal(py::str(""))) {
                      return py::str("{}({}, {})")


### PR DESCRIPTION
This reduces the number of refcount changes we make by quite a bit - should be especially nice on free-threaded Python. :)
