### PR TITLE
chore: bump cibw & pybind11

### DIFF
--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -24,7 +24,7 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - uses: pypa/cibuildwheel@v3.0.0rc3
+      - uses: pypa/cibuildwheel@v3.0
         env:
           CIBW_PLATFORM: pyodide
 

--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -24,7 +24,7 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - uses: pypa/cibuildwheel@v3.0.0b5
+      - uses: pypa/cibuildwheel@v3.0.0rc3
         env:
           CIBW_PLATFORM: pyodide
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: pypa/cibuildwheel@v3.0.0rc3
+      - uses: pypa/cibuildwheel@v3.0
         with:
           only: "${{ matrix.only }}"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: pypa/cibuildwheel@v3.0.0b5
+      - uses: pypa/cibuildwheel@v3.0.0rc3
         with:
           only: "${{ matrix.only }}"
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -145,32 +145,32 @@ jobs:
           path: wheelhouse/*.whl
           name: wheels-ios-${{ matrix.runs-on }}
 
-#  build_android_wheels:
-#    name: Android ${{ matrix.runs-on }}
-#    runs-on: ${{ matrix.runs-on }}
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        runs-on: [ubuntu-latest, macos-latest]
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          fetch-depth: 0
-#          submodules: true
-#
-#      - uses: mhsmith/cibuildwheel@android
-#        env:
-#          CIBW_PLATFORM: android
-#
-#      - name: Verify clean directory
-#        run: git diff --exit-code
-#        shell: bash
-#
-#      - name: Upload wheels
-#        uses: actions/upload-artifact@v4
-#        with:
-#          path: wheelhouse/*.whl
-#          name: wheels-android-${{ matrix.runs-on }}
+  #  build_android_wheels:
+  #    name: Android ${{ matrix.runs-on }}
+  #    runs-on: ${{ matrix.runs-on }}
+  #    strategy:
+  #      fail-fast: false
+  #      matrix:
+  #        runs-on: [ubuntu-latest, macos-latest]
+  #    steps:
+  #      - uses: actions/checkout@v4
+  #        with:
+  #          fetch-depth: 0
+  #          submodules: true
+  #
+  #      - uses: mhsmith/cibuildwheel@android
+  #        env:
+  #          CIBW_PLATFORM: android
+  #
+  #      - name: Verify clean directory
+  #        run: git diff --exit-code
+  #        shell: bash
+  #
+  #      - name: Upload wheels
+  #        uses: actions/upload-artifact@v4
+  #        with:
+  #          path: wheelhouse/*.whl
+  #          name: wheels-android-${{ matrix.runs-on }}
 
   upload_all:
     name: Upload if release

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -100,7 +100,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: pypa/cibuildwheel@v3.0.0rc2
+      - uses: pypa/cibuildwheel@v3.0.0rc3
         env:
           CIBW_BUILD: ${{ matrix.build }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -131,7 +131,7 @@ jobs:
 
       - run: brew upgrade cmake
 
-      - uses: pypa/cibuildwheel@v3.0.0rc2
+      - uses: pypa/cibuildwheel@v3.0.0rc3
         env:
           CIBW_PLATFORM: ios
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -100,7 +100,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
-      - uses: pypa/cibuildwheel@v3.0.0rc3
+      - uses: pypa/cibuildwheel@v3.0
         env:
           CIBW_BUILD: ${{ matrix.build }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -131,7 +131,7 @@ jobs:
 
       - run: brew upgrade cmake
 
-      - uses: pypa/cibuildwheel@v3.0.0rc3
+      - uses: pypa/cibuildwheel@v3.0
         env:
           CIBW_PLATFORM: ios
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -145,9 +145,36 @@ jobs:
           path: wheelhouse/*.whl
           name: wheels-ios-${{ matrix.runs-on }}
 
+  build_android_wheels:
+    name: Android ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - uses: mhsmith/cibuildwheel@android
+        env:
+          CIBW_PLATFORM: android
+
+      - name: Verify clean directory
+        run: git diff --exit-code
+        shell: bash
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          path: wheelhouse/*.whl
+          name: wheels-android-${{ matrix.runs-on }}
+
   upload_all:
     name: Upload if release
-    needs: [build_wheels, build_ios_wheels, build_sdist]
+    needs: [build_wheels, build_ios_wheels, build_android_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     environment:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -145,36 +145,36 @@ jobs:
           path: wheelhouse/*.whl
           name: wheels-ios-${{ matrix.runs-on }}
 
-  build_android_wheels:
-    name: Android ${{ matrix.runs-on }}
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on: [ubuntu-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
-
-      - uses: mhsmith/cibuildwheel@android
-        env:
-          CIBW_PLATFORM: android
-
-      - name: Verify clean directory
-        run: git diff --exit-code
-        shell: bash
-
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          path: wheelhouse/*.whl
-          name: wheels-android-${{ matrix.runs-on }}
+#  build_android_wheels:
+#    name: Android ${{ matrix.runs-on }}
+#    runs-on: ${{ matrix.runs-on }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        runs-on: [ubuntu-latest, macos-latest]
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          fetch-depth: 0
+#          submodules: true
+#
+#      - uses: mhsmith/cibuildwheel@android
+#        env:
+#          CIBW_PLATFORM: android
+#
+#      - name: Verify clean directory
+#        run: git diff --exit-code
+#        shell: bash
+#
+#      - name: Upload wheels
+#        uses: actions/upload-artifact@v4
+#        with:
+#          path: wheelhouse/*.whl
+#          name: wheels-android-${{ matrix.runs-on }}
 
   upload_all:
     name: Upload if release
-    needs: [build_wheels, build_ios_wheels, build_android_wheels, build_sdist]
+    needs: [build_wheels, build_ios_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,16 +222,16 @@ inherit.environment = "append"
 environment.MACOSX_DEPLOYMENT_TARGET = "14.0"
 
 [[tool.cibuildwheel.overrides]]
-select = ["cp314*", "pp311*", "cp*-musllinux_*", "cp31*-win_arm64"]
+select = ["cp314*",]
 inherit.environment = "append"
-environment.UV_EXTRA_INDEX_URL = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
+environment.UV_INDEX = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
 environment.UV_INDEX_STRATEGY = "unsafe-best-match"
 environment.UV_PRERELEASE = "allow"
 
 [[tool.cibuildwheel.overrides]]
 select = ["gp*"]
 inherit.environment = "append"
-environment.UV_EXTRA_INDEX_URL = "https://www.graalvm.org/python/wheels/"
+environment.UV_INDEX = "https://www.graalvm.org/python/wheels/"
 environment.UV_INDEX_STRATEGY = "unsafe-best-match"
 test-command = "pytest --benchmark-disable tests"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,11 +210,11 @@ xbuild-tools = ["cmake", "ninja"]
 test-command = "pytest --benchmark-disable tests"
 environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/beeware/simple/"
 
-[tool.cibuildwheel.android]
-build-frontend = "build"
-xbuild-tools = ["cmake", "ninja"]
-test-command = "pytest --benchmark-disable tests"
-environment.PIP_EXTRA_INDEX_URL = "https://chaquo.com/pypi-13.1"
+# [tool.cibuildwheel.android]
+# build-frontend = "build"
+# xbuild-tools = ["cmake", "ninja"]
+# test-command = "pytest --benchmark-disable tests"
+# environment.PIP_EXTRA_INDEX_URL = "https://chaquo.com/pypi-13.1"
 
 [[tool.cibuildwheel.overrides]]
 select = "pp310-macosx_arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,8 @@ test-core = [
     "cloudpickle",
     "pytest-benchmark",
     "pytest>=6.0",
+    "pytest-benchmark",
+    "pytest>=6.0",
     "numpy",
 ]
 test = [
@@ -186,8 +188,11 @@ test-skip = [
   "pp310-manylinux_aarch64",
   "pp310-macosx_arm64",
   "cp31*-musllinux_*", # Threading test crashes
+  "gp311_242-macosx_x86_64",
+  "gp311_242-manylinux_aarch64",
+  "gp311_242-win*",  # pytest crashes with module 'io' has no attribute '_WindowsConsoleIO'
 ]
-enable = ["cpython-freethreading", "pypy", "cpython-prerelease"]
+enable = ["cpython-freethreading", "pypy", "cpython-prerelease", "graalpy"]
 environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]
 environment.PIP_ONLY_BINARY = "numpy"
 environment.PIP_PREFER_BINARY = "1"
@@ -205,6 +210,12 @@ xbuild-tools = ["cmake", "ninja"]
 test-command = "pytest --benchmark-disable tests"
 environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/beeware/simple/"
 
+[tool.cibuildwheel.android]
+build-frontend = "build"
+xbuild-tools = ["cmake", "ninja"]
+test-command = "pytest --benchmark-disable tests"
+environment.PIP_EXTRA_INDEX_URL = "https://chaquo.com/pypi-13.1"
+
 [[tool.cibuildwheel.overrides]]
 select = "pp310-macosx_arm64"
 inherit.environment = "append"
@@ -216,6 +227,13 @@ inherit.environment = "append"
 environment.UV_EXTRA_INDEX_URL = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
 environment.UV_INDEX_STRATEGY = "unsafe-best-match"
 environment.UV_PRERELEASE = "allow"
+
+[[tool.cibuildwheel.overrides]]
+select = ["gp*"]
+inherit.environment = "append"
+environment.UV_EXTRA_INDEX_URL = "https://www.graalvm.org/python/wheels/"
+environment.UV_INDEX_STRATEGY = "unsafe-best-match"
+test-command = "pytest --benchmark-disable tests"
 
 [tool.pylint]
 py-version = "3.9"

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -191,6 +191,10 @@ def test_histogram_metadata(copy_fn, metadata):
     sys.implementation.name == "pypy",
     reason="Not remotely supported on PyPY, hangs forever",
 )
+@pytest.mark.skipif(
+    sys.implementation.name == "graalpy",
+    reason="Not supported, throws exception",
+)
 @pytest.mark.parametrize("mod", [np, math])
 def test_pickle_transforms(mod, copy_fn):
     ax1 = bh.axis.Regular(


### PR DESCRIPTION
cibuildwheel 3.0 with graalpy, linux image bumps, iOS. pybind11 3.0.
