### PR TITLE
ci: update Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,9 +62,10 @@ jobs:
           - python-version: "3.9"
             cmake-extras: "-DCMAKE_CXX_STANDARD=17"
           - python-version: "3.11"
-          - python-version: "3.13"
           - python-version: "3.13t"
-          - python-version: "pypy3.10"
+          - python-version: "3.14"
+          - python-version: "3.14t"
+          - python-version: "pypy3.11"
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ test-core = [
     "pytest-benchmark",
     "pytest>=6.0",
     "pytest-benchmark",
-    "pytest>=6.0",
     "numpy",
 ]
 test = [


### PR DESCRIPTION
I was originally adding subinterpreter support, but it looks like numpy doesn't support it yet. Here's some test version updates, anyway.


<details><summary>Subinterpreter attempt:</summary>
<p>

```diff
diff --git a/src/module.cpp b/src/module.cpp
index 7a6bbe2..b09086d 100644
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -12,7 +12,10 @@ void register_histograms(py::module&);
 void register_accumulators(py::module&);
 void register_transforms(py::module&);

-PYBIND11_MODULE(_core, m, py::mod_gil_not_used()) {
+PYBIND11_MODULE(_core,
+                m,
+                py::mod_gil_not_used(),
+                py::multiple_interpreters::per_interpreter_gil()) {
     py::module storage = m.def_submodule("storage");
     register_storages(storage);

diff --git a/src/register_accumulators.cpp b/src/register_accumulators.cpp
index 1c634e3..5485ad4 100644
--- a/src/register_accumulators.cpp
+++ b/src/register_accumulators.cpp
@@ -70,7 +70,10 @@ void register_accumulators(py::module& accumulators) {

     using weighted_sum = accumulators::weighted_sum<double>;

-    PYBIND11_NUMPY_DTYPE(weighted_sum, value, variance);
+    try {
+        PYBIND11_NUMPY_DTYPE(weighted_sum, value, variance);
+    } catch (const std::exception& ) {
+    }

     register_accumulator<weighted_sum>(
         accumulators, "WeightedSum", py::buffer_protocol())
@@ -171,11 +174,14 @@ void register_accumulators(py::module& accumulators) {
         ;

     using weighted_mean = accumulators::weighted_mean<double>;
-    PYBIND11_NUMPY_DTYPE(weighted_mean,
-                         sum_of_weights,
-                         sum_of_weights_squared,
-                         value,
-                         _sum_of_weighted_deltas_squared);
+    try {
+        PYBIND11_NUMPY_DTYPE(weighted_mean,
+                             sum_of_weights,
+                             sum_of_weights_squared,
+                             value,
+                             _sum_of_weighted_deltas_squared);
+    } catch (const std::exception& ) {
+    }

     register_accumulator<weighted_mean>(
         accumulators, "WeightedMean", py::buffer_protocol())
@@ -268,7 +274,10 @@ void register_accumulators(py::module& accumulators) {
         ;

     using mean = accumulators::mean<double>;
-    PYBIND11_NUMPY_DTYPE(mean, count, value, _sum_of_deltas_squared);
+    try {
+        PYBIND11_NUMPY_DTYPE(mean, count, value, _sum_of_deltas_squared);
+    } catch (const std::exception& ) {
+    }

     register_accumulator<mean>(accumulators, "Mean", py::buffer_protocol())
         .def_buffer(make_buffer<mean>())
diff --git a/tests/test_threaded_fill.py b/tests/test_threaded_fill.py
index d60841f..ef3b4fa 100644
--- a/tests/test_threaded_fill.py
+++ b/tests/test_threaded_fill.py
@@ -6,7 +6,10 @@
 import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal

+import pickle
+
 import boost_histogram as bh
+import boost_histogram._subinterp_test

 if sys.platform.startswith("emscripten"):
     pytest.skip(allow_module_level=True)
@@ -124,3 +127,22 @@ def test_no_weighted_profile():
 #     assert_almost_equal(hist_1.view().value, hist_2.view().value)
 #     assert_almost_equal(hist_1.view().variance, hist_2.view().variance)
 #     assert_almost_equal(hist_1.view().sum_of_weights, hist_2.view().sum_of_weights)
+
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14), reason="Needs 3.14's subinterpeter modules"
+)
+def test_subinterpreters():
+    from concurrent.futures import InterpreterPoolExecutor
+
+    x = np.random.rand(10003)
+    xs = np.array_split(x, 4)
+    xsp = (pickle.dumps(a) for a in xs)
+
+    with InterpreterPoolExecutor(max_workers=4) as pool:
+        results = pool.map(boost_histogram._subinterp_test.fill_one, xsp)
+        final = sum([pickle.loads(r) for r in results])
+
+    print(final)
+    assert False
```

Thwarted by pybind/pybind11#5781, and https://github.com/numpy/numpy/issues/24755.

</p>
</details> 