### PR TITLE
feat: unserializable metadata

### DIFF
--- a/src/boost_histogram/serialization/__init__.py
+++ b/src/boost_histogram/serialization/__init__.py
@@ -26,7 +26,9 @@ def to_uhi(h: histogram.Histogram, /) -> dict[str, Any]:
         "storage": _storage_to_dict(h.storage_type(), h.view(flow=True)),
     }
     if h.metadata is not None:
-        data["metadata"] = h.metadata
+        data["metadata"] = {
+            k: v for k, v in h.metadata.items() if not k.startswith("@")
+        }
 
     return data
 

--- a/src/boost_histogram/serialization/_axis.py
+++ b/src/boost_histogram/serialization/_axis.py
@@ -56,7 +56,9 @@ def _(ax: axis.Regular | axis.Integer, /) -> dict[str, Any]:
     if isinstance(ax, axis.Integer):
         data["writer_info"] = {"boost-histogram": {"orig_type": "Integer"}}
     if ax.metadata is not None:
-        data["metadata"] = ax.metadata
+        data["metadata"] = {
+            k: v for k, v in ax.metadata.items() if not k.startswith("@")
+        }
 
     return data
 
@@ -72,7 +74,9 @@ def _(ax: axis.Variable, /) -> dict[str, Any]:
         "circular": ax.traits.circular,
     }
     if ax.metadata is not None:
-        data["metadata"] = ax.metadata
+        data["metadata"] = {
+            k: v for k, v in ax.metadata.items() if not k.startswith("@")
+        }
 
     return data
 
@@ -86,7 +90,9 @@ def _(ax: axis.IntCategory, /) -> dict[str, Any]:
         "flow": ax.traits.overflow,
     }
     if ax.metadata is not None:
-        data["metadata"] = ax.metadata
+        data["metadata"] = {
+            k: v for k, v in ax.metadata.items() if not k.startswith("@")
+        }
 
     return data
 
@@ -100,7 +106,9 @@ def _(ax: axis.StrCategory, /) -> dict[str, Any]:
         "flow": ax.traits.overflow,
     }
     if ax.metadata is not None:
-        data["metadata"] = ax.metadata
+        data["metadata"] = {
+            k: v for k, v in ax.metadata.items() if not k.startswith("@")
+        }
 
     return data
 
@@ -108,11 +116,13 @@ def _(ax: axis.StrCategory, /) -> dict[str, Any]:
 @_axis_to_dict.register
 def _(ax: axis.Boolean, /) -> dict[str, Any]:
     """Convert a Boolean axis to a dictionary."""
-    data = {
+    data: dict[str, Any] = {
         "type": "boolean",
     }
     if ax.metadata is not None:
-        data["metadata"] = ax.metadata
+        data["metadata"] = {
+            k: v for k, v in ax.metadata.items() if not k.startswith("@")
+        }
 
     return data
 

--- a/tests/test_serialization_uhi.py
+++ b/tests/test_serialization_uhi.py
@@ -235,3 +235,13 @@ def test_round_trip_clean() -> None:
 
     assert isinstance(h2.axes[0], bh.axis.Regular)
     assert h2.storage_type is bh.storage.Int64
+
+
+def test_unserializable_metadata() -> None:
+    h = bh.Histogram(
+        bh.axis.Integer(0, 10, metadata={"c": 3, "@d": 4}), metadata={"a": 1, "@b": 2}
+    )
+    data = to_uhi(h)
+
+    assert data["metadata"] == {"a": 1}
+    assert data["axes"][0]["metadata"] == {"c": 3}


### PR DESCRIPTION
Adding unserializable metadata.

This is only for histogram serialization; which supports a limited set of values, it still gets pickled.
