### PR TITLE
fix: support setting with histograms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ minversion = "6.0"
 junit_family = "xunit2"
 addopts = [
   "-ra",
-  "--showlocals",
   "--strict-markers",
   "--strict-config",
   "--import-mode=importlib",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ foreach(TEST_FILE IN LISTS BOOST_HIST_PY_TESTS)
   get_filename_component(TEST_NAME "${TEST_FILE}" NAME_WE)
   add_test(
     NAME ${TEST_NAME}
-    COMMAND ${Python_EXECUTABLE} -m pytest "${TEST_FILE}" --rootdir=.
+    COMMAND ${Python_EXECUTABLE} -m pytest "${TEST_FILE}" --rootdir=. --showlocals
     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}")
   set_tests_properties(${TEST_NAME} PROPERTIES SKIP_RETURN_CODE 5)
 endforeach()

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -295,6 +295,18 @@ def test_set_range_with_scalar():
     assert h[5] == 0
 
 
+def test_set_range_with_scalar_callable():
+    h = bh.Histogram(bh.axis.Integer(0, 10))
+    h[2:len] = 42
+
+    assert h[1] == 0
+    assert h[2] == 42
+    assert h[3] == 42
+    assert h[4] == 42
+    assert h[5] == 42
+    assert h[bh.overflow] == 0
+
+
 def test_set_all_with_scalar():
     h = bh.Histogram(bh.axis.Integer(0, 10))
     h[:] = 42
@@ -483,3 +495,62 @@ def test_large_index():
     )
     assert h.axes[0].value(6) == 99_999_001
     assert h.axes[0].index(99_999_001) == 6
+
+
+def test_scaling_slice():
+    h = bh.Histogram(bh.axis.Regular(3, 0, 3), bh.axis.StrCategory(["a", "b"]))
+    h.fill([1, 1, 2], "a")
+    h.fill([0], "b")
+
+    h[:, bh.loc("a")] *= 2
+
+    assert h[1, 0] == approx(4)
+    assert h[2, 0] == approx(2)
+    assert h[0, 1] == approx(1)
+
+
+def test_scaling_slice_weight():
+    h = bh.Histogram(
+        bh.axis.Regular(3, 0, 3),
+        bh.axis.StrCategory(["a", "b"]),
+        storage=bh.storage.Weight(),
+    )
+    h.fill([1, 1, 2], "a")
+    h.fill([0], "b")
+
+    h[:, bh.loc("a")] *= 2
+
+    assert h[1, 0].value == approx(4)
+    assert h[2, 0].value == approx(2)
+    assert h[0, 1].value == approx(1)
+
+
+def test_setting_histogram_mismatch():
+    h = bh.Histogram(bh.axis.Regular(10, 0, 10), bh.axis.Integer(0, 20))
+
+    h[:, 0] = bh.Histogram(bh.axis.Regular(10, 0, 10))
+    h[0:, 0] = bh.Histogram(bh.axis.Regular(10, 0, 10, underflow=False))
+    h[:len, 0] = bh.Histogram(bh.axis.Regular(10, 0, 10, overflow=False))
+    h[0:len, 0] = bh.Histogram(
+        bh.axis.Regular(10, 0, 10, underflow=False, overflow=False)
+    )
+    with pytest.raises(ValueError, match="Cannot set histogram with underflow"):
+        h[0:, 0] = bh.Histogram(bh.axis.Regular(10, 0, 10))
+    with pytest.raises(ValueError, match="Cannot set histogram with underflow"):
+        h[:len, 0] = bh.Histogram(bh.axis.Regular(10, 0, 10))
+    with pytest.raises(ValueError, match="Cannot set histogram with underflow"):
+        h[:, 0] = bh.Histogram(bh.axis.Regular(10, 0, 10, underflow=False))
+    with pytest.raises(ValueError, match="Cannot set histogram with underflow"):
+        h[:, 0] = bh.Histogram(bh.axis.Regular(10, 0, 10, overflow=False))
+    with pytest.raises(ValueError, match="Cannot set histogram with underflow"):
+        h[:, 0] = bh.Histogram(
+            bh.axis.Regular(10, 0, 10, underflow=False, overflow=False)
+        )
+    with pytest.raises(ValueError, match="Cannot set histogram with underflow"):
+        h[0:, 0] = bh.Histogram(
+            bh.axis.Regular(10, 0, 10, underflow=False, overflow=False)
+        )
+    with pytest.raises(ValueError, match="Cannot set histogram with underflow"):
+        h[:len, 0] = bh.Histogram(
+            bh.axis.Regular(10, 0, 10, underflow=False, overflow=False)
+        )


### PR DESCRIPTION
This add support for setting a slice with a Histogram. Flow bins must match the request, adding some protection over setting it with `.view()`. But most importantly,
this enables operations like `*=` that internally use this, fixing #736. Also found and fixed a bug where callables were supported in `__getitem__` but not `__setitem__`.
