### PR TITLE
fix: unset classic metadata shouldn't show up in serialization

### DIFF
--- a/tests/test_serialization_uhi.py
+++ b/tests/test_serialization_uhi.py
@@ -244,7 +244,7 @@ def test_unserializable_metadata() -> None:
     h.__dict__["@b"] = 2
     data = to_uhi(h)
 
-    assert data["metadata"] == {"a": 1, "_variance_known": True, "metadata": None}
+    assert data["metadata"] == {"a": 1, "_variance_known": True}
     assert data["axes"][0]["metadata"] == {"c": 3}
 
 
@@ -261,5 +261,4 @@ def test_histogram_metadata() -> None:
         "label": "hi",
         "other": 3,
         "_variance_known": True,
-        "metadata": None,
     }


### PR DESCRIPTION
Fix for this showing up stored metadata. Add a warning if users access `.metadata` it without setting it.
