### PR TITLE
fix: support __dict__ on histogram like axes

### DIFF
--- a/src/boost_histogram/serialization/__init__.py
+++ b/src/boost_histogram/serialization/__init__.py
@@ -6,8 +6,8 @@ from typing import Any, TypeVar
 # pylint: disable-next=import-error
 from .. import histogram, version
 from ._axis import _axis_from_dict, _axis_to_dict
-from ._storage import _data_from_dict, _storage_from_dict, _storage_to_dict
 from ._common import serialize_metadata
+from ._storage import _data_from_dict, _storage_from_dict, _storage_to_dict
 
 __all__ = ["from_uhi", "remove_writer_info", "to_uhi"]
 

--- a/src/boost_histogram/serialization/__init__.py
+++ b/src/boost_histogram/serialization/__init__.py
@@ -7,6 +7,7 @@ from typing import Any, TypeVar
 from .. import histogram, version
 from ._axis import _axis_from_dict, _axis_to_dict
 from ._storage import _data_from_dict, _storage_from_dict, _storage_to_dict
+from ._common import serialize_metadata
 
 __all__ = ["from_uhi", "remove_writer_info", "to_uhi"]
 
@@ -25,7 +26,7 @@ def to_uhi(h: histogram.Histogram, /) -> dict[str, Any]:
         "axes": [_axis_to_dict(axis) for axis in h.axes],
         "storage": _storage_to_dict(h.storage_type(), h.view(flow=True)),
     }
-    data["metadata"] = {k: v for k, v in h.__dict__.items() if not k.startswith("@")}
+    data["metadata"] = serialize_metadata(h.__dict__)
 
     return data
 

--- a/src/boost_histogram/serialization/_axis.py
+++ b/src/boost_histogram/serialization/_axis.py
@@ -4,6 +4,7 @@ import functools
 from typing import Any
 
 from .. import axis
+from ._common import serialize_metadata
 
 __all__ = ["_axis_from_dict", "_axis_to_dict"]
 
@@ -55,10 +56,8 @@ def _(ax: axis.Regular | axis.Integer, /) -> dict[str, Any]:
 
     if isinstance(ax, axis.Integer):
         data["writer_info"] = {"boost-histogram": {"orig_type": "Integer"}}
-    if ax.metadata is not None:
-        data["metadata"] = {
-            k: v for k, v in ax.metadata.items() if not k.startswith("@")
-        }
+
+    data["metadata"] = serialize_metadata(ax.__dict__)
 
     return data
 
@@ -73,10 +72,7 @@ def _(ax: axis.Variable, /) -> dict[str, Any]:
         "overflow": ax.traits.overflow,
         "circular": ax.traits.circular,
     }
-    if ax.metadata is not None:
-        data["metadata"] = {
-            k: v for k, v in ax.metadata.items() if not k.startswith("@")
-        }
+    data["metadata"] = serialize_metadata(ax.__dict__)
 
     return data
 
@@ -89,10 +85,7 @@ def _(ax: axis.IntCategory, /) -> dict[str, Any]:
         "categories": list(ax),
         "flow": ax.traits.overflow,
     }
-    if ax.metadata is not None:
-        data["metadata"] = {
-            k: v for k, v in ax.metadata.items() if not k.startswith("@")
-        }
+    data["metadata"] = serialize_metadata(ax.__dict__)
 
     return data
 
@@ -105,10 +98,7 @@ def _(ax: axis.StrCategory, /) -> dict[str, Any]:
         "categories": list(ax),
         "flow": ax.traits.overflow,
     }
-    if ax.metadata is not None:
-        data["metadata"] = {
-            k: v for k, v in ax.metadata.items() if not k.startswith("@")
-        }
+    data["metadata"] = serialize_metadata(ax.__dict__)
 
     return data
 
@@ -119,10 +109,7 @@ def _(ax: axis.Boolean, /) -> dict[str, Any]:
     data: dict[str, Any] = {
         "type": "boolean",
     }
-    if ax.metadata is not None:
-        data["metadata"] = {
-            k: v for k, v in ax.metadata.items() if not k.startswith("@")
-        }
+    data["metadata"] = serialize_metadata(ax.__dict__)
 
     return data
 
@@ -139,7 +126,7 @@ def _axis_from_dict(data: dict[str, Any], /) -> axis.Axis:
             underflow=data["underflow"],
             overflow=data["overflow"],
             circular=data["circular"],
-            metadata=data.get("metadata"),
+            __dict__=data.get("metadata"),
         )
 
     hist_type = data["type"]
@@ -151,7 +138,7 @@ def _axis_from_dict(data: dict[str, Any], /) -> axis.Axis:
             underflow=data["underflow"],
             overflow=data["overflow"],
             circular=data["circular"],
-            metadata=data.get("metadata"),
+            __dict__=data.get("metadata"),
         )
     if hist_type == "variable":
         return axis.Variable(
@@ -159,21 +146,21 @@ def _axis_from_dict(data: dict[str, Any], /) -> axis.Axis:
             underflow=data["underflow"],
             overflow=data["overflow"],
             circular=data["circular"],
-            metadata=data.get("metadata"),
+            __dict__=data.get("metadata"),
         )
     if hist_type == "category_int":
         return axis.IntCategory(
             data["categories"],
             overflow=data["flow"],
-            metadata=data.get("metadata"),
+            __dict__=data.get("metadata"),
         )
     if hist_type == "category_str":
         return axis.StrCategory(
             data["categories"],
             overflow=data["flow"],
-            metadata=data.get("metadata"),
+            __dict__=data.get("metadata"),
         )
     if hist_type == "boolean":
-        return axis.Boolean(metadata=data.get("metadata"))
+        return axis.Boolean(__dict__=data.get("metadata"))
 
     raise TypeError(f"Unsupported axis type: {hist_type}")

--- a/src/boost_histogram/serialization/_common.py
+++ b/src/boost_histogram/serialization/_common.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def serialize_metadata(value: dict[str, Any], /) -> dict[str, Any]:
+    return {k: v for k, v in value.items() if not k.startswith("@") and v is not None}

--- a/tests/test_serialization_uhi.py
+++ b/tests/test_serialization_uhi.py
@@ -238,7 +238,7 @@ def test_round_trip_clean() -> None:
 
 def test_unserializable_metadata() -> None:
     h = bh.Histogram(
-        bh.axis.Integer(0, 10, metadata={"c": 3, "@d": 4}),
+        bh.axis.Integer(0, 10, __dict__={"c": 3, "@d": 4}),
     )
     h.__dict__["a"] = 1
     h.__dict__["@b"] = 2


### PR DESCRIPTION
Supporting this on Histogram, like it's already supported on Axes. Should help users find the correct way to set metadata, and is more optimal than replacing `__dict__`, as we can use the key-sharing dict in modern Pythons.

Also skip storing None, since None isn't a defined datatype in UHI.