### PR TITLE
chore: setting __file__ no longer required (pybind11 3.0)

### DIFF
--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -74,16 +74,6 @@ def __dir__() -> list[str]:
     return __all__
 
 
-# Support cloudpickle - pybind11 submodules do not have __file__ attributes
-# And setting this in C++ causes a segfault
-_core.accumulators.__file__ = _core.__file__
-_core.algorithm.__file__ = _core.__file__
-_core.axis.__file__ = _core.__file__
-_core.axis.transform.__file__ = _core.__file__
-_core.hist.__file__ = _core.__file__
-_core.storage.__file__ = _core.__file__
-
-
 NOTHING = object()
 
 


### PR DESCRIPTION
This was fixed in pybind11 3.0.0.
