### PR TITLE
Avoid compiler warning: declaration of 'i' hides previous local declaration

### DIFF
--- a/include/bh_python/vector_string_caster.hpp
+++ b/include/bh_python/vector_string_caster.hpp
@@ -61,10 +61,10 @@ struct type_caster<std::vector<std::string>>
             const auto n = strlen(p, step);
             std::string s;
             s.reserve(n);
-            for(std::size_t i = 0; i < n; ++i) {
-                if(p[i] >= 128)
+            for(std::size_t j = 0; j < n; ++j) {
+                if(p[j] >= 128)
                     return false;
-                s.push_back(static_cast<char>(p[i]));
+                s.push_back(static_cast<char>(p[j]));
             }
             value.emplace_back(s);
         }


### PR DESCRIPTION
When compiling boost-histogram on Windows, I get the following annoying warning:

```
\boost-histogram\include\bh_python\vector_string_caster.hpp(64,29): warning C4456: 
declaration of 'i' hides previous local declaration [\AppData\Local\Temp\tmpe4tm749r\build\_core.vcxproj]
    (compiling source file '/boost-histogram/src/register_axis.cpp')
        \boost-histogram\include\bh_python\vector_string_caster.hpp(59,25):
        see declaration of 'i'
```

I "fixed" it by renaming the inner iteration variable from `i -> j`