### PR TITLE
fix: correct repr for MultiCell

### DIFF
--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -814,7 +814,8 @@ class Histogram(typing.Generic[S]):
         )
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
 
-    def get_storage(self) -> S:
+    @property
+    def storage(self) -> S:
         """
         New storage matching the one the histogram was constructed with.
         """
@@ -877,7 +878,7 @@ class Histogram(typing.Generic[S]):
         sep = "," if len(self.axes) > 0 else ""
         ret = f"{self.__class__.__name__}({first_newline}"
         ret += f",{newline}".join(repr(ax) for ax in self.axes)
-        ret += f"{sep}{storage_newline}storage={self.get_storage()}"
+        ret += f"{sep}{storage_newline}storage={self.storage}"
         ret += ")"
         outer = self.sum(flow=True)
         if outer:

--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -802,17 +802,25 @@ class Histogram(typing.Generic[S]):
         return cast(self, self._hist.axis(i), Axis)
 
     @property
-    def storage_type(self) -> type[Storage]:
+    def storage_type(self) -> type[S]:
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
 
     @property
-    def _storage_type(self) -> type[Storage]:
+    def _storage_type(self) -> type[S]:
         warnings.warn(
             "Accessing storage type has changed from _storage_type to storage_type, and will be removed in future.",
             FutureWarning,
             stacklevel=2,
         )
         return cast(self, self._hist._storage_type, Storage)  # type: ignore[return-value]
+
+    def get_storage(self) -> S:
+        """
+        New storage matching the one the histogram was constructed with.
+        """
+        if issubclass(self.storage_type, bhs.MultiCell):
+            return self.storage_type(self._hist.nelem())  # type: ignore[attr-defined]
+        return self.storage_type()
 
     def _reduce(self, *args: Any) -> Self:
         return self._new_hist(self._hist.reduce(*args))
@@ -869,7 +877,7 @@ class Histogram(typing.Generic[S]):
         sep = "," if len(self.axes) > 0 else ""
         ret = f"{self.__class__.__name__}({first_newline}"
         ret += f",{newline}".join(repr(ax) for ax in self.axes)
-        ret += f"{sep}{storage_newline}storage={self.storage_type()}"  # pylint: disable=not-callable
+        ret += f"{sep}{storage_newline}storage={self.get_storage()}"
         ret += ")"
         outer = self.sum(flow=True)
         if outer:

--- a/src/boost_histogram/storage.py
+++ b/src/boost_histogram/storage.py
@@ -79,5 +79,7 @@ class WeightedMean(store.weighted_mean, Storage, family=boost_histogram):
 class MultiCell(store.multi_cell, Storage, family=boost_histogram):
     accumulator = float
 
+    __match_args__ = ("nelem",)
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.nelem})"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -400,6 +400,14 @@ def test_multi_cell():
     weights = np.array([[1, 2, 3], [4, 5, 6]])
     h = bh.Histogram(bh.axis.Regular(5, 0, 5), storage=bh.storage.MultiCell(3))
 
+
+    # Repr must contain MultiCell(3)
+    repr_h = repr(h)
+    assert "MultiCell(3)" in repr_h
+
+    # Can access number of elements
+    assert h.get_storage().nelem == 3
+
     # Filling 1-Dim
     h.fill(x, weight=weights)
     assert_array_equal(h[1], [1, 2, 3])

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -400,13 +400,19 @@ def test_multi_cell():
     weights = np.array([[1, 2, 3], [4, 5, 6]])
     h = bh.Histogram(bh.axis.Regular(5, 0, 5), storage=bh.storage.MultiCell(3))
 
-
     # Repr must contain MultiCell(3)
     repr_h = repr(h)
     assert "MultiCell(3)" in repr_h
 
     # Can access number of elements
-    assert h.get_storage().nelem == 3
+    assert h.storage.nelem == 3
+
+    # Can use pattern matching
+    match h:
+        case bh.Histogram(storage=bh.storage.MultiCell(nelem)):
+            assert nelem == 3
+        case _:
+            raise AssertionError("Can't pattern match")
 
     # Filling 1-Dim
     h.fill(x, weight=weights)


### PR DESCRIPTION
Followup to #1008. This fixes the repr for MultiCell, which currently always shows `0`, since we can't get the actual instance, but just it's type (without the value of nelem).

I've added a `h.get_storage()` method which gets a storage object with the same parameters, an instance of `h.storage_type`. It's natural for the repr, and allows users to query with `h.get_storage().nelem`. Thoughts, @hdembinski and @Superharz? I could make it a property instead, such as `h.storage.nelem`. The main issue is it is just the `bh.storage` creation object, and doesn't actually give access to storage, so you can't do much with `h.storage`.

Edit: I realized that making this a property actually works better for pattern matching, which expects properties to match constructor arguments, so I've used `h.storage` now.

I thought about exposing `.nelem` on the histogram, but I can't properly statically type it (mypy doesn't allow `@property` and `@typing.overload` to be combined), and it's just None on most histograms.
