### PR TITLE
chore: update wheel build

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,16 +193,19 @@ when you run the above command on a supported platform. Wheels are produced usin
 [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/); all common
 platforms have wheels provided in boost-histogram:
 
-| System    | Arch   | Python versions                            | PyPy versions |
-| --------- | ------ | ------------------------------------------ | ------------- |
-| manylinux | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          |
-| manylinux | ARM64  | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          |
-| musllinux | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t |               |
-| macOS     | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          |
-| macOS     | Arm64  | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          |
-| Windows   | 32-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t |               |
-| Windows   | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          |
-| Windows   | ARM64  | 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t       |               |
+| System    | Arch   | Python versions                            | PyPy versions | GraalPy versions |
+| --------- | ------ | ------------------------------------------ | ------------- | ---------------- |
+| manylinux | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          | 24.2, 25.0       |
+| manylinux | ARM64  | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          | 24.2, 25.0       |
+| musllinux | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t |               |                  |
+| macOS     | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          | 24.2, 25.0       |
+| macOS     | Arm64  | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          | 24.2, 25.0       |
+| Windows   | 32-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t |               |                  |
+| Windows   | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          | 24.2, 25.0       |
+| Windows   | ARM64  | 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t       |               |                  |
+| iOS       | Device | 3.13, 3.14                                 |               |                  |
+| iOS       | AS Sim | 3.13, 3.14                                 |               |                  |
+| iOS       | Intel  | 3.13, 3.14                                 |               |                  |
 
 PowerPC, IBM-Z, and RISC-V wheels are not provided but are available on request.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,14 +182,12 @@ test-environment.CI = "1"  # Hypothosis needs this on GraalPy
 test-skip = [
   "cp310-win_arm64",
   "cp310-musllinux_*",
-  "pp310-manylinux_aarch64",
-  "pp310-macosx_arm64",
   "cp31*-musllinux_*", # Threading test crashes
   "gp311_242-macosx_x86_64",
   "gp311_242-manylinux_aarch64",
   "gp311_242-win*",  # pytest crashes with module 'io' has no attribute '_WindowsConsoleIO'
   "gp312_*",  # No numpy wheels yet
-  "cp314*-ios_*",  # No numpy wheels yet
+  "*-ios_*",  # Fails on CI with no device found
 ]
 enable = ["pypy", "graalpy"]
 environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]
@@ -213,11 +211,6 @@ environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/beeware/simple/"
 # xbuild-tools = ["cmake", "ninja"]
 # test-command = "pytest --benchmark-disable tests"
 # environment.PIP_EXTRA_INDEX_URL = "https://chaquo.com/pypi-13.1"
-
-[[tool.cibuildwheel.overrides]]
-select = "pp310-macosx_arm64"
-inherit.environment = "append"
-environment.MACOSX_DEPLOYMENT_TARGET = "14.0"
 
 [[tool.cibuildwheel.overrides]]
 select = ["gp*"]


### PR DESCRIPTION
This is failing due to iOS not finding a device. Skipping for now, and cleaning up a few warnings.
