### PR TITLE
feat: add flow=False support to histogram projections

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## WIP
+
+#### Features
+
+- Support `flow=False` in histogram projections by @Rishabh-git10 in [#1109][]
+
 ## Version 1.7
 
 ### Version 1.7.2
@@ -7,7 +13,6 @@
 #### Features
 
 - No storage option/support for serialization, by @henryiii in [#1098][]
-- Support `flow=False` in histogram projections by @Rishabh-git10 in [#1109][]
 
 #### Fixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 #### Features
 
 - No storage option/support for serialization, by @henryiii in [#1098][]
+- Support `flow=False` in histogram projections by @Rishabh-git10 in [#1109][]
 
 #### Fixes
 
@@ -36,6 +37,7 @@
 [#1092]: https://github.com/scikit-hep/boost-histogram/pull/1092
 [#1105]: https://github.com/scikit-hep/boost-histogram/pull/1105
 [#1106]: https://github.com/scikit-hep/boost-histogram/pull/1106
+[#1109]: https://github.com/scikit-hep/boost-histogram/pull/1109
 
 ### Version 1.7.1
 

--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -1499,11 +1499,12 @@ class Histogram(typing.Generic[S]):
             indexes.insert(0, slice(None, None, None))
         view[tuple(indexes)] = in_array
 
-    def project(self, *args: int) -> Self:
+    def project(self, *args: int, flow: bool = True) -> Self:
         """
         Project to a single axis or several axes on a multidimensional histogram.
         Provided a list of axis numbers, this will produce the histogram over
-        those axes only. Flow bins are used if available.
+        those axes only. Flow bins are used if available. If flow is False,
+        flow bins on the integrated-out axes are excluded.
         """
         for arg in args:
             if arg < 0 or arg >= self.ndim:
@@ -1511,7 +1512,21 @@ class Histogram(typing.Generic[S]):
                     f"Projection axis must be a valid axis number 0 to {self.ndim - 1}, not {arg}"
                 )
 
-        return self._new_hist(self._hist.project(*args))
+        if flow:
+            return self._new_hist(self._hist.project(*args))
+
+        keep_axes = set(args)
+        drop_axes = [i for i in range(self.ndim) if i not in keep_axes]
+
+        slices = [
+            _core.algorithm.slice(
+                i, 0, self.axes[i].size, _core.algorithm.slice_mode.crop
+            )
+            for i in drop_axes
+        ]
+
+        reduced_hist = self._hist.reduce(*slices) if slices else self._hist
+        return self._new_hist(reduced_hist.project(*args))
 
     # Implementation of PlottableHistogram
 

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -619,6 +619,18 @@ def test_project():
     with pytest.raises(ValueError):
         h.project(-1)
 
+    h_noflow = h.project(0, flow=False)
+    assert [h_noflow[i] for i in range(2)] == [2, 1]
+
+    h.fill(-1, 0)
+    h.fill(0, 0)
+
+    h_flow_true = h.project(0, flow=True)
+    assert h_flow_true[0] == 3
+
+    h_flow_false = h.project(0, flow=False)
+    assert h_flow_false[0] == 2
+
 
 def test_shrink_1d():
     h = bh.Histogram(bh.axis.Regular(20, 1, 5))


### PR DESCRIPTION
Closes #1032

Implements `flow=False` for histogram projections. Since the C++ backend doesn't natively support this, it handles the logic on the Python side by using `_core.algorithm.slice_mode.crop` to strip the flow bins from the integrated-out axes prior to calling `.project()`. 

Tests are included to verify the behavior.