### PR TITLE
test: add ND projection test for flow=False

### DIFF
--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -632,6 +632,27 @@ def test_project():
     assert h_flow_false[0] == 2
 
 
+def test_project_nd():
+    h = bh.Histogram(
+        bh.axis.Integer(0, 2), bh.axis.Integer(0, 2), bh.axis.Integer(0, 2)
+    )
+
+    h.fill(0, 0, 0)
+    h.fill(1, 1, 0)
+
+    h.fill(0, 0, -1)
+    h.fill(1, 1, 2)
+
+    h_flow_true = h.project(0, 1, flow=True)
+    h_flow_false = h.project(0, 1, flow=False)
+
+    assert h_flow_true[0, 0] == 2
+    assert h_flow_true[1, 1] == 2
+
+    assert h_flow_false[0, 0] == 1
+    assert h_flow_false[1, 1] == 1
+
+
 def test_shrink_1d():
     h = bh.Histogram(bh.axis.Regular(20, 1, 5))
     h.fill(1.1)


### PR DESCRIPTION
Follow-up to #1109. 

Adds a 3D projection test to verify `flow=False` behavior across multiple preserved dimensions, as requested by @henryiii [here](https://github.com/scikit-hep/boost-histogram/pull/1109#issuecomment-4296707176).