### PR TITLE
fix: correct Mean storage string rejection and __setitem__ error message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ examples = [
 ]
 test = [
     "cloudpickle",
-    "pytest-benchmark",
     "pytest>=6.0",
     "pytest-benchmark",
     "numpy>=1.21.3",

--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -159,7 +159,7 @@ def mean_storage_sample_check(sample: ArrayLike | None) -> None:
         raise TypeError("Sample key-argument (sample=) needs to be provided.")
     seqs = (collections.abc.Sequence, np.ndarray)
     msg1 = f"Sample key-argument needs to be a sequence, {sample.__class__.__name__} given."
-    if isinstance(sample, str) and not isinstance(sample, seqs):
+    if isinstance(sample, str) or not isinstance(sample, seqs):
         raise ValueError(msg1)
     sample_dim = np.ndim(sample)
     msg2 = f"Sample key-argument needs to be 1 dimensional, {sample_dim} given."
@@ -1574,7 +1574,7 @@ class Histogram(typing.Generic[S]):
 
                 else:
                     msg = f"Mismatched shapes {value_shape} in dimension {n}"
-                    msg += f", {value_shape[n]} != {request_len}"
+                    msg += f", {value_shape[value_n]} != {request_len}"
                     if use_underflow or use_overflow:
                         msg += f" or {request_len + use_underflow + use_overflow}"
                     raise ValueError(msg)

--- a/tests/test_histogram_set.py
+++ b/tests/test_histogram_set.py
@@ -145,3 +145,12 @@ def test_set_special_dtype(storage, default):
 
     with pytest.raises(ValueError):
         h[1, 1] = 1
+
+
+def test_set_array_slice_mismatch_not_at_start():
+    h = bh.Histogram(
+        bh.axis.Regular(3, 0, 3), bh.axis.Regular(4, 0, 4), bh.axis.Regular(5, 0, 5)
+    )
+
+    with pytest.raises(ValueError, match=r"Mismatched shapes \(4, 6\) in dimension 2, 6 != 5"):
+        h[0, :, :] = np.ones((4, 6))

--- a/tests/test_histogram_set.py
+++ b/tests/test_histogram_set.py
@@ -152,5 +152,7 @@ def test_set_array_slice_mismatch_not_at_start():
         bh.axis.Regular(3, 0, 3), bh.axis.Regular(4, 0, 4), bh.axis.Regular(5, 0, 5)
     )
 
-    with pytest.raises(ValueError, match=r"Mismatched shapes \(4, 6\) in dimension 2, 6 != 5"):
+    with pytest.raises(
+        ValueError, match=r"Mismatched shapes \(4, 6\) in dimension 2, 6 != 5"
+    ):
         h[0, :, :] = np.ones((4, 6))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -130,6 +130,16 @@ def test_setting_profile():
     )
 
 
+def test_mean_storage_rejects_string_sample():
+    h = bh.Histogram(bh.axis.Regular(10, 0, 10), storage=bh.storage.Mean())
+
+    with pytest.raises(
+        ValueError,
+        match=r"Sample key-argument needs to be a sequence, str given\.",
+    ):
+        h.fill([0.3], sample="abc")
+
+
 def test_setting_weighted_profile():
     h = bh.Histogram(bh.axis.Regular(10, 0, 10), storage=bh.storage.WeightedMean())
 


### PR DESCRIPTION
More from #1115.

:robot: *Human triggerd, AI assisted PR. AI text below.* :robot:

## Summary

- Fix logic bug in `mean_storage_sample_check`: changed `and` to `or` so that strings are always rejected as invalid samples (strings are sequences but should never be accepted as sample data)
- Fix `__setitem__` shape mismatch error message: use `value_shape[value_n]` instead of `value_shape[n]` to report the correct dimension index
- Remove duplicate `pytest-benchmark` entry in `pyproject.toml`
- Add tests covering both bug fixes

Assisted-by: OpenCode:GLM-5