### PR TITLE
fix: best practices and cleanups from automated review

### DIFF
--- a/include/bh_python/accumulators/mean.hpp
+++ b/include/bh_python/accumulators/mean.hpp
@@ -14,6 +14,8 @@
 #include <boost/core/nvp.hpp>
 #include <boost/histogram/weight.hpp>
 
+#include <limits>
+
 namespace accumulators {
 
 /** Calculates mean and variance of sample.
@@ -90,6 +92,8 @@ struct mean {
     bool operator!=(const mean& rhs) const noexcept { return !operator==(rhs); }
 
     value_type variance() const noexcept {
+        if(count <= 1)
+            return std::numeric_limits<value_type>::quiet_NaN();
         return _sum_of_deltas_squared / (count - 1);
     }
 

--- a/include/bh_python/accumulators/weighted_mean.hpp
+++ b/include/bh_python/accumulators/weighted_mean.hpp
@@ -40,7 +40,7 @@ struct weighted_mean {
         , sum_of_weights_squared(wsum2)
         , value(mean)
         , _sum_of_weighted_deltas_squared(
-              variance * (sum_of_weights - sum_of_weights_squared / sum_of_weights)) {}
+              variance * (sum_of_weights - (sum_of_weights_squared / sum_of_weights))) {}
 
     weighted_mean(const value_type& wsum,
                   const value_type& wsum2,
@@ -102,7 +102,7 @@ struct weighted_mean {
 
     value_type variance() const {
         const value_type denom
-            = sum_of_weights - sum_of_weights_squared / sum_of_weights;
+            = sum_of_weights - (sum_of_weights_squared / sum_of_weights);
         if(denom <= 0)
             return std::numeric_limits<value_type>::quiet_NaN();
         return _sum_of_weighted_deltas_squared / denom;

--- a/include/bh_python/accumulators/weighted_mean.hpp
+++ b/include/bh_python/accumulators/weighted_mean.hpp
@@ -15,6 +15,8 @@
 #include <boost/core/nvp.hpp>
 #include <boost/histogram/weight.hpp>
 
+#include <limits>
+
 namespace accumulators {
 
 /**
@@ -99,8 +101,11 @@ struct weighted_mean {
     bool operator!=(const weighted_mean rhs) const noexcept { return !operator==(rhs); }
 
     value_type variance() const {
-        return _sum_of_weighted_deltas_squared
-               / (sum_of_weights - sum_of_weights_squared / sum_of_weights);
+        const value_type denom
+            = sum_of_weights - sum_of_weights_squared / sum_of_weights;
+        if(denom <= 0)
+            return std::numeric_limits<value_type>::quiet_NaN();
+        return _sum_of_weighted_deltas_squared / denom;
     }
 
     template <class Archive>

--- a/include/bh_python/accumulators/weighted_mean.hpp
+++ b/include/bh_python/accumulators/weighted_mean.hpp
@@ -40,7 +40,8 @@ struct weighted_mean {
         , sum_of_weights_squared(wsum2)
         , value(mean)
         , _sum_of_weighted_deltas_squared(
-              variance * (sum_of_weights - (sum_of_weights_squared / sum_of_weights))) {}
+              variance * (sum_of_weights - (sum_of_weights_squared / sum_of_weights))) {
+    }
 
     weighted_mean(const value_type& wsum,
                   const value_type& wsum2,

--- a/include/bh_python/register_axis.hpp
+++ b/include/bh_python/register_axis.hpp
@@ -40,12 +40,6 @@ auto vectorize_index(T input) {
     return py::vectorize(input);
 }
 
-#ifdef __cpp_noexcept_function_type
-#define BHP_NOEXCEPT_17 noexcept
-#else
-#define BHP_NOEXCEPT_17
-#endif
-
 namespace detail {
 template <class T>
 decltype(auto) axis_cast(py::handle x) {

--- a/src/boost_histogram/_compat/typing.py
+++ b/src/boost_histogram/_compat/typing.py
@@ -8,7 +8,7 @@ if sys.version_info >= (3, 11):
 elif typing.TYPE_CHECKING:
     from typing_extensions import Self
 else:
-    Self = object
+    Self = typing.Any
 
 __all__ = ["Self"]
 

--- a/src/boost_histogram/axis/__init__.py
+++ b/src/boost_histogram/axis/__init__.py
@@ -890,7 +890,7 @@ class AxesTuple(tuple):  # type: ignore[type-arg]
             )
         return tuple(self[i].bin(indexes[i]) for i in range(len(indexes)))
 
-    def index(self, *values: float) -> tuple[float, ...]:  # type: ignore[override, override]
+    def index(self, *values: float) -> tuple[int, ...]:  # type: ignore[override, override]
         if len(values) != len(self):
             raise IndexError(
                 "Must have the same number of arguments as the number of axes"

--- a/src/boost_histogram/numpy.py
+++ b/src/boost_histogram/numpy.py
@@ -37,9 +37,11 @@ def histogramdd(
     density: bool = False,
     *,
     histogram: None | (type[Histogram[Any]]) = None,
-    storage: _storage.Storage = _storage.Double(),  # noqa: B008
+    storage: _storage.Storage | None = None,
     threads: int | None = None,
 ) -> Any:
+    if storage is None:
+        storage = _storage.Double()
     cls: type[Histogram[Any]] = Histogram if histogram is None else histogram
 
     if normed is not None:
@@ -108,9 +110,11 @@ def histogram2d(
     density: bool = False,
     *,
     histogram: None | (type[Histogram[Any]]) = None,
-    storage: _storage.Storage = _storage.Double(),  # noqa: B008
+    storage: _storage.Storage | None = None,
     threads: int | None = None,
 ) -> Any:
+    if storage is None:
+        storage = _storage.Double()
     result = histogramdd(
         (x, y),
         bins,

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -8,6 +8,9 @@ import boost_histogram as bh
 hypothesis = pytest.importorskip("hypothesis")
 st = pytest.importorskip("hypothesis.strategies")
 
+hypothesis.settings.register_profile("ci", deadline=None)
+hypothesis.settings.load_profile("ci")
+
 
 def test_weighted_sum():
     a = bh.accumulators.WeightedSum(1.5, 2.5)

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -847,7 +847,7 @@ class TestCategory(Axis):
         assert_allclose(a.widths, [1, 1, 1])
 
 
-class TestBoolean:
+class TestBoolean(Axis):
     def test_init(self):
         bh.axis.Boolean()
         bh.axis.Boolean(metadata="foo")

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -191,7 +191,6 @@ def test_growth():
     h.fill(0)
     for _ in range(1000 - 256):
         h.fill(0)
-    print(h.view(flow=True))
     assert h[bh.underflow] == 0
     assert h[0] == 1
     assert h[1] == 1000
@@ -1360,22 +1359,6 @@ def test_hist_division():
     h1 /= h.axes[0].widths * h.sum()
 
     assert_array_equal(h1.view(), dens)
-
-
-# issue #416 b
-# def test_hist_division():
-#     edges = [0, .25, .5, .75, 1, 2, 3, 4, 7, 10]
-#    edges = [-x for x in reversed(edges)] + edges[1:]
-#
-#    h = bh.Histogram(bh.axis.Variable(edges))
-#    h[...] = 1
-#
-#    dens = h.view().copy() / h.axes[0].widths * h.sum()
-#    h1 = h.copy()
-#
-#    h1[:] /=  h.axes[0].widths * h.sum()
-#
-#    assert_allclose(h1.view(), dens)
 
 
 def test_add_hists():

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -173,8 +173,6 @@ def test_mix_value_with_slice():
     vals = np.arange(100).reshape(10, 10, 1)
     h[:, :, 1:2] = vals
 
-    print(h.view()[:3, :3, :])
-
     assert h[0, 1, True] == 1
     assert h[1, 0, True] == 10
     assert h[1, 1, True] == 11

--- a/tests/test_pbt.py
+++ b/tests/test_pbt.py
@@ -9,6 +9,9 @@ import boost_histogram as bh
 hypothesis = pytest.importorskip("hypothesis")
 nst = pytest.importorskip("hypothesis.extra.numpy")
 
+hypothesis.settings.register_profile("ci", deadline=None)
+hypothesis.settings.load_profile("ci")
+
 
 @hypothesis.given(
     nst.arrays(


### PR DESCRIPTION
:robot: *Human triggerd, AI assisted PR. AI text below.* :robot:

Addresses the **Best Practices & Cleanups** section of #1115.

## Python fixes
- **numpy.py**: Replaced mutable default `storage=_storage.Double()` with `storage=None` + lazy init in `histogramdd()` and `histogram2d()`
- **axis/__init__.py**: Fixed `AxesTuple.index` return type from `tuple[float, ...]` to `tuple[int, ...]`
- **_compat/typing.py**: Changed `Self = object` fallback to `Self = typing.Any` (more semantically correct)

## C++ fixes
- **register_axis.hpp**: Removed duplicate `BHP_NOEXCEPT_17` macro definition (lines 43-47)
- **accumulators/mean.hpp**: Added division-by-zero guard in `variance()` — returns NaN when `count <= 1`
- **accumulators/weighted_mean.hpp**: Added division-by-zero guard in `variance()` — returns NaN when denominator <= 0

## Test cleanups
- Removed `print()` debug statements from `test_histogram.py` and `test_histogram_indexing.py`
- Removed commented-out dead `test_hist_division` code (from 2020)
- Made `TestBoolean` inherit from `Axis` ABC for structural test coverage
- Added `hypothesis.settings(deadline=None)` to `test_pbt.py` and `test_accumulators.py`

## Skipped
- `rebin.__init__` validation: Investigated but existing logic is correct — `axis` alongside `groups`/`edges` is a valid use case (confirmed by existing tests)
- `using namespace pybind11::literals` in header: Too many usages across the C++ codebase to safely refactor in this PR

Closes #1115 (best practices portion)

Assisted-by: OpenCode:GLM-5