### PR TITLE
tests: disable cloudpickle tests on PyPy

### DIFF
--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -278,6 +278,11 @@ def test_trans_wrapped(copy_fn):
 
 
 # Testing #342
+# https://github.com/cloudpipe/cloudpickle/issues/592
+@pytest.mark.skipif(
+    sys.implementation.name == "pypy",
+    reason="cloudpickle does not work with the latest PyPy",
+)
 def test_cloudpickle():
     cloudpickle = pytest.importorskip("cloudpickle")
     h = bh.Histogram(bh.axis.Regular(50, 0, 20))


### PR DESCRIPTION
This is broken (see https://github.com/cloudpipe/cloudpickle/issues/592). Skip until cloudpickle fixes it.

Assisted-by: OpenCode:GLM-5.1
