### PR TITLE
feat: accept scalar sample argument in fill

### DIFF
--- a/include/bh_python/fill.hpp
+++ b/include/bh_python/fill.hpp
@@ -131,6 +131,9 @@ using arg_t = variant::variant<c_array_t<double>,
 
 using weight_t = variant::variant<variant::monostate, double, c_array_t<double>>;
 
+// a sample is either a scalar (broadcast) or a 1D array
+using sample_t = variant::variant<double, c_array_t<double>>;
+
 inline auto get_vargs(const vector_axis_variant& axes, const py::args& args) {
     if(args.size() != axes.size())
         throw std::invalid_argument("Wrong number of args");
@@ -171,6 +174,21 @@ inline auto get_weight(py::kwargs& kwargs) {
     return weight;
 }
 
+inline auto get_sample(const py::handle& s) {
+    sample_t sample;
+    // a scalar sample is broadcast to match the other arguments, like a scalar
+    // axis value or weight
+    if(is_value<double>(s)) {
+        sample = py::cast<double>(s);
+    } else {
+        auto sarray = py::cast<c_array_t<double>>(s);
+        if(sarray.ndim() != 1)
+            throw std::invalid_argument("Sample array must be 1D");
+        sample = std::move(sarray);
+    }
+    return sample;
+}
+
 // for accumulators that accept a weight
 template <class Histogram, class VArgs>
 void fill_impl(bh::detail::accumulator_traits_holder<true>,
@@ -198,20 +216,22 @@ void fill_impl(bh::detail::accumulator_traits_holder<true, const double&>,
                py::kwargs& kwargs) {
     auto s = required_arg(kwargs, "sample");
     finalize_args(kwargs);
-    auto sarray = py::cast<c_array_t<double>>(s);
-
-    if(sarray.ndim() != 1)
-        throw std::invalid_argument("Sample array must be 1D");
+    auto sample = get_sample(s);
 
     // releasing gil here is safe, we don't manipulate refcounts
     const py::gil_scoped_release lock;
     variant::visit(
-        overload([&h, &vargs, &sarray](
-                     const variant::monostate&) { h.fill(vargs, bh::sample(sarray)); },
-                 [&h, &vargs, &sarray](const auto& w) {
-                     h.fill(vargs, bh::sample(sarray), bh::weight(w));
-                 }),
-        weight);
+        [&h, &vargs, &weight](const auto& sval) {
+            variant::visit(overload(
+                               [&h, &vargs, &sval](const variant::monostate&) {
+                                   h.fill(vargs, bh::sample(sval));
+                               },
+                               [&h, &vargs, &sval](const auto& w) {
+                                   h.fill(vargs, bh::sample(sval), bh::weight(w));
+                               }),
+                           weight);
+        },
+        sample);
 }
 
 // for multi_cell

--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -157,13 +157,12 @@ def _fill_cast(
 def mean_storage_sample_check(sample: ArrayLike | None) -> None:
     if sample is None:
         raise TypeError("Sample key-argument (sample=) needs to be provided.")
-    seqs = (collections.abc.Sequence, np.ndarray)
-    msg1 = f"Sample key-argument needs to be a sequence, {sample.__class__.__name__} given."
-    if isinstance(sample, str) or not isinstance(sample, seqs):
+    msg1 = f"Sample key-argument needs to be a number or a sequence, {sample.__class__.__name__} given."
+    if isinstance(sample, str):
         raise ValueError(msg1)
     sample_dim = np.ndim(sample)
-    msg2 = f"Sample key-argument needs to be 1 dimensional, {sample_dim} given."
-    if sample_dim != 1:
+    msg2 = f"Sample key-argument needs to be a scalar or 1 dimensional, {sample_dim} given."
+    if sample_dim > 1:
         raise ValueError(msg2)
 
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -71,3 +71,38 @@ def test_weighted_mean_hist_scalar_axis_broadcast():
     assert h[1].value == approx(30.0)
     assert h[2].sum_of_weights == approx(5.0)
     assert h[2].value == approx(300.0)
+
+
+def test_mean_hist_scalar_sample():
+    """A scalar sample is accepted like a scalar axis value (issue #646)."""
+    h = bh.Histogram(bh.axis.Regular(10, 0, 1), storage=bh.storage.Mean())
+    h.fill(0.3, sample=4)
+
+    ref = bh.Histogram(bh.axis.Regular(10, 0, 1), storage=bh.storage.Mean())
+    ref.fill(0.3, sample=[4])
+
+    assert h[3] == ref[3]
+
+
+def test_weighted_mean_hist_scalar_sample():
+    """A scalar sample is accepted like a scalar axis value (issue #646)."""
+    h = bh.Histogram(bh.axis.Regular(10, 0, 1), storage=bh.storage.WeightedMean())
+    h.fill(0.3, sample=4, weight=1.0)
+
+    ref = bh.Histogram(bh.axis.Regular(10, 0, 1), storage=bh.storage.WeightedMean())
+    ref.fill(0.3, sample=np.array([4]), weight=1.0)
+
+    assert h[3] == ref[3]
+
+
+def test_mean_hist_scalar_sample_broadcast():
+    """A scalar sample is broadcast across an array of axis values (issue #646)."""
+    h = bh.Histogram(bh.axis.Regular(10, 0, 1), storage=bh.storage.Mean())
+    h.fill([0.3, 0.31, 0.32], sample=4)
+
+    ref = bh.Histogram(bh.axis.Regular(10, 0, 1), storage=bh.storage.Mean())
+    ref.fill([0.3, 0.31, 0.32], sample=[4, 4, 4])
+
+    assert h[3] == ref[3]
+    assert h[3].count == 3
+    assert h[3].value == approx(4.0)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -135,7 +135,7 @@ def test_mean_storage_rejects_string_sample():
 
     with pytest.raises(
         ValueError,
-        match=r"Sample key-argument needs to be a sequence, str given\.",
+        match=r"Sample key-argument needs to be a number or a sequence, str given\.",
     ):
         h.fill([0.3], sample="abc")
 


### PR DESCRIPTION
:robot: Resolves #646.

## Problem

`h.fill(x=0.3, sample=4, weight=1.)` raised `ValueError: Sample array must be 1D`, even though scalar axis values and scalar weights already work. The blocker was our own validation in two layers — Boost.Histogram itself already broadcasts scalar samples natively (`to_ptr_size` treats scalars as broadcast).

## Changes

- **`include/bh_python/fill.hpp`** — added a `sample_t` variant (`double | c_array_t<double>`) and a `get_sample()` helper that accepts a scalar (via the same `is_value<double>` test used for axis args and weights) or a 1D array. A scalar sample is passed through `bh::sample(scalar)` so Boost broadcasts it against the other arguments.
- **`src/boost_histogram/histogram.py`** — relaxed `mean_storage_sample_check` to allow scalars. It still rejects `None` (TypeError), strings, and arrays with `ndim > 1`, with updated messages.
- **Tests** — added coverage in `test_profiles.py` for scalar samples on Mean and WeightedMean (matching the array form) plus scalar-sample broadcast across an array of axis values; updated the string-rejection message assertion in `test_storage.py`.

## Verification

- The exact reproduction from the issue now works; scalar samples match the explicit array equivalent and broadcast across array axis values.
- Rejection cases still behave correctly (missing sample, string, 2D arrays).
- `prek -a` clean; full suite passes (937 tests).

Out of scope: the secondary comment on #646 about Mean/WeightedMean *requiring* a sample and the docs wording — that's a separate concern from scalar support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)