### PR TITLE
test: regression test for scalar-broadcast fill on non-inclusive axis (#960)

### DIFF
--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -219,6 +219,39 @@ def test_noflow_cats():
     assert h.sum() == 2
 
 
+def _has_issue_960_bug():
+    # Probe for the upstream Boost.Histogram bug where a broadcast scalar argument
+    # invalidates an entire bulk fill when an earlier non-inclusive axis dropped the
+    # first array entry. Returns True while the (vendored) bug is present.
+    h = bh.Histogram(bh.axis.IntCategory([1], overflow=False), bh.axis.IntCategory([1]))
+    h.fill([0, 1], 1)  # first entry (0) is out of range on the non-inclusive axis
+    return h.sum() == 0
+
+
+@pytest.mark.xfail(
+    _has_issue_960_bug(),
+    reason="upstream Boost.Histogram bug, fixed upstream; pending boost bump (#960)",
+    strict=True,
+)
+def test_noflow_cat_scalar_broadcast():
+    # https://github.com/scikit-hep/boost-histogram/issues/960
+    # A broadcast scalar on a later axis must not zero the whole fill when an earlier
+    # non-inclusive axis drops the first array entry.
+    h = bh.Histogram(
+        bh.axis.IntCategory([1, 2, 3], overflow=False),
+        bh.axis.StrCategory(["nominal"]),
+        storage=bh.storage.Weight(),
+    )
+    values = np.array([-1, 1, 2, 3, 1])  # first entry (-1) is out of range
+    h.fill(values, "nominal", weight=np.ones_like(values, dtype=float))
+
+    # only the out-of-range -1 is dropped; everything else is kept
+    assert h.sum().value == 4
+    assert h[bh.loc(1), bh.loc("nominal")].value == 2
+    assert h[bh.loc(2), bh.loc("nominal")].value == 1
+    assert h[bh.loc(3), bh.loc("nominal")].value == 1
+
+
 def test_metadata_add():
     h1 = bh.Histogram(
         bh.axis.IntCategory([1, 2, 3]), bh.axis.StrCategory(["1", "2", "3"])


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a regression test for #960.

## The bug

A bulk `fill` that mixes an **array** argument with a **broadcast scalar** argument zeroes the *entire* histogram when an earlier **non-inclusive** axis (no flow, no growth) drops the **first** array entry — instead of dropping only the out-of-range entries. Single-value `h(x, y)` fills are unaffected; only the bulk path is wrong.

The root cause is upstream in Boost.Histogram (`detail/fill_n.hpp`, `index_visitor::call_1`, scalar/broadcast path): it reads validity back from the first index-buffer entry `*begin_`, which a previously-processed non-inclusive axis may already have set to `invalid_index`. Because `optional_index` is "sticky", a valid scalar then leaves `*begin_` invalid and the whole buffer is `std::fill`-ed with `invalid_index`. An upstream report + fix are being submitted to boostorg/histogram separately.

## This PR

Adds `test_noflow_cat_scalar_broadcast` reproducing the exact scenario (`IntCategory(overflow=False)` + `StrCategory`, `Weight` storage, array with a leading out-of-range value + a broadcast scalar string), asserting only the out-of-range entry is dropped.

The test is guarded by a runtime probe `_has_issue_960_bug()` driving an `xfail(strict=True)` marker, so it is **self-adjusting**:

- **While the vendored Boost still has the bug** (today, and CI now) → the probe detects it → the test **xfails** → CI stays green.
- **Once the upstream fix lands** (via `nox -s bump_boost`) → the probe returns clean → the marker deactivates → the test runs as a **live, strict regression test**.

No marker to remember to remove — it converts to live protection automatically when the boost bump lands. Verified both directions by building against patched and pristine Boost.