### PR TITLE
fix: clear error for unsupported histogram inplace operations

### DIFF
--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -99,6 +99,17 @@ _histograms: set[type[CppHistogram]] = {
 
 logger = logging.getLogger(__name__)
 
+# User-facing operator symbols for the in-place dunders dispatched in
+# _compute_inplace_op, used to build clear errors when a storage's underlying
+# C++ histogram does not support an operation between two histograms.
+_INPLACE_OP_SYMBOLS: dict[str, str] = {
+    "__iadd__": "+",
+    "__isub__": "-",
+    "__imul__": "*",
+    "__idiv__": "/",
+    "__itruediv__": "/",
+}
+
 
 CppAxis = NewType("CppAxis", object)
 
@@ -740,14 +751,29 @@ class Histogram(typing.Generic[S]):
     def __imul__(self, other: Histogram[S] | np.typing.NDArray[Any] | float) -> Self:
         return self._compute_inplace_op("__imul__", other)
 
+    def _hist_inplace_op(self, name: str, other: CppHistogram) -> None:
+        # The underlying C++ histogram only exposes the in-place dunders its
+        # storage supports (e.g. weight/mean/multi_cell storages have no
+        # __isub__). Calling a missing one raises a confusing AttributeError
+        # leaking the dunder name, so surface a clear error instead.
+        op = getattr(self._hist, name, None)
+        if op is None:
+            symbol = _INPLACE_OP_SYMBOLS.get(name, name)
+            msg = (
+                f"The {self.storage_type.__name__} storage does not support the "
+                f"{symbol!r} operation between two histograms"
+            )
+            raise TypeError(msg)
+        op(other)
+
     def _compute_inplace_op(
         self, name: str, other: Histogram[S] | np.typing.NDArray[Any] | float
     ) -> Self:
         # Also takes CppHistogram, but that confuses mypy because it's hard to pick out
         if isinstance(other, Histogram):
-            getattr(self._hist, name)(other._hist)
+            self._hist_inplace_op(name, other._hist)
         elif isinstance(other, tuple(_histograms)):
-            getattr(self._hist, name)(other)
+            self._hist_inplace_op(name, other)  # type: ignore[arg-type]
         elif hasattr(other, "shape") and other.shape:
             assert not isinstance(other, float)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -459,6 +459,33 @@ def test_multi_cell_add_mismatched_nelem():
         h3 + h2
 
 
+# Issue #1128
+@pytest.mark.parametrize(
+    ("storage", "fill_kwargs"),
+    [
+        (bh.storage.MultiCell(3), {"weight": np.array([[1, 2, 3]])}),
+        (bh.storage.Weight(), {}),
+        (bh.storage.Mean(), {"sample": [1]}),
+        (bh.storage.WeightedMean(), {"sample": [1], "weight": [1]}),
+    ],
+    ids=["MultiCell", "Weight", "Mean", "WeightedMean"],
+)
+def test_unsupported_histogram_subtraction(storage, fill_kwargs):
+    # Storages whose C++ backend has no __isub__ must raise a clear TypeError
+    # rather than leaking the dunder name via AttributeError.
+    def mk():
+        h = bh.Histogram(bh.axis.Regular(5, 0, 5), storage=storage)
+        h.fill([1], **fill_kwargs)
+        return h
+
+    name = type(storage).__name__
+    with pytest.raises(
+        TypeError,
+        match=rf"{name} storage does not support the '-' operation",
+    ):
+        mk() - mk()
+
+
 @pytest.mark.parametrize("nelem", [1, 3])
 def test_multi_cell_reset(nelem):
     h = _filled_multi_cell(nelem)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #1128.

## Problem

Subtracting one histogram from another raised a confusing internal error when the storage's underlying C++ histogram has no `__isub__`:

```python
mk() - mk()
# AttributeError: 'boost_histogram._core.hist.any_multi_cell' object has no attribute '__isub__'
```

While #1128 was filed about `MultiCell`, this is **not** MultiCell-specific — the same `AttributeError` leaked for `Weight`, `Mean`, and `WeightedMean`. Only the simple count storages (`Double`, `Int64`, …) define `__isub__` in C++, and `test_sub_2d` already excludes `Weight` from histogram−histogram subtraction, so "non-simple storages don't support hist−hist subtraction" is the established design.

## Fix

The two histogram−histogram branches of `_compute_inplace_op` now go through a small `_hist_inplace_op` helper that checks for the dunder and raises a clear `TypeError` instead of leaking it:

```
TypeError: The MultiCell storage does not support the '-' operation between two histograms
```

Scalar and array operations (`h - 2`, `h - h.view() * 4`, `*`, `/`) go through the NumPy view and are unaffected. Supported histogram−histogram operations (e.g. `+`) are unchanged.

## Tests

`test_unsupported_histogram_subtraction` in `tests/test_storage.py`, parametrized over `MultiCell`, `Weight`, `Mean`, and `WeightedMean`, asserting the clear `TypeError`.