### PR TITLE
feat: support subtraction for the MultiCell storage

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 #### Features
 
 - Support `flow=False` in histogram projections by @Rishabh-git10 in [#1109][]
+- Support subtraction for the `MultiCell` storage by @henryiii in [#1131][]
 
 #### Fixes
 
@@ -47,6 +48,7 @@
 [#1105]: https://github.com/scikit-hep/boost-histogram/pull/1105
 [#1106]: https://github.com/scikit-hep/boost-histogram/pull/1106
 [#1109]: https://github.com/scikit-hep/boost-histogram/pull/1109
+[#1131]: https://github.com/scikit-hep/boost-histogram/pull/1131
 [#1132]: https://github.com/scikit-hep/boost-histogram/pull/1132
 
 ### Version 1.7.1

--- a/include/bh_python/multi_cell.hpp
+++ b/include/bh_python/multi_cell.hpp
@@ -45,6 +45,14 @@ struct multi_cell_reference : public multi_cell_base<T, boost::span<T>> {
             *it++ += x;
     }
 
+    void operator-=(const boost::span<T> values) {
+        if(values.size() != this->size())
+            throw std::range_error("size does not match for -= ref");
+        auto it = this->begin();
+        for(const T& x : values)
+            *it++ -= x;
+    }
+
     template <class S>
     multi_cell_reference& operator=(const S& values) {
         if(values.size() != this->size())
@@ -78,6 +86,23 @@ struct multi_cell_value : public multi_cell_base<T, std::vector<T>> {
         auto it = this->begin();
         for(const T& x : values)
             *it++ += x;
+    }
+
+    void operator-=(const boost::span<T>& values) {
+        if(values.size() != this->size()) {
+            if(this->size() > 0) {
+                throw std::range_error("size does not match for -= val");
+            }
+            // Subtracting into an uninitialized cell yields the negation.
+            this->resize(values.size());
+            auto it = this->begin();
+            for(const T& x : values)
+                *it++ = -x;
+            return;
+        }
+        auto it = this->begin();
+        for(const T& x : values)
+            *it++ -= x;
     }
 
     template <class S>
@@ -203,6 +228,16 @@ class multi_cell {
         }
         for(std::size_t i = 0; i < size_ * nelem_; i++) {
             buffer_[i] += other.buffer_[i];
+        }
+    }
+
+    template <class T>
+    void operator-=(const multi_cell<T>& other) {
+        if(size_ * nelem_ != other.size_ * other.nelem_) {
+            throw std::range_error("size does not match");
+        }
+        for(std::size_t i = 0; i < size_ * nelem_; i++) {
+            buffer_[i] -= other.buffer_[i];
         }
     }
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import operator
 
 import numpy as np
 import pytest
@@ -425,6 +426,16 @@ def test_multi_cell_arithmetic(nelem):
     h_iadd += h
     assert_array_equal(h_iadd.view(), base * 2)
 
+    # Histogram - Histogram (element-wise on the cells), including the in-place
+    # form and a result with negative cells
+    assert_array_equal((h - h).view(), base * 0)
+    assert_array_equal((h + h - h).view(), base)
+    assert_array_equal((h - h - h).view(), -base)
+
+    h_isub = _filled_multi_cell(nelem)
+    h_isub -= h
+    assert_array_equal(h_isub.view(), base * 0)
+
     # Scalar multiplication / division (both orders and in-place)
     assert_array_equal((h * 2).view(), base * 2)
     assert_array_equal((2 * h).view(), base * 2)
@@ -452,27 +463,28 @@ def test_multi_cell_equality(nelem):
     assert not (h1 == h2)  # noqa: SIM201
 
 
-def test_multi_cell_add_mismatched_nelem():
+@pytest.mark.parametrize("op", [operator.add, operator.sub], ids=["add", "sub"])
+def test_multi_cell_mismatched_nelem(op):
     h3 = _filled_multi_cell(3)
     h2 = _filled_multi_cell(2)
     with pytest.raises(ValueError, match="size does not match"):
-        h3 + h2
+        op(h3, h2)
 
 
 # Issue #1128
 @pytest.mark.parametrize(
     ("storage", "fill_kwargs"),
     [
-        (bh.storage.MultiCell(3), {"weight": np.array([[1, 2, 3]])}),
         (bh.storage.Weight(), {}),
         (bh.storage.Mean(), {"sample": [1]}),
         (bh.storage.WeightedMean(), {"sample": [1], "weight": [1]}),
     ],
-    ids=["MultiCell", "Weight", "Mean", "WeightedMean"],
+    ids=["Weight", "Mean", "WeightedMean"],
 )
 def test_unsupported_histogram_subtraction(storage, fill_kwargs):
     # Storages whose C++ backend has no __isub__ must raise a clear TypeError
-    # rather than leaking the dunder name via AttributeError.
+    # rather than leaking the dunder name via AttributeError. (MultiCell does
+    # support subtraction; see test_multi_cell_arithmetic.)
     def mk():
         h = bh.Histogram(bh.axis.Regular(5, 0, 5), storage=storage)
         h.fill([1], **fill_kwargs)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to #1128 / #1130.

> **Stacked on #1130** — based on that branch since it edits the `test_unsupported_histogram_subtraction` test #1130 introduced. The diff will collapse to just this change once #1130 merges into `develop`; until then it shows both commits.

## What

`MultiCell` cells are plain `double` vectors, so histogram−histogram subtraction is well-defined element-wise (unlike `Mean`/`WeightedMean`, whose accumulators can't be meaningfully subtracted). This enables it.

## How

`__isub__` is registered automatically for any histogram whose cell type supports `operator-=`, via the existing `def_optionally(hist, has_operator_rsub<...>{}, py::self -= py::self)` in `register_histogram.hpp`. `multi_cell` only defined `operator+=`, so the gate was `false`.

This adds `operator-=` to the three cooperating types in `include/bh_python/multi_cell.hpp` (`multi_cell_reference`, `multi_cell_value`, and the `multi_cell` storage), mirroring the existing `operator+=`. That flips the gate to `true` and exposes both `-` and `-=` — **no Python changes required**.

It composes with #1130: `_hist_inplace_op` now *finds* `__isub__` for `MultiCell`, while `Weight`/`Mean`/`WeightedMean` still hit the `None` branch and raise the clear `TypeError`.

## Tests (`tests/test_storage.py`)

- `test_multi_cell_arithmetic` extended with `h - h`, `h + h - h`, `h - h - h` (negative cells), and in-place `-=`.
- `test_multi_cell_add_mismatched_nelem` → `test_multi_cell_mismatched_nelem`, now parametrized over `add`/`sub` (both raise on mismatched `nelem`).
- `MultiCell` dropped from `test_unsupported_histogram_subtraction` (it now works); `Weight`/`Mean`/`WeightedMean` retained.

Verified: subtraction (incl. flow bins and negatives) works; mismatched `nelem` raises `ValueError`; the other three storages still raise `TypeError`; `prek` lint + mypy clean; `test_histogram.py`/`test_storage.py`/`test_pickle.py` pass (455).