### PR TITLE
fix: zero-fill MultiCell sum() over zero bins

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@
 
 - Support `flow=False` in histogram projections by @Rishabh-git10 in [#1109][]
 
+#### Fixes
+
+- Return a zero-filled vector from `MultiCell` `sum()` over zero bins instead of an empty list by @henryiii in [#1132][]
+
 ## Version 1.7
 
 ### Version 1.7.2
@@ -43,6 +47,7 @@
 [#1105]: https://github.com/scikit-hep/boost-histogram/pull/1105
 [#1106]: https://github.com/scikit-hep/boost-histogram/pull/1106
 [#1109]: https://github.com/scikit-hep/boost-histogram/pull/1109
+[#1132]: https://github.com/scikit-hep/boost-histogram/pull/1132
 
 ### Version 1.7.1
 

--- a/include/bh_python/register_histogram.hpp
+++ b/include/bh_python/register_histogram.hpp
@@ -367,8 +367,16 @@ auto inline register_histogram<bh::multi_cell<double>>(py::module& m,
             "sum",
             [](const histogram_t& self, bool flow) -> value_type {
                 const py::gil_scoped_release release;
-                return bh::algorithm::sum(
+                value_type result = bh::algorithm::sum(
                     self, flow ? bh::coverage::all : bh::coverage::inner);
+                // A histogram with zero bins has no cells to accumulate, so the
+                // default-constructed accumulator stays empty. Return a
+                // zero-filled vector of length nelem so the result shape is
+                // consistent with the non-empty case.
+                if(result.empty()) {
+                    result.assign(bh::unsafe_access::storage(self).nelem(), 0.0);
+                }
+                return result;
             },
             "flow"_a = false)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -495,15 +495,18 @@ def test_multi_cell_reset(nelem):
     assert_array_equal(h.view(flow=True), np.zeros_like(h.view(flow=True)))
 
 
+# Issue #1129
 def test_multi_cell_empty_axis():
-    # An empty categorical axis means zero bins, so the per-cell sum is empty.
+    # An empty categorical axis means zero bins, but the sum is still reported
+    # as a zero-filled vector of length nelem for consistency with non-empty
+    # histograms (rather than an empty list).
     h = bh.Histogram(
         bh.axis.Regular(10, 0, 10),
         bh.axis.StrCategory([], growth=True),
         storage=bh.storage.MultiCell(3),
     )
-    assert h.sum() == []
-    assert h.sum(flow=True) == []
+    assert h.sum() == [0.0, 0.0, 0.0]
+    assert h.sum(flow=True) == [0.0, 0.0, 0.0]
 
 
 def test_multi_cell():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #1129.

## Problem

A `MultiCell(nelem)` histogram with zero bins (e.g. an empty growth categorical axis) returned an empty list from `sum()` instead of a length-`nelem` zero vector:

```python
h = bh.Histogram(
    bh.axis.Regular(10, 0, 10),
    bh.axis.StrCategory([], growth=True),
    storage=bh.storage.MultiCell(3),
)
h.sum()          # [] -> now [0.0, 0.0, 0.0]
h.sum(flow=True) # [] -> now [0.0, 0.0, 0.0]
```

A normally-filled MultiCell histogram returns a length-`nelem` list (e.g. `[12.0, 15.0, 18.0]`), so the empty case was inconsistent.

## Cause

`bh::algorithm::sum` seeds its accumulator with a default-constructed `multi_cell_value` (an empty vector, since the default has no `nelem`) and `+=` each cell. With zero bins nothing is accumulated, so it stays empty.

## Fix

In the `multi_cell` `sum` binding (`include/bh_python/register_histogram.hpp`), when the accumulated result is empty, seed it with `nelem` zeros via `bh::unsafe_access::storage(self).nelem()`. Pure C++ change; the non-empty path is unchanged.

## Tests

Updated `test_multi_cell_empty_axis` (from #1127, which pinned the old `[]` behavior) to assert `[0.0, 0.0, 0.0]` for both `sum()` and `sum(flow=True)`.

Verified: empty cat axis (1D/2D), `nelem=1`, and unfilled-but-binned histograms all return the right-length zero vector; non-empty sums unchanged; full suite passes (955).