### PR TITLE
feat: addable Mean/WeightedMean views (#276)

### DIFF
--- a/src/boost_histogram/view.py
+++ b/src/boost_histogram/view.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping, MutableMapping
-from typing import Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import numpy as np
 
@@ -15,6 +15,11 @@ class View(np.ndarray[Any, Any]):
     __slots__ = ()
     _FIELDS: ClassVar[tuple[str, ...]]
     _PARENT: type[WeightedSum | WeightedMean | Mean]
+
+    # Whether ``a - b`` (and unary ``-``) and multiplying/dividing two views are
+    # meaningful for this view. Overridden per subclass.
+    _SUPPORTS_SUB: ClassVar[bool] = False
+    _SUPPORTS_VIEW_PRODUCT: ClassVar[bool] = False
 
     def __getitem__(self, ind: StrIndex) -> np.typing.NDArray[Any]:  # type: ignore[override]
         sliced = super().__getitem__(ind)  # type: ignore[index]
@@ -65,6 +70,117 @@ class View(np.ndarray[Any, Any]):
         msg += f", {current_ndim}D {self.dtype} or {current_ndim + 1}D required, got {array.ndim}D {array.dtype}"
         raise ValueError(msg)
 
+    # ------------------------------------------------------------------
+    # Arithmetic: shared ufunc scaffolding that dispatches the field math
+    # to per-view hooks (``_combine``/``_add_scalar``/``_scale``/...).
+    # ------------------------------------------------------------------
+    def __array_ufunc__(
+        self, ufunc: Ufunc, method: UFMethod, *inputs: Any, **kwargs: Any
+    ) -> np.typing.NDArray[Any]:
+        # Avoid infinite recursion by working with plain ndarrays
+        raw_inputs = [np.asarray(x) for x in inputs]
+
+        # Reductions (``.sum()`` / ``np.add.reduce``) don't get a pre-allocated
+        # ``out`` here; the hook builds the reduced accumulator(s) itself.
+        match method, ufunc, raw_inputs:
+            case "reduce", np.add, [raw_input]:
+                return self._reduce(raw_input, **kwargs)
+
+        # Everything else fills a pre-allocated result of this view's dtype
+        (result,) = (
+            kwargs.pop("out") if "out" in kwargs else [np.empty(self.shape, self.dtype)]
+        )
+        match method, ufunc, raw_inputs:
+            # Unary + and -
+            case "__call__", (np.negative | np.positive), [raw_input]:
+                self._unary(raw_input, result, ufunc, **kwargs)
+                return result.view(self.__class__)
+
+            # Addition and subtraction
+            case "__call__", (np.add | np.subtract), [raw1, raw2]:
+                if ufunc is np.subtract and not self._SUPPORTS_SUB:
+                    raise TypeError(
+                        f"{self.__class__.__name__} does not support subtraction"
+                    )
+                if raw1.dtype == raw2.dtype:
+                    self._combine(raw1, raw2, result, ufunc, **kwargs)
+                else:
+                    self._add_scalar(raw1, raw2, result, ufunc, **kwargs)
+                return result.view(self.__class__)
+
+            # Multiplication and division
+            case (
+                "__call__",
+                (np.multiply | np.divide | np.true_divide | np.floor_divide),
+                [raw1, raw2],
+            ):
+                if raw1.dtype == raw2.dtype:
+                    if not self._SUPPORTS_VIEW_PRODUCT:
+                        raise TypeError(
+                            f"{self.__class__.__name__} does not support multiplying "
+                            "or dividing two views"
+                        )
+                    self._product(raw1, raw2, result, ufunc, **kwargs)
+                else:
+                    self._scale(raw1, raw2, result, ufunc, **kwargs)
+                return result.view(self.__class__)
+
+            # Cumulative sums (``np.cumsum`` / ``np.add.accumulate``)
+            case "accumulate", np.add, [raw_input]:
+                self._accumulate(raw_input, result, **kwargs)
+                return result.view(self.__class__)
+
+        # If unsupported, just pass through (will return not implemented)
+        # pylint: disable-next=no-member
+        return super().__array_ufunc__(ufunc, method, *raw_inputs, **kwargs)  # type: ignore[no-any-return]
+
+    # --- Arithmetic hooks; the defaults are the field-wise (linear) behavior
+    # correct for additive storages like WeightedSum. Non-linear views (means)
+    # override the ones they need and reject the rest. ---
+
+    def _unary(self, raw: Any, out: Any, ufunc: Ufunc, **kwargs: Any) -> None:
+        del raw, out, kwargs
+        raise TypeError(
+            f"{self.__class__.__name__} does not support unary {ufunc.__name__}"
+        )
+
+    def _combine(
+        self, raw1: Any, raw2: Any, out: Any, ufunc: Ufunc, **kwargs: Any
+    ) -> None:
+        del raw1, raw2, out, ufunc, kwargs
+        raise TypeError(f"{self.__class__.__name__} does not support this operation")
+
+    def _add_scalar(
+        self, raw1: Any, raw2: Any, out: Any, ufunc: Ufunc, **kwargs: Any
+    ) -> None:
+        del raw1, raw2, out, kwargs
+        raise TypeError(
+            f"{self.__class__.__name__} does not support {ufunc.__name__} "
+            "with a scalar or array"
+        )
+
+    def _scale(
+        self, raw1: Any, raw2: Any, out: Any, ufunc: Ufunc, **kwargs: Any
+    ) -> None:
+        del raw1, raw2, out, kwargs
+        raise TypeError(f"{self.__class__.__name__} does not support {ufunc.__name__}")
+
+    def _product(
+        self, raw1: Any, raw2: Any, out: Any, ufunc: Ufunc, **kwargs: Any
+    ) -> None:
+        del raw1, raw2, out, ufunc, kwargs
+        raise TypeError(
+            f"{self.__class__.__name__} does not support multiplying two views"
+        )
+
+    def _reduce(self, raw: Any, **kwargs: Any) -> np.typing.NDArray[Any]:
+        results = (np.add.reduce(raw[field], **kwargs) for field in self._FIELDS)
+        return self._PARENT._make(*results)  # type: ignore[return-value]
+
+    def _accumulate(self, raw: Any, out: Any, **kwargs: Any) -> None:
+        for field in self._FIELDS:
+            np.add.accumulate(raw[field], out=out[field], **kwargs)
+
 
 def make_getitem_property(name: str) -> property:
     def fget(self: Mapping[str, Any]) -> Any:
@@ -110,120 +226,164 @@ def fields(*names: str) -> Callable[[type[object]], type[object]]:
 class WeightedSumView(View):
     __slots__ = ()
     _PARENT = WeightedSum
+    _SUPPORTS_SUB = True
 
     value: np.typing.NDArray[Any]
     variance: np.typing.NDArray[Any]
 
-    # Could be implemented on master View
-    def __array_ufunc__(
-        self, ufunc: Ufunc, method: UFMethod, *inputs: Any, **kwargs: Any
-    ) -> np.typing.NDArray[Any]:
-        # Avoid infinite recursion
-        raw_inputs = [np.asarray(x) for x in inputs]
+    def _unary(self, raw: Any, out: Any, ufunc: Ufunc, **kwargs: Any) -> None:
+        ufunc(raw["value"], out=out["value"], **kwargs)
+        out["variance"] = raw["variance"]
 
-        # First match the ones without a pre-computed out= parameter
-        match method, ufunc, raw_inputs:
-            case "reduce", np.add, [raw_input]:
-                results = (
-                    ufunc.reduce(raw_input[field], **kwargs) for field in self._FIELDS
-                )
-                return self._PARENT._make(*results)  # type: ignore[return-value]
+    def _combine(
+        self, raw1: Any, raw2: Any, out: Any, ufunc: Ufunc, **kwargs: Any
+    ) -> None:
+        # Values add/subtract; independent variances always add.
+        ufunc(raw1["value"], raw2["value"], out=out["value"], **kwargs)
+        np.add(raw1["variance"], raw2["variance"], out=out["variance"], **kwargs)
 
-        # These use a pre-computed out parameter
-        (result,) = (
-            kwargs.pop("out") if "out" in kwargs else [np.empty(self.shape, self.dtype)]
+    def _add_scalar(
+        self, raw1: Any, raw2: Any, out: Any, ufunc: Ufunc, **kwargs: Any
+    ) -> None:
+        # The scalar/array operand is treated as a constant with variance s**2.
+        if raw1.dtype == self.dtype:
+            ufunc(raw1["value"], raw2, out=out["value"], **kwargs)
+            np.add(raw1["variance"], raw2**2, out=out["variance"], **kwargs)
+        else:
+            ufunc(raw1, raw2["value"], out=out["value"], **kwargs)
+            np.add(raw1**2, raw2["variance"], out=out["variance"], **kwargs)
+
+    def _scale(
+        self, raw1: Any, raw2: Any, out: Any, ufunc: Ufunc, **kwargs: Any
+    ) -> None:
+        # Multiplying/dividing by a scalar scales the variance by s**2.
+        if raw1.dtype == self.dtype:
+            ufunc(raw1["value"], raw2, out=out["value"], **kwargs)
+            ufunc(raw1["variance"], raw2**2, out=out["variance"], **kwargs)
+        else:
+            ufunc(raw1, raw2["value"], out=out["value"], **kwargs)
+            ufunc(raw1**2, raw2["variance"], out=out["variance"], **kwargs)
+
+
+class _MeanArithmetic:
+    """Combine + scalar-scaling arithmetic shared by the mean-like views.
+
+    Addition combines two samples (the Welford/West parallel merge, mirroring the
+    C++ ``mean``/``weighted_mean`` ``operator+=``); multiplication/division by a
+    scalar scales the mean and ``_sum_of_*deltas_squared`` (by ``s`` and ``s**2``
+    respectively) while leaving the weights untouched (mirroring ``operator*=``).
+    Subtraction, scalar addition, unary minus, and cumulative sums are undefined
+    for means and fall through to the rejecting :class:`View` defaults.
+    """
+
+    __slots__ = ()
+
+    # Field names supplied by the concrete view subclass.
+    _WEIGHT_FIELD: ClassVar[str]
+    _DELTAS_FIELD: ClassVar[str]
+    _WEIGHT_SQ_FIELD: ClassVar[str | None] = None
+
+    if TYPE_CHECKING:
+        # Provided by the View base that the concrete subclass also inherits.
+        _FIELDS: ClassVar[tuple[str, ...]]
+        _PARENT: type[Mean | WeightedMean]
+        dtype: np.dtype[Any]
+
+    def _combine(
+        self, raw1: Any, raw2: Any, out: Any, ufunc: Ufunc, **kwargs: Any
+    ) -> None:
+        # Means only ever reach here for addition (subtraction is rejected).
+        del ufunc, kwargs
+        weight, deltas, weight_sq = (
+            self._WEIGHT_FIELD,
+            self._DELTAS_FIELD,
+            self._WEIGHT_SQ_FIELD,
         )
-        match method, ufunc, raw_inputs:
-            # Support unary + and -
-            case "__call__", np.negative | np.positive, [raw_input]:
-                ufunc(raw_input["value"], out=result["value"], **kwargs)
-                result["variance"] = raw_input["variance"]
-                return result.view(self.__class__)
-            # Support + and -
-            case "__call__", np.add | np.subtract, [raw_input1, raw_input2]:
-                if raw_input1.dtype == raw_input2.dtype:
-                    ufunc(
-                        raw_input1["value"],
-                        raw_input2["value"],
-                        out=result["value"],
-                        **kwargs,
-                    )
-                    np.add(
-                        raw_input1["variance"],
-                        raw_input2["variance"],
-                        out=result["variance"],
-                        **kwargs,
-                    )
-                elif self.dtype == raw_input1.dtype:
-                    ufunc(
-                        raw_input1["value"],
-                        raw_input2,
-                        out=result["value"],
-                        **kwargs,
-                    )
-                    np.add(
-                        raw_input1["variance"],
-                        raw_input2**2,
-                        out=result["variance"],
-                        **kwargs,
-                    )
-                else:
-                    ufunc(
-                        raw_input1,
-                        raw_input2["value"],
-                        out=result["value"],
-                        **kwargs,
-                    )
-                    np.add(
-                        raw_input1**2,
-                        raw_input2["variance"],
-                        out=result["variance"],
-                        **kwargs,
-                    )
-                return result.view(self.__class__)
+        n1, n2 = raw1[weight], raw2[weight]
+        mu1, mu2 = raw1["value"], raw2["value"]
 
-            case (
-                "__call__",
-                np.multiply | np.divide | np.true_divide | np.floor_divide,
-                [raw_input1, raw_input2],
-            ):
-                if self.dtype == raw_input1.dtype:
-                    ufunc(
-                        raw_input1["value"],
-                        raw_input2,
-                        out=result["value"],
-                        **kwargs,
-                    )
-                    ufunc(
-                        raw_input1["variance"],
-                        raw_input2**2,
-                        out=result["variance"],
-                        **kwargs,
-                    )
-                else:
-                    ufunc(
-                        raw_input1,
-                        raw_input2["value"],
-                        out=result["value"],
-                        **kwargs,
-                    )
-                    ufunc(
-                        raw_input1**2,
-                        raw_input2["variance"],
-                        out=result["variance"],
-                        **kwargs,
-                    )
+        total = n1 + n2
+        # New mean = weight-weighted average; 0 (not NaN) where both are empty.
+        new_value = np.zeros_like(total)
+        np.divide(n1 * mu1 + n2 * mu2, total, out=new_value, where=(total != 0))
 
-                return result.view(self.__class__)
+        # ``deltas`` uses the *new* value; empty operands contribute nothing.
+        # Compute every field into a fresh array *before* writing, so an
+        # in-place ``v += other`` (where ``out`` aliases ``raw1``) is correct.
+        new_deltas = (
+            raw1[deltas]
+            + raw2[deltas]
+            + n1 * (new_value - mu1) ** 2
+            + n2 * (new_value - mu2) ** 2
+        )
+        new_weight_sq = None if weight_sq is None else raw1[weight_sq] + raw2[weight_sq]
 
-            case "accumulate", np.add, [raw_input]:
-                for field in self._FIELDS:
-                    ufunc.accumulate(self[field], out=result[field], **kwargs)
-                return result.view(self.__class__)
+        out[weight] = total
+        out["value"] = new_value
+        out[deltas] = new_deltas
+        if weight_sq is not None:
+            out[weight_sq] = new_weight_sq
 
-        # If unsupported, just pass through (will return not implemented)
-        # pylint: disable-next=no-member
-        return super().__array_ufunc__(ufunc, method, *raw_inputs, **kwargs)  # type: ignore[no-any-return]
+    def _scale(
+        self, raw1: Any, raw2: Any, out: Any, ufunc: Ufunc, **kwargs: Any
+    ) -> None:
+        del kwargs
+        weight, deltas, weight_sq = (
+            self._WEIGHT_FIELD,
+            self._DELTAS_FIELD,
+            self._WEIGHT_SQ_FIELD,
+        )
+        if raw1.dtype == self.dtype:
+            view, scalar = raw1, raw2
+        else:
+            # ``scalar / view`` is not a meaningful scaling of a mean.
+            if ufunc in (np.divide, np.true_divide, np.floor_divide):
+                raise TypeError(
+                    f"Cannot divide a scalar or array by a {self.__class__.__name__}"
+                )
+            view, scalar = raw2, raw1
+
+        out[weight] = view[weight]
+        out["value"] = ufunc(view["value"], scalar)
+        # Applying ``ufunc`` twice yields *s**2 (multiply) or /s**2 (divide).
+        out[deltas] = ufunc(ufunc(view[deltas], scalar), scalar)
+        if weight_sq is not None:
+            out[weight_sq] = view[weight_sq]
+
+    def _reduce(self, raw: Any, **kwargs: Any) -> np.typing.NDArray[Any]:
+        weight, deltas, weight_sq = (
+            self._WEIGHT_FIELD,
+            self._DELTAS_FIELD,
+            self._WEIGHT_SQ_FIELD,
+        )
+        axis = kwargs.get("axis", 0)
+        counts = raw[weight]
+        values = raw["value"]
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            total = np.add.reduce(counts, axis=axis)
+            combined = np.where(
+                total != 0,
+                np.add.reduce(counts * values, axis=axis) / total,
+                0.0,
+            )
+            combined_b = combined if axis is None else np.expand_dims(combined, axis)
+            new_deltas = np.add.reduce(raw[deltas], axis=axis) + np.add.reduce(
+                counts * (values - combined_b) ** 2, axis=axis
+            )
+
+        out_fields: dict[str, Any] = {
+            weight: total,
+            "value": combined,
+            deltas: new_deltas,
+        }
+        if weight_sq is not None:
+            out_fields[weight_sq] = np.add.reduce(raw[weight_sq], axis=axis)
+        return self._PARENT._make(*(out_fields[name] for name in self._FIELDS))  # type: ignore[return-value]
+
+    def _accumulate(self, raw: Any, out: Any, **kwargs: Any) -> None:
+        del raw, out, kwargs
+        raise TypeError(f"{self.__class__.__name__} does not support cumulative sums")
 
 
 @fields(
@@ -232,9 +392,13 @@ class WeightedSumView(View):
     "value",
     "_sum_of_weighted_deltas_squared",
 )
-class WeightedMeanView(View):
+class WeightedMeanView(_MeanArithmetic, View):
     __slots__ = ()
     _PARENT = WeightedMean
+
+    _WEIGHT_FIELD = "sum_of_weights"
+    _DELTAS_FIELD = "_sum_of_weighted_deltas_squared"
+    _WEIGHT_SQ_FIELD = "sum_of_weights_squared"
 
     sum_of_weights: np.typing.NDArray[Any]
     sum_of_weights_squared: np.typing.NDArray[Any]
@@ -251,9 +415,13 @@ class WeightedMeanView(View):
 
 
 @fields("count", "value", "_sum_of_deltas_squared")
-class MeanView(View):
+class MeanView(_MeanArithmetic, View):
     __slots__ = ()
     _PARENT = Mean
+
+    _WEIGHT_FIELD = "count"
+    _DELTAS_FIELD = "_sum_of_deltas_squared"
+    _WEIGHT_SQ_FIELD = None
 
     count: np.typing.NDArray[Any]
     value: np.typing.NDArray[Any]

--- a/src/boost_histogram/view.py
+++ b/src/boost_histogram/view.py
@@ -328,6 +328,12 @@ class _MeanArithmetic:
         self, raw1: Any, raw2: Any, out: Any, ufunc: Ufunc, **kwargs: Any
     ) -> None:
         del kwargs
+        # Floor division would truncate the (floating-point) mean and deltas, so
+        # it is not a meaningful scaling of a mean accumulator.
+        if ufunc is np.floor_divide:
+            raise TypeError(
+                f"{self.__class__.__name__} does not support floor division"
+            )
         weight, deltas, weight_sq = (
             self._WEIGHT_FIELD,
             self._DELTAS_FIELD,
@@ -335,17 +341,19 @@ class _MeanArithmetic:
         )
         if raw1.dtype == self.dtype:
             view, scalar = raw1, raw2
-        else:
+        elif ufunc in (np.divide, np.true_divide):
             # ``scalar / view`` is not a meaningful scaling of a mean.
-            if ufunc in (np.divide, np.true_divide, np.floor_divide):
-                raise TypeError(
-                    f"Cannot divide a scalar or array by a {self.__class__.__name__}"
-                )
+            raise TypeError(
+                f"Cannot divide a scalar or array by a {self.__class__.__name__}"
+            )
+        else:
             view, scalar = raw2, raw1
 
         out[weight] = view[weight]
         out["value"] = ufunc(view["value"], scalar)
-        # Applying ``ufunc`` twice yields *s**2 (multiply) or /s**2 (divide).
+        # The mean scales by ``s``; its variance (hence ``deltas``) scales by
+        # ``s**2``. Applying ``ufunc`` twice gives exactly that: for multiply
+        # ``(x*s)*s == x*s**2`` and for divide ``(x/s)/s == x/s**2``.
         out[deltas] = ufunc(ufunc(view[deltas], scalar), scalar)
         if weight_sq is not None:
             out[weight_sq] = view[weight_sq]
@@ -357,20 +365,26 @@ class _MeanArithmetic:
             self._WEIGHT_SQ_FIELD,
         )
         axis = kwargs.get("axis", 0)
+        keepdims = kwargs.get("keepdims", False)
         counts = raw[weight]
         values = raw["value"]
 
+        def reduce(array: Any, *, keep: bool = keepdims) -> Any:
+            return np.add.reduce(array, axis=axis, keepdims=keep)  # type: ignore[call-overload]
+
         with np.errstate(divide="ignore", invalid="ignore"):
-            total = np.add.reduce(counts, axis=axis)
-            combined = np.where(
-                total != 0,
-                np.add.reduce(counts * values, axis=axis) / total,
-                0.0,
+            total = reduce(counts)
+            combined = np.where(total != 0, reduce(counts * values) / total, 0.0)
+
+            # The spread term needs the combined mean broadcast back against the
+            # un-reduced ``values``; ``keepdims=True`` keeps the reduced axis as
+            # size 1 so this works for any ``axis`` (int, tuple, or None) and is
+            # independent of the caller's ``keepdims``.
+            total_b = reduce(counts, keep=True)
+            mean_b = np.where(
+                total_b != 0, reduce(counts * values, keep=True) / total_b, 0.0
             )
-            combined_b = combined if axis is None else np.expand_dims(combined, axis)
-            new_deltas = np.add.reduce(raw[deltas], axis=axis) + np.add.reduce(
-                counts * (values - combined_b) ** 2, axis=axis
-            )
+            new_deltas = reduce(raw[deltas]) + reduce(counts * (values - mean_b) ** 2)
 
         out_fields: dict[str, Any] = {
             weight: total,
@@ -378,7 +392,7 @@ class _MeanArithmetic:
             deltas: new_deltas,
         }
         if weight_sq is not None:
-            out_fields[weight_sq] = np.add.reduce(raw[weight_sq], axis=axis)
+            out_fields[weight_sq] = reduce(raw[weight_sq])
         return self._PARENT._make(*(out_fields[name] for name in self._FIELDS))  # type: ignore[return-value]
 
     def _accumulate(self, raw: Any, out: Any, **kwargs: Any) -> None:

--- a/src/boost_histogram/view.py
+++ b/src/boost_histogram/view.py
@@ -305,7 +305,7 @@ class _MeanArithmetic:
         total = n1 + n2
         # New mean = weight-weighted average; 0 (not NaN) where both are empty.
         new_value = np.zeros_like(total)
-        np.divide(n1 * mu1 + n2 * mu2, total, out=new_value, where=(total != 0))
+        np.divide(n1 * mu1 + n2 * mu2, total, out=new_value, where=total != 0)
 
         # ``deltas`` uses the *new* value; empty operands contribute nothing.
         # Compute every field into a fresh array *before* writing, so an

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -410,6 +410,30 @@ def test_weighted_mean_view_reduce_sum(weighted_mean_pair):
     )
 
 
+def test_mean_view_reduce_keepdims():
+    h = bh.Histogram(
+        bh.axis.Integer(0, 3), bh.axis.Integer(0, 2), storage=bh.storage.Mean()
+    )
+    h.fill([0, 0, 1, 2], [0, 1, 1, 0], sample=[1.0, 2.0, 3.0, 4.0])
+    v = h.view()
+
+    plain = np.add.reduce(v, axis=0)
+    kept = np.add.reduce(v, axis=0, keepdims=True)
+    assert plain.shape == (2,)
+    assert kept.shape == (1, 2)
+    for field in v.dtype.names:
+        assert_allclose(kept[field][0], plain[field])
+
+
+def test_mean_view_rejects_floor_division(mean_pair):
+    h1, _ = mean_pair
+    v = h1.view()
+    with pytest.raises(TypeError):
+        v // 2
+    with pytest.raises(TypeError):
+        2 // v
+
+
 def test_mean_view_rejects_subtraction(mean_pair):
     h1, h2 = mean_pair
     v1, v2 = h1.view(), h2.view()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -231,6 +231,209 @@ def test_0d_weighted_mean_view():
     assert profile.counts() == approx(4.0)
 
 
+@pytest.fixture
+def mean_pair():
+    # Overlapping fills, each with at least one empty bin, to exercise the
+    # zero-count merge guard.
+    h1 = bh.Histogram(bh.axis.Integer(0, 4), storage=bh.storage.Mean())
+    h1.fill([0, 0, 1, 3], sample=[1.0, 2.0, 3.0, 9.0])  # bin 2 empty
+    h2 = bh.Histogram(bh.axis.Integer(0, 4), storage=bh.storage.Mean())
+    h2.fill([0, 2, 2], sample=[5.0, 6.0, 8.0])  # bins 1 and 3 empty
+    return h1, h2
+
+
+@pytest.fixture
+def weighted_mean_pair():
+    h1 = bh.Histogram(bh.axis.Integer(0, 4), storage=bh.storage.WeightedMean())
+    h1.fill([0, 0, 1, 3], sample=[1.0, 2.0, 3.0, 9.0], weight=[1.0, 2.0, 1.0, 3.0])
+    h2 = bh.Histogram(bh.axis.Integer(0, 4), storage=bh.storage.WeightedMean())
+    h2.fill([0, 2, 2], sample=[5.0, 6.0, 8.0], weight=[2.0, 1.0, 1.0])
+    return h1, h2
+
+
+def test_mean_view_combine_matches_hist(mean_pair):
+    h1, h2 = mean_pair
+    combined = (h1 + h2).view()
+    summed = h1.view() + h2.view()
+
+    assert isinstance(summed, type(h1.view()))
+    for field in combined.dtype.names:
+        assert_allclose(summed[field], combined[field])
+    assert_allclose(summed.value, combined.value)
+    assert_allclose(summed.variance, combined.variance, equal_nan=True)
+
+
+def test_weighted_mean_view_combine_matches_hist(weighted_mean_pair):
+    h1, h2 = weighted_mean_pair
+    combined = (h1 + h2).view()
+    summed = h1.view() + h2.view()
+
+    for field in combined.dtype.names:
+        assert_allclose(summed[field], combined[field])
+    assert_allclose(summed.sum_of_weights, combined.sum_of_weights)
+    assert_allclose(summed.sum_of_weights_squared, combined.sum_of_weights_squared)
+    assert_allclose(summed.value, combined.value)
+    assert_allclose(summed.variance, combined.variance, equal_nan=True)
+
+
+def test_mean_view_iadd(mean_pair):
+    h1, h2 = mean_pair
+    expected = (h1 + h2).view()
+    v = h1.view().copy()
+    v += h2.view()
+    for field in expected.dtype.names:
+        assert_allclose(v[field], expected[field])
+
+
+def test_mean_view_zero_count_bins():
+    # Both empty -> all-zero result, no NaN and (under filterwarnings=error) no
+    # divide/invalid warning.
+    empty = bh.Histogram(bh.axis.Integer(0, 3), storage=bh.storage.Mean()).view()
+    result = empty + empty
+    assert_allclose(result.count, [0, 0, 0])
+    assert_allclose(result.value, [0, 0, 0])
+    assert_allclose(result._sum_of_deltas_squared, [0, 0, 0])
+    assert not np.any(np.isnan(result.value))
+
+    # Empty in one operand only -> result equals the other operand bin-for-bin.
+    h = bh.Histogram(bh.axis.Integer(0, 3), storage=bh.storage.Mean())
+    h.fill([0, 0, 2], sample=[3.0, 5.0, 7.0])
+    left = empty + h.view()
+    right = h.view() + empty
+    for field in h.view().dtype.names:
+        assert_allclose(left[field], h.view()[field])
+        assert_allclose(right[field], h.view()[field])
+
+
+def test_mean_view_add_accumulator(mean_pair):
+    h1, _ = mean_pair
+    v = h1.view()
+    acc = bh.accumulators.Mean(3, 5.0, 2.0)  # count, value, variance
+    result = v + acc
+
+    # Equivalent to merging every bin with a view holding that accumulator.
+    other = bh.Histogram(bh.axis.Integer(0, 4), storage=bh.storage.Mean())
+    other[...] = [[3.0, 5.0, 2.0]] * 4  # count, value, variance (matches acc)
+    expected = v + other.view()
+    for field in v.dtype.names:
+        assert_allclose(result[field], expected[field])
+
+
+def test_weighted_mean_view_add_accumulator(weighted_mean_pair):
+    h1, _ = weighted_mean_pair
+    v = h1.view()
+    acc = bh.accumulators.WeightedMean(2.0, 1.5, 5.0, 2.0)
+    result = v + acc
+
+    # Equivalent to merging every bin with a view holding that accumulator.
+    other = bh.Histogram(bh.axis.Integer(0, 4), storage=bh.storage.WeightedMean())
+    # sum_of_weights, sum_of_weights_squared, value, variance (matches acc)
+    other[...] = [[2.0, 1.5, 5.0, 2.0]] * 4
+    expected = v + other.view()
+    for field in v.dtype.names:
+        assert_allclose(result[field], expected[field])
+
+
+def test_weighted_mean_view_combine_empty_bin():
+    # A genuinely empty bin (sum_of_weights == 0) must not introduce NaN.
+    h = bh.Histogram(bh.axis.Integer(0, 3), storage=bh.storage.WeightedMean())
+    h.fill([0, 2], sample=[3.0, 7.0], weight=[1.0, 1.0])  # bin 1 empty
+    empty = bh.Histogram(
+        bh.axis.Integer(0, 3), storage=bh.storage.WeightedMean()
+    ).view()
+    result = h.view() + empty
+    for field in h.view().dtype.names:
+        assert_allclose(result[field], h.view()[field])
+    assert not np.any(np.isnan(result.value))
+
+
+def test_mean_view_scalar_scale():
+    h = bh.Histogram(bh.axis.Integer(0, 4), storage=bh.storage.Mean())
+    h.fill([0, 0, 1], sample=[2.0, 4.0, 6.0])
+    v = h.view()
+
+    for scaled in (v * 3, 3 * v):
+        assert_allclose(scaled.count, v.count)  # weights unchanged
+        assert_allclose(scaled.value, v.value * 3)
+        assert_allclose(scaled._sum_of_deltas_squared, v._sum_of_deltas_squared * 9)
+
+    divided = v / 2
+    assert_allclose(divided.count, v.count)
+    assert_allclose(divided.value, v.value / 2)
+    assert_allclose(divided._sum_of_deltas_squared, v._sum_of_deltas_squared / 4)
+
+    v2 = v.copy()
+    v2 *= 3
+    assert_allclose(v2.value, v.value * 3)
+    v2 = v.copy()
+    v2 /= 2
+    assert_allclose(v2.value, v.value / 2)
+
+
+def test_weighted_mean_view_scalar_scale(weighted_mean_pair):
+    h1, _ = weighted_mean_pair
+    v = h1.view()
+    scaled = v * 2
+    assert_allclose(scaled.sum_of_weights, v.sum_of_weights)
+    assert_allclose(scaled.sum_of_weights_squared, v.sum_of_weights_squared)
+    assert_allclose(scaled.value, v.value * 2)
+    assert_allclose(
+        scaled._sum_of_weighted_deltas_squared,
+        v._sum_of_weighted_deltas_squared * 4,
+    )
+
+
+def test_mean_view_reduce_sum():
+    h = bh.Histogram(bh.axis.Integer(0, 4), storage=bh.storage.Mean())
+    h.fill([0, 0, 1, 3], sample=[1.0, 2.0, 3.0, 9.0])
+    v = h.view()
+
+    reduced = v.sum()
+    assert isinstance(reduced, bh.accumulators.Mean)
+
+    projected = h.project().view()
+    assert reduced.count == approx(projected.count)
+    assert reduced.value == approx(projected.value)
+    assert reduced._sum_of_deltas_squared == approx(projected._sum_of_deltas_squared)
+
+
+def test_weighted_mean_view_reduce_sum(weighted_mean_pair):
+    h1, _ = weighted_mean_pair
+    reduced = h1.view().sum()
+    assert isinstance(reduced, bh.accumulators.WeightedMean)
+
+    projected = h1.project().view()
+    assert reduced.sum_of_weights == approx(projected.sum_of_weights)
+    assert reduced.value == approx(projected.value)
+    assert reduced._sum_of_weighted_deltas_squared == approx(
+        projected._sum_of_weighted_deltas_squared
+    )
+
+
+def test_mean_view_rejects_subtraction(mean_pair):
+    h1, h2 = mean_pair
+    v1, v2 = h1.view(), h2.view()
+    with pytest.raises(TypeError):
+        v1 - v2
+    with pytest.raises(TypeError):
+        v1 - 5
+
+
+def test_mean_view_rejects_scalar_add(mean_pair):
+    h1, _ = mean_pair
+    with pytest.raises(TypeError):
+        h1.view() + 5
+
+
+def test_mean_view_rejects_view_product(mean_pair):
+    h1, h2 = mean_pair
+    v1, v2 = h1.view(), h2.view()
+    with pytest.raises(TypeError):
+        v1 * v2
+    with pytest.raises(TypeError):
+        v1 / v2
+
+
 # Issue #696
 def test_view_cumsum():
     h = bh.Histogram(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #276.

Histogram views now support the same arithmetic the histograms themselves do — "all operations a histogram supports should also be supported by accumulator views." PR #368 gave `WeightedSumView` full ufunc support; this fills the remaining gap: `MeanView` and `WeightedMeanView` previously had **no** arithmetic, only a read-only `variance` property.

At the C++ level, `Mean`/`WeightedMean` histograms already combine via `__iadd__` (the Welford/West merge), and the accumulators define `operator*=` — but the views exposed none of it, so `h1.view() + h2.view()` did not match `(h1 + h2).view()`.

### What changed (`src/boost_histogram/view.py`)

- **Hoisted the `__array_ufunc__` scaffolding onto the base `View`** (the `out=` allocation, dtype-based view/view-vs-scalar branching, reduce/accumulate, passthrough), dispatching the field math to per-view hooks: `_unary` / `_combine` / `_add_scalar` / `_scale` / `_reduce` / `_accumulate`, gated by `_SUPPORTS_SUB` / `_SUPPORTS_VIEW_PRODUCT`. `WeightedSumView` is migrated onto this machinery with **no behavior change** (its existing tests pass untouched).
- **Added a `_MeanArithmetic` mixin** shared by `MeanView` and `WeightedMeanView`:
  - `+` / `+=` / `.sum()` / `view + accumulator` → the vectorized parallel merge, mirroring the C++ `mean`/`weighted_mean` `operator+=`. Empty bins (`weight == 0`) are zero-guarded with `np.divide(..., where=...)` so they yield `0`, not `NaN` (important under `filterwarnings = error`). All fields are computed into temporaries before writing, so in-place `v += other` is correct despite `out` aliasing `v`.
  - scalar `*` / `/` → scales `value` by `s` and the deltas by `s²`, weights untouched (mirrors `operator*=`).
  - Subtraction, scalar-add, unary `-`, and view×view are rejected with clear `TypeError`s (means have no `operator-=`, and view ratios are out of scope).

### Tests (`tests/test_views.py`)

14 new tests: combine matches `(h1+h2).view()` field-for-field (Mean and WeightedMean, with empty bins), zero-count guard (no `NaN`, no warning), `view + accumulator`, scalar scaling, `.sum()`/reduce matching `h.project()`, and all rejection cases.

### Verification

- `tests/test_views.py`: 27 passed
- Full suite: 978 passed, 1 pre-existing xfail — confirms view-level `+` now matches histogram-level `+` (which runs the exact C++ merge) including empty-bin handling
- `mypy` clean; `prek -a` clean

### Out of scope

`WeightedSumView` view×view / view÷view ratios are intentionally **not** included (they'd go beyond what histograms support and assume independence) — that path raises a clean `TypeError` and can be a separate follow-up. This also lays groundwork for doing cross-storage histogram addition in Python (#261).