### PR TITLE
fix: promote integer storages to double on division (#601)

### DIFF
--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -738,22 +738,55 @@ class Histogram(typing.Generic[S]):
 
     def __truediv__(self, other: Histogram[S] | np.typing.NDArray[Any] | float) -> Self:
         result = self.copy(deep=False)
-        return result._compute_inplace_op("__itruediv__", other)
+        return result.__itruediv__(other)
 
     def __div__(self, other: Histogram[S] | np.typing.NDArray[Any] | float) -> Self:
         result = self.copy(deep=False)
-        return result._compute_inplace_op("__idiv__", other)
+        return result.__idiv__(other)
 
     def __idiv__(self, other: Histogram[S] | np.typing.NDArray[Any] | float) -> Self:
-        return self._compute_inplace_op("__idiv__", other)
+        return self.__itruediv__(other)
 
     def __itruediv__(
         self, other: Histogram[S] | np.typing.NDArray[Any] | float
     ) -> Self:
+        # Division should produce floating-point results, so promote integer
+        # storages to Double. Histogram/histogram division in C++ requires both
+        # operands to share a storage, so the divisor is promoted to match.
+        self._convert_int_storage_to_double()
+        if isinstance(other, Histogram):
+            other = self._as_double_cpp(other._hist)  # type: ignore[assignment]
+        elif isinstance(other, tuple(_histograms)):
+            other = self._as_double_cpp(other)  # type: ignore[arg-type, assignment]
         return self._compute_inplace_op("__itruediv__", other)
 
     def __imul__(self, other: Histogram[S] | np.typing.NDArray[Any] | float) -> Self:
         return self._compute_inplace_op("__imul__", other)
+
+    @staticmethod
+    def _as_double_cpp(cpp_hist: CppHistogram) -> CppHistogram:
+        """
+        Return a Double-storage copy of an integer-storage (Int64/AtomicInt64)
+        C++ histogram, so that division produces floating-point results instead
+        of truncating. Returns the input unchanged for storages that are already
+        floating point or richer.
+        """
+        if cpp_hist._storage_type not in {
+            _core.storage.int64,
+            _core.storage.atomic_int64,
+        }:
+            return cpp_hist
+
+        cpp_axes = [cpp_hist.axis(i) for i in range(cpp_hist.rank())]
+        new_hist = _core.hist.any_double(cpp_axes, _core.storage.double())
+        new_hist.view(flow=True)[...] = cpp_hist.view(flow=True)
+        return new_hist
+
+    def _convert_int_storage_to_double(self) -> None:
+        """
+        Convert an integer storage to Double in place (see _as_double_cpp).
+        """
+        self._hist = self._as_double_cpp(self._hist)
 
     def _hist_inplace_op(self, name: str, other: CppHistogram) -> None:
         # The underlying C++ histogram only exposes the in-place dunders its

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -623,6 +623,48 @@ def test_hist_hist_div():
     assert h1[True] == 2
 
 
+@pytest.mark.parametrize("storage", [bh.storage.Int64, bh.storage.AtomicInt64])
+def test_int_storage_division_promotes_to_double(storage):
+    # gh #601: dividing integer-storage histograms must not truncate.
+    a = bh.Histogram(bh.axis.Integer(0, 3), storage=storage())
+    b = bh.Histogram(bh.axis.Integer(0, 3), storage=storage())
+    a[:] = (5, 3, 7)
+    b[:] = (2, 4, 3)
+
+    expected = np.array([5, 3, 7]) / np.array([2, 4, 3])
+
+    # hist / hist
+    result = a / b
+    assert result.storage_type is bh.storage.Double
+    assert_array_equal(result.view(), expected)
+    # operands are unchanged
+    assert a.storage_type is storage
+    assert b.storage_type is storage
+
+    # hist / scalar
+    assert_array_equal((a / 2).view(), np.array([5, 3, 7]) / 2)
+    assert (a / 2).storage_type is bh.storage.Double
+
+    # in-place division promotes storage but keeps the same object
+    a_orig = a
+    a /= b
+    assert a is a_orig
+    assert a.storage_type is bh.storage.Double
+    assert_array_equal(a.view(), expected)
+
+
+def test_mixed_int_double_division():
+    # gh #601: storage mismatch must still divide correctly.
+    ai = bh.Histogram(bh.axis.Integer(0, 3), storage=bh.storage.Int64())
+    bd = bh.Histogram(bh.axis.Integer(0, 3), storage=bh.storage.Double())
+    ai[:] = (5, 3, 7)
+    bd[:] = (2, 4, 3)
+
+    expected = np.array([5, 3, 7]) / np.array([2, 4, 3])
+    assert_array_equal((ai / bd).view(), expected)
+    assert_array_equal((bd / ai).view(), 1 / expected)
+
+
 def test_project():
     h = bh.Histogram(bh.axis.Integer(0, 2), bh.axis.Integer(1, 4))
     h.fill(0, 1)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #601.

## Problem

Dividing two integer-storage histograms performed integer division, truncating the result:

```python
a = Hist.new.Reg(10, -2, 2).Int64().fill(...)
b = Hist.new.Reg(10, -2, 2).Int64().fill(...)
(a / b).values()   # -> [2, 1, 0, 0, ...]  (wrong, truncated)
a.values() / b.values()  # -> [2.51, 1.46, 0.92, ...]
```

As discussed in the issue, division should promote to floating point — the least-surprising behavior, and what `Unlimited` storage already does.

## Fix

Division now promotes integer storages (`Int64`/`AtomicInt64`) to `Double`:

- `_as_double_cpp(cpp_hist)` returns a `Double`-storage copy of an integer C++ histogram (copying flow bins, reusing axes); it is a no-op for storages that are already float or richer (`Double`, `Weight`, `Mean`, …).
- `__itruediv__` promotes `self` and — since histogram/histogram division in C++ requires both operands to share a storage — also promotes the divisor. `__div__`/`__idiv__` route through it.

Promoting **both** operands is required: converting only `self` silently no-ops because the C++ op rejects mismatched storage. This also incidentally fixes the previously-silent no-op for `Double / Int64` division.

## Behavior preserved

- Operands are left unchanged; in-place `/=` keeps the same object identity.
- Histogram/axis metadata, edges, and flow bins are preserved.
- `Weight`/`Weight` division still raises the existing clear "storage does not support" error; mismatched-axis-metadata division still raises "axes differ" (both confirmed unchanged from `develop`).

## Tests

Added `test_int_storage_division_promotes_to_double` (parametrized over `Int64`/`AtomicInt64`) and `test_mixed_int_double_division`. Full suite passes (983 passed, 1 xfailed); `prek -a` clean (ruff + mypy strict).