### PR TITLE
test: validate UHI serialization against the uhi JSON schema

### DIFF
--- a/docs/user-guide/histogram.rst
+++ b/docs/user-guide/histogram.rst
@@ -101,3 +101,36 @@ cannot use version 0, the version that used to be default on Python 2. The most
 recent versions provide performance benefits.
 
 You can nest this in other Python structures, like dictionaries, and save those instead.
+
+UHI dictionary serialization
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can also convert a histogram to and from a plain dictionary following the
+`UHI serialization schema <https://uhi.readthedocs.io/en/latest/serialization.html>`_.
+This is useful for sharing histograms as JSON (or any other format that supports
+nested dictionaries and arrays):
+
+.. code-block:: python3
+
+    from boost_histogram.serialization import to_uhi, from_uhi
+
+    data = to_uhi(h)
+    h2 = from_uhi(data)
+
+    assert h == h2
+
+If you only want to share the *structure* of a histogram -- its axes, metadata,
+and storage type -- without the (potentially large) bin contents, pass
+``keep_storage=False``. The resulting storage entry contains only its ``type``:
+
+.. code-block:: python3
+
+    data = to_uhi(h, keep_storage=False)
+    assert data["storage"] == {"type": "double"}
+
+    # Loading restores an empty histogram with the same axes and storage type
+    h_empty = from_uhi(data)
+
+This is handy for transmitting just the "initialization" of a histogram (for
+example, to set up a matching histogram on a server) without serializing all of
+the zeros. ``from_uhi`` accepts both full and metadata-only dictionaries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,8 @@ test = [
     "numpy>=1.21.3",
     "hypothesis>=6.0; sys_platform != 'ios'", # slow on iOS, can fail health check
     "pytest-xdist; sys_platform != 'ios'",  # No processes on iOS
+    "jsonschema",  # validate UHI serialization against the uhi schema
+    "uhi>=1.1",  # ships the histogram JSON schema with metadata-only storage support
 ]
 github = [
   { include-group = "test" },

--- a/tests/test_serialization_uhi.py
+++ b/tests/test_serialization_uhi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+import importlib.resources
 import json
 import math
 import sys
@@ -698,3 +699,46 @@ def test_from_uhi_structure_only_no_error() -> None:
     h = from_uhi(data)
     assert h.storage_type is bh.storage.Double
     assert np.asarray(h) == pytest.approx(np.zeros(5))
+
+
+@pytest.mark.parametrize(
+    "storage_type",
+    [
+        pytest.param(bh.storage.Int64(), id="int64"),
+        pytest.param(bh.storage.AtomicInt64(), id="atomic_int64"),
+        pytest.param(bh.storage.Double(), id="double"),
+        pytest.param(bh.storage.Unlimited(), id="unlimited"),
+        pytest.param(bh.storage.Weight(), id="weight"),
+        pytest.param(bh.storage.Mean(), id="mean"),
+        pytest.param(bh.storage.WeightedMean(), id="weighted_mean"),
+    ],
+)
+@pytest.mark.parametrize(
+    "keep_storage", [True, False], ids=["with_data", "metadata_only"]
+)
+def test_to_uhi_matches_uhi_schema(
+    storage_type: bh.storage.Storage, keep_storage: bool
+) -> None:
+    """``to_uhi`` output conforms to the UHI histogram JSON schema, including the
+    metadata-only (``keep_storage=False``) form used for type-only storage."""
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(
+        importlib.resources.files("uhi.resources")
+        .joinpath("histogram.schema.json")
+        .read_text()
+    )
+
+    h = bh.Histogram(
+        bh.axis.Regular(3, 0, 1),
+        bh.axis.IntCategory([1, 2]),
+        storage=storage_type,
+    )
+    if isinstance(storage_type, (bh.storage.Mean, bh.storage.WeightedMean)):
+        h.fill([0.1, 0.5, 0.5], [1, 2, 2], sample=[1.0, 2.0, 3.0])
+    else:
+        h.fill([0.1, 0.5, 0.5], [1, 2, 2])
+
+    data = _json_round_trip(to_uhi(h, keep_storage=keep_storage))
+
+    # The schema describes a mapping of named histograms.
+    jsonschema.validate({"hist": data}, schema)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to #1098, closing #1089 now that metadata-only storage support landed in uhi ([scikit-hep/uhi#230](https://github.com/scikit-hep/uhi/pull/230), released in uhi 1.1).

The type-only serialization itself (`to_uhi(h, keep_storage=False)` → `{"type": ...}`, and `from_uhi` loading such payloads) was already implemented in #1098. This PR hardens and documents it:

- **Schema-validation test** — `test_to_uhi_matches_uhi_schema` validates `to_uhi` output for every storage type, in both the full and metadata-only (`keep_storage=False`) forms, against the `histogram.schema.json` shipped with uhi. This locks in compliance with the finalized UHI spec, including the new empty-storage `oneOf` branch.
- **Test deps** — add `jsonschema` and `uhi>=1.1` to the `test` group (`uhi` was previously only in `dev`; `>=1.1` guarantees the metadata-only schema is present).
- **Docs** — new "UHI dictionary serialization" subsection in the user guide covering `to_uhi`/`from_uhi` and the `keep_storage=False` metadata-only option.

### Verification
- `uv run pytest tests/test_serialization_uhi.py` → 73 passed (14 new schema cases).
- `prek -a` clean.