### PR TITLE
fix(numpy): do not mutate input edges; validate histogramdd dimensions

### DIFF
--- a/src/boost_histogram/numpy.py
+++ b/src/boost_histogram/numpy.py
@@ -63,13 +63,19 @@ def histogramdd(
     with contextlib.suppress(TypeError):
         bins = (int(bins),) * rank  # type: ignore[arg-type]
     assert not isinstance(bins, int)
+    if len(bins) != rank:
+        raise ValueError(
+            "The dimension of bins must be equal to the dimension of the sample x."
+        )
 
     # Single None -> list of Nones
     if range is None:
         range = (None,) * rank
+    elif len(range) != rank:
+        raise ValueError("range argument must have one entry per dimension")
 
     axs: list[_axis.Axis] = []
-    for n, (b, r) in enumerate(zip(bins, range, strict=False)):
+    for n, (b, r) in enumerate(zip(bins, range, strict=True)):
         if np.issubdtype(type(b), np.integer):
             if r is None:
                 # Nextafter may affect bin edges slightly
@@ -81,7 +87,8 @@ def histogramdd(
             )
             axs.append(new_ax)
         else:
-            barr: np.typing.NDArray[Any] = np.asarray(b, dtype=np.double)
+            # Always copy; the input edges must not be modified in-place below
+            barr: np.typing.NDArray[Any] = np.array(b, dtype=np.double)
             # This does have a .max member, not sure why pylint doesn't like it
             # pylint: disable-next=no-member
             barr[-1] = np.nextafter(barr[-1], np.finfo("d").max)
@@ -155,11 +162,6 @@ def histogram(
         )
 
     if isinstance(bins, str):
-        # Bug in NumPy 1.20 typing support - __version__ is missing
-        if tuple(int(x) for x in np.version.version.split(".")[:2]) < (1, 13):
-            raise KeyError(
-                "Upgrade numpy to 1.13+ to use string arguments to boost-histogram's histogram function"
-            )
         bins = np.histogram_bin_edges(a, bins, range, weights)
 
     # TODO: make sure all types work at runtime (type ignore below)

--- a/tests/test_numpy_interface.py
+++ b/tests/test_numpy_interface.py
@@ -200,3 +200,52 @@ def test_histogram_all_ones():
 
     assert bh_h1 == approx(h1)
     assert bh_edges == approx(edges)
+
+
+def test_histogram_does_not_mutate_input_edges():
+    edges = np.array([0.0, 1.0, 2.0])
+    original = edges.copy()
+
+    bh.numpy.histogram([0.5, 1.5], bins=edges)
+
+    np.testing.assert_array_equal(edges, original)
+
+
+def test_histogramdd_does_not_mutate_input_edges():
+    x = np.array([0.3, 0.3, 0.1, 0.8])
+    y = np.array([0.4, 0.5, 0.22, 0.65])
+    edges_x = np.array([0.0, 0.5, 1.0])
+    edges_y = np.array([0.0, 0.25, 0.5, 1.0])
+    original_x = edges_x.copy()
+    original_y = edges_y.copy()
+
+    bh.numpy.histogramdd((x, y), bins=(edges_x, edges_y))
+
+    np.testing.assert_array_equal(edges_x, original_x)
+    np.testing.assert_array_equal(edges_y, original_y)
+
+
+@pytest.mark.parametrize("bad_bins", [(2,), (2, 2, 2), (2, 2, 2, 2)])
+def test_histogramdd_mismatched_bins(bad_bins):
+    x = np.array([0.3, 0.3, 0.1, 0.8])
+    y = np.array([0.4, 0.5, 0.22, 0.65])
+
+    with pytest.raises(ValueError, match="dimension of bins"):
+        np.histogramdd((x, y), bins=bad_bins)
+
+    with pytest.raises(ValueError, match="dimension of bins"):
+        bh.numpy.histogramdd((x, y), bins=bad_bins)
+
+
+@pytest.mark.parametrize(
+    "bad_range", [((0, 1),), ((0, 1), (0, 1), (0, 1)), ((0, 1), (0, 1), (0, 1), (0, 1))]
+)
+def test_histogramdd_mismatched_range(bad_range):
+    x = np.array([0.3, 0.3, 0.1, 0.8])
+    y = np.array([0.4, 0.5, 0.22, 0.65])
+
+    with pytest.raises(ValueError, match="range argument"):
+        np.histogramdd((x, y), bins=2, range=bad_range)
+
+    with pytest.raises(ValueError, match="range argument"):
+        bh.numpy.histogramdd((x, y), bins=2, range=bad_range)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1143.

Fixes three findings in `src/boost_histogram/numpy.py`:

- **B3 (caller data mutation)**: `histogramdd` (and therefore `histogram`/`histogram2d`) used `np.asarray(b, dtype=np.double)` on user-supplied bin edges, which aliases an already-float64 input. The subsequent in-place `np.nextafter` adjustment of the last edge then mutated the caller's array (e.g. `edges = np.array([0., 1., 2.]); bh.numpy.histogram([0.5, 1.5], bins=edges)` left `edges[-1] == 2.0000000000000004`). `np.histogram` never mutates its input. The edges are now always copied before adjustment.

- **B13 (silent truncation)**: `histogramdd` zipped `bins` and `range` with `strict=False`, silently truncating on length mismatch: `bh.numpy.histogramdd((x, y), bins=(2, 2, 2))` returned a 2-D result where `np.histogramdd` raises, and a too-short `range` failed later with an unhelpful "Wrong number of args". Lengths are now validated up front, raising `ValueError` with the same messages as `np.histogramdd` ("The dimension of bins must be equal to the dimension of the sample x." / "range argument must have one entry per dimension").

- **Dead version check (D2, numpy part)**: removed the unreachable `numpy < 1.13` check ("Upgrade numpy to 1.13+") in the string-bins branch of `histogram` — `pyproject.toml` requires `numpy>=1.21.3` — along with the obsolete "Bug in NumPy 1.20 typing" comment; `np.histogram_bin_edges` is now called directly (mypy strict remains clean).

Regression tests added in `tests/test_numpy_interface.py`: input-edges non-mutation for `histogram` and `histogramdd`, and mismatched `bins`/`range` raising `ValueError` in lockstep with `np.histogramdd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)