### PR TITLE
fix(view): out= handling, scalar division, and broadcasting in structured views

### DIFF
--- a/src/boost_histogram/view.py
+++ b/src/boost_histogram/view.py
@@ -81,14 +81,35 @@ class View(np.ndarray[Any, Any]):
         raw_inputs = [np.asarray(x) for x in inputs]
 
         # Reductions (``.sum()`` / ``np.add.reduce``) don't get a pre-allocated
-        # ``out`` here; the hook builds the reduced accumulator(s) itself.
+        # ``out`` here; the hook builds the reduced accumulator(s) itself. A
+        # caller-supplied ``out`` cannot be forwarded to the per-field math (it
+        # would be reused for every field), so it is filled in afterwards.
         match method, ufunc, raw_inputs:
             case "reduce", np.add, [raw_input]:
-                return self._reduce(raw_input, **kwargs)
+                out_tuple = kwargs.pop("out", None)
+                reduced = self._reduce(raw_input, **kwargs)
+                if out_tuple is None:
+                    return reduced
+                out_array: np.typing.NDArray[Any] = out_tuple[0]
+                if out_array.dtype != self.dtype:
+                    raise TypeError(
+                        f"out= with dtype {out_array.dtype} is not supported for "
+                        f"{self.__class__.__name__} reductions; the dtype must "
+                        f"match the view ({self.dtype})"
+                    )
+                out_array[...] = reduced
+                return out_array.view(self.__class__)
 
         # Everything else fills a pre-allocated result of this view's dtype
         (result,) = (
-            kwargs.pop("out") if "out" in kwargs else [np.empty(self.shape, self.dtype)]
+            kwargs.pop("out")
+            if "out" in kwargs
+            else [
+                np.empty(
+                    np.broadcast_shapes(*(np.shape(r) for r in raw_inputs)),
+                    self.dtype,
+                )
+            ]
         )
         match method, ufunc, raw_inputs:
             # Unary + and -
@@ -111,7 +132,7 @@ class View(np.ndarray[Any, Any]):
             # Multiplication and division
             case (
                 "__call__",
-                (np.multiply | np.divide | np.true_divide | np.floor_divide),
+                (np.multiply | np.divide | np.floor_divide),
                 [raw1, raw2],
             ):
                 if raw1.dtype == raw2.dtype:
@@ -260,6 +281,12 @@ class WeightedSumView(View):
         if raw1.dtype == self.dtype:
             ufunc(raw1["value"], raw2, out=out["value"], **kwargs)
             ufunc(raw1["variance"], raw2**2, out=out["variance"], **kwargs)
+        elif ufunc in {np.divide, np.floor_divide}:
+            # ``scalar / view``: the reciprocal of a weighted sum is not a
+            # linear scaling, so no meaningful variance can be propagated.
+            raise TypeError(
+                f"Cannot divide a scalar or array by a {self.__class__.__name__}"
+            )
         else:
             ufunc(raw1, raw2["value"], out=out["value"], **kwargs)
             ufunc(raw1**2, raw2["variance"], out=out["variance"], **kwargs)
@@ -341,7 +368,7 @@ class _MeanArithmetic:
         )
         if raw1.dtype == self.dtype:
             view, scalar = raw1, raw2
-        elif ufunc in (np.divide, np.true_divide):
+        elif ufunc is np.divide:
             # ``scalar / view`` is not a meaningful scaling of a mean.
             raise TypeError(
                 f"Cannot divide a scalar or array by a {self.__class__.__name__}"
@@ -359,13 +386,26 @@ class _MeanArithmetic:
             out[weight_sq] = view[weight_sq]
 
     def _reduce(self, raw: Any, **kwargs: Any) -> np.typing.NDArray[Any]:
+        axis = kwargs.pop("axis", 0)
+        keepdims = kwargs.pop("keepdims", False)
+        # ``np.sum`` always forwards ``dtype=None`` and ``where=True``; any
+        # other reduction argument (a real dtype, a where mask, initial, ...)
+        # cannot be honored by the mean-merging math below, so reject it
+        # instead of silently ignoring it.
+        if (
+            kwargs.pop("dtype", None) is not None
+            or kwargs.pop("where", True) is not True
+            or kwargs
+        ):
+            raise TypeError(
+                f"{self.__class__.__name__} reductions only support the "
+                "axis and keepdims arguments"
+            )
         weight, deltas, weight_sq = (
             self._WEIGHT_FIELD,
             self._DELTAS_FIELD,
             self._WEIGHT_SQ_FIELD,
         )
-        axis = kwargs.get("axis", 0)
-        keepdims = kwargs.get("keepdims", False)
         counts = raw[weight]
         values = raw["value"]
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -47,9 +47,10 @@ def test_view_div(v):
     assert_allclose(v2.value, [0, -6, -4, -2])
     assert_allclose(v2.variance, [0, 12, 8, 4])
 
-    v2 = 1 / v[1:]
-    assert_allclose(v2.value, [1 / 3, 1 / 2, 1])
-    assert_allclose(v2.variance, [1 / 3, 1 / 2, 1])
+    # Issue #1143 (B11): the reciprocal of a weighted sum has no meaningful
+    # variance, so dividing by a view is rejected.
+    with pytest.raises(TypeError, match="divide a scalar or array"):
+        1 / v[1:]
 
     v /= 0.5
     assert_allclose(v.value, [0, 6, 4, 2])
@@ -229,6 +230,84 @@ def test_0d_weighted_mean_view():
     # values() and counts() on the histogram should work
     assert profile.values() == approx(2.5)
     assert profile.counts() == approx(4.0)
+
+
+@pytest.fixture
+def v2d():
+    h = bh.Histogram(
+        bh.axis.Integer(0, 2), bh.axis.Integer(0, 2), storage=bh.storage.Weight()
+    )
+    h.fill([0, 0, 1, 1], [0, 1, 0, 1], weight=[1, 2, 1, 1])
+    return h.view()
+
+
+# Issue #1143 (B11): ``scalar / view`` would produce a statistically
+# meaningless variance (s**2 / variance), so it must raise like the mean views.
+def test_view_rdiv_rejected(v):
+    with pytest.raises(TypeError, match="divide a scalar or array"):
+        2.0 / v
+    with pytest.raises(TypeError, match="divide a scalar or array"):
+        2 // v
+    with pytest.raises(TypeError, match="divide a scalar or array"):
+        np.true_divide(2.0, v)
+    with pytest.raises(TypeError, match="divide a scalar or array"):
+        np.ones(4) / v
+
+    # Scaling in the other direction must keep working.
+    assert_allclose((v / 2).value, v.value / 2)
+    assert_allclose((2 * v).value, v.value * 2)
+
+
+# Issue #1143 (B2): a caller-supplied ``out=`` used to be forwarded into the
+# per-field reductions, so every field overwrote the same buffer.
+def test_view_reduce_out_mismatched_dtype(v2d):
+    with pytest.raises(TypeError, match="out="):
+        np.sum(v2d, axis=0, out=np.empty(2))
+
+
+def test_view_reduce_out_matching_dtype(v2d):
+    out = np.zeros(2, dtype=v2d.dtype)
+    result = np.sum(v2d, axis=0, out=out)
+
+    assert np.shares_memory(result, out)
+    assert isinstance(result, type(v2d))
+    assert_allclose(out["value"], np.sum(v2d["value"], axis=0))
+    assert_allclose(out["variance"], np.sum(v2d["variance"], axis=0))
+
+
+def test_view_reduce_out_full(v2d):
+    out = np.zeros((), dtype=v2d.dtype)
+    result = np.sum(v2d, out=out)
+
+    assert np.shares_memory(result, out)
+    assert out["value"] == approx(np.sum(v2d["value"]))
+    assert out["variance"] == approx(np.sum(v2d["variance"]))
+
+
+def test_view_reduce_axis(v2d):
+    result = np.sum(v2d, axis=0)
+    assert_allclose(result["value"], [2, 3])
+    assert_allclose(result["variance"], [2, 5])
+
+
+# Issue #1143 (B12): binary ops used to preallocate the result with the view's
+# own shape, breaking legal broadcasts.
+def test_view_broadcast_add(v):
+    arr = np.ones((2, 4))
+    for result in (v + arr, arr + v):
+        assert result.shape == (2, 4)
+        assert isinstance(result, type(v))
+        assert_allclose(result.value, np.broadcast_to(v.value + 1, (2, 4)))
+        assert_allclose(result.variance, np.broadcast_to(v.variance + 1, (2, 4)))
+
+
+def test_view_broadcast_mul(v):
+    arr = np.full((2, 4), 2.0)
+    for result in (v * arr, arr * v):
+        assert result.shape == (2, 4)
+        assert isinstance(result, type(v))
+        assert_allclose(result.value, np.broadcast_to(v.value * 2, (2, 4)))
+        assert_allclose(result.variance, np.broadcast_to(v.variance * 4, (2, 4)))
 
 
 @pytest.fixture
@@ -423,6 +502,36 @@ def test_mean_view_reduce_keepdims():
     assert kept.shape == (1, 2)
     for field in v.dtype.names:
         assert_allclose(kept[field][0], plain[field])
+
+
+# Issue #1143 (B2): mean reductions used to silently ignore reduction
+# arguments (out, where, initial, dtype) they cannot honor.
+def test_mean_view_reduce_rejects_unsupported_kwargs(mean_pair):
+    h1, _ = mean_pair
+    v = h1.view()
+
+    with pytest.raises(TypeError, match="axis and keepdims"):
+        np.sum(v, dtype=np.float32)
+    with pytest.raises(TypeError, match="axis and keepdims"):
+        np.sum(v, initial=2.0)
+    with pytest.raises(TypeError, match="axis and keepdims"):
+        np.sum(v, where=np.zeros(v.shape, dtype=bool))
+    with pytest.raises(TypeError, match="out="):
+        np.sum(v, out=np.empty(()))
+
+
+def test_mean_view_reduce_out_matching_dtype(mean_pair):
+    h1, _ = mean_pair
+    v = h1.view()
+
+    out = np.zeros((), dtype=v.dtype)
+    result = np.sum(v, out=out)
+    assert np.shares_memory(result, out)
+
+    expected = np.sum(v)
+    assert out["count"] == approx(expected.count)
+    assert out["value"] == approx(expected.value)
+    assert out["_sum_of_deltas_squared"] == approx(expected._sum_of_deltas_squared)
 
 
 def test_mean_view_rejects_floor_division(mean_pair):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1143.

Fixes three verified findings in the structured-view (`view.py`) ufunc machinery:

### B2 — `out=` silently corrupted reductions
The `"reduce"` branch of `__array_ufunc__` forwarded the caller's `out=` into `_reduce`, where `np.add.reduce(raw[field], **kwargs)` ran once per field with the **same** out buffer, so each field's reduction overwrote the previous one (e.g. `np.sum(v, axis=0, out=np.empty(2))` on a 2-D Weight view returned `[(4., 4.), (9., 9.)]` instead of `[(2., 4.), (3., 9.)]`).

Now `out=` is popped before reducing: if the out dtype matches the view dtype, the result is computed fresh and copied into the out buffer (which is returned); otherwise a `TypeError` is raised. This applies uniformly to `WeightedSumView` and the mean views. `_MeanArithmetic._reduce` now also raises `TypeError` on reduction arguments it cannot honor (`dtype`, `where`, `initial`) instead of silently ignoring them; `axis` and `keepdims` keep working.

### B11 — `scalar / view` produced meaningless statistics
`2.0 / weighted_sum_view` went through the scalar-first `_scale` branch and produced `variance = s**2 / variance`, which is statistically meaningless. The mean views already raise for exactly this case; `WeightedSumView` now raises a matching `TypeError` for `divide`/`floor_divide` with the view as the divisor. `scalar * view` and `view / scalar` are unchanged. (The existing test asserting the old `1 / v` behavior was updated to expect the error.)

### B12 — legal broadcasts failed
Binary ops preallocated `np.empty(self.shape, self.dtype)`, so a `(3,)` view plus a `(2, 3)` array raised `ValueError: non-broadcastable output operand`. The result is now allocated with `np.broadcast_shapes` over all inputs; tested in both operand orders for `+` and `*`.

### Cleanup (from D2)
`np.divide is np.true_divide`, so the redundant `np.true_divide` entries in the match alternation and the mean `_scale` tuple were dropped.

### Testing
- Regression tests added to `tests/test_views.py` for each finding, including the exact issue reproductions.
- `uv run pytest -n auto --benchmark-disable`: 1006 passed, 1 xfailed.
- `mypy` (strict) clean; `prek -a` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)