### PR TITLE
fix: non-contiguous array handling and memory safety in C++ bindings

### DIFF
--- a/include/bh_python/array_like.hpp
+++ b/include/bh_python/array_like.hpp
@@ -8,9 +8,12 @@
 #include <bh_python/pybind11.hpp>
 
 #include <boost/core/span.hpp>
-#include <vector>
 
-/// Generate empty array with same shape and strides as argument
+/// Generate empty C-contiguous array with same shape as argument
+///
+/// Note: the result is always C-contiguous regardless of the input's memory
+/// layout (strides are *not* copied); callers fill it linearly in C order from
+/// a C-contiguous copy of the input.
 template <class T>
 py::array_t<T> array_like(const py::object& obj) {
     if(!py::isinstance<py::array>(obj)) {
@@ -23,13 +26,6 @@ py::array_t<T> array_like(const py::object& obj) {
         return py::array_t<T>(shape);
     }
     auto arr = py::cast<py::array>(obj);
-    std::vector<py::ssize_t> strides;
-    strides.reserve(static_cast<std::size_t>(arr.ndim()));
-    for(int i = 0; i < arr.ndim(); ++i) {
-        strides.emplace_back(arr.strides()[i] / arr.itemsize()
-                             * static_cast<py::ssize_t>(sizeof(T)));
-    }
     return py::array_t<T>{boost::span<const py::ssize_t>{
-                              arr.shape(), static_cast<std::size_t>(arr.ndim())},
-                          strides};
+        arr.shape(), static_cast<std::size_t>(arr.ndim())}};
 }

--- a/include/bh_python/axis.hpp
+++ b/include/bh_python/axis.hpp
@@ -229,7 +229,7 @@ py::array_t<double> edges(const A& ax, bool flow = false, bool numpy_upper = fal
                 || std::is_same<A, axis::regular_uflow>::value
                 || std::is_same<A, axis::regular_numpy>::value)) {
             data[ax.size() + underflow] = std::nextafter(
-                data[ax.size() + underflow], std::numeric_limits<double>::min());
+                data[ax.size() + underflow], std::numeric_limits<double>::lowest());
         }
 
         return edges;

--- a/include/bh_python/make_pickle.hpp
+++ b/include/bh_python/make_pickle.hpp
@@ -54,6 +54,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -300,7 +301,16 @@ class tuple_iarchive {
 
     template <class T>
     tuple_iarchive& operator>>(py::array_t<T>& a) {
-        return operator>>(static_cast<py::object&>(a));
+        py::object obj;
+        this->operator>>(obj);
+        // validate that the pickled object really is an array of the right
+        // dtype; make a C-contiguous copy/conversion if needed
+        auto arr
+            = py::array_t<T, py::array::c_style | py::array::forcecast>::ensure(obj);
+        if(!arr)
+            throw py::value_error("expected a numpy array in pickle data");
+        a = std::move(arr);
+        return *this;
     }
 
     template <class T>
@@ -334,7 +344,9 @@ class tuple_iarchive {
         py::array_t<T> a;
         this->operator>>(a);
         // buffer wrapped by array_wrapper must already have correct size
-        BOOST_ASSERT(static_cast<std::size_t>(a.size()) == w.size);
+        if(static_cast<std::size_t>(a.size()) != w.size)
+            throw std::runtime_error(
+                "array size does not match expected size in pickle data");
         // sadly we cannot move the memory from the numpy array into the vector
         std::copy(a.data(), a.data() + a.size(), w.ptr);
         return *this;

--- a/include/bh_python/multi_cell.hpp
+++ b/include/bh_python/multi_cell.hpp
@@ -8,6 +8,8 @@
 #include <boost/histogram/detail/iterator_adaptor.hpp>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
+#include <vector>
 
 namespace boost {
 namespace histogram {
@@ -248,6 +250,9 @@ class multi_cell {
         std::vector<element_type> w;
         if(Archive::is_loading::value) {
             ar& make_nvp("buffer", w);
+            if(w.size() != size_ * nelem_)
+                throw std::runtime_error(
+                    "multi_cell: serialized buffer size does not match size * nelem");
             reset(size_);
             std::swap_ranges(buffer_.get(), buffer_.get() + size_ * nelem_, w.data());
         } else {

--- a/include/bh_python/register_axis.hpp
+++ b/include/bh_python/register_axis.hpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -48,8 +49,8 @@ decltype(auto) axis_cast(py::handle x) {
 
 template <>
 inline decltype(auto) axis_cast<int>(py::handle x) {
-    if(py::isinstance<int>(x))
-        return py::cast<int>(x);
+    if(py::isinstance<py::int_>(x))
+        return py::cast<int>(x); // overflow raises here
 
     auto val  = py::cast<double>(x);
     auto ival = static_cast<int>(val);
@@ -201,7 +202,7 @@ py::class_<A> register_axis(py::module& m, Args&&... args) {
         .def("__copy__", [](const A& self) { return A(self); })
         .def("__deepcopy__",
              [](const A& self, const py::object& memo) {
-                 A* a                  = new A(self);
+                 auto a                = std::make_unique<A>(self);
                  py::module const copy = py::module::import("copy");
                  a->metadata()         = copy.attr("deepcopy")(a->metadata(), memo);
                  return a;

--- a/include/bh_python/register_histogram.hpp
+++ b/include/bh_python/register_histogram.hpp
@@ -24,6 +24,7 @@
 #include <boost/mp11.hpp>
 
 #include <future>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -49,7 +50,7 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
         .def("__copy__", [](const histogram_t& self) { return histogram_t(self); })
         .def("__deepcopy__",
              [](const histogram_t& self, const py::object& memo) {
-                 auto* a               = new histogram_t(self);
+                 auto a                = std::make_unique<histogram_t>(self);
                  py::module const copy = py::module::import("copy");
                  for(unsigned i = 0; i < a->rank(); i++) {
                      bh::unsafe_access::axis(*a, i).metadata()
@@ -243,7 +244,7 @@ auto inline register_histogram<bh::multi_cell<double>>(py::module& m,
         .def("__copy__", [](const histogram_t& self) { return histogram_t(self); })
         .def("__deepcopy__",
              [](const histogram_t& self, const py::object& memo) {
-                 auto* a               = new histogram_t(self);
+                 auto a                = std::make_unique<histogram_t>(self);
                  const py::module copy = py::module::import("copy");
                  for(unsigned i = 0; i < a->rank(); i++) {
                      bh::unsafe_access::axis(*a, i).metadata()

--- a/include/bh_python/storage.hpp
+++ b/include/bh_python/storage.hpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <stdexcept>
 #include <type_traits>
 
 namespace storage {
@@ -128,6 +129,9 @@ void load(Archive& ar,
     // data is stored as flat numpy array
     py::array_t<double> a;
     ar >> a;
+    if(a.size() % 2 != 0)
+        throw std::runtime_error(
+            "weighted_sum: serialized buffer size is not a multiple of 2");
     s.resize(static_cast<std::size_t>(a.size() / 2));
     // sadly we cannot move the memory from the numpy array into the vector
     std::copy(a.data(), a.data() + a.size(), reinterpret_cast<double*>(s.data()));
@@ -155,6 +159,8 @@ void load(Archive& ar,
     // data is stored as flat numpy array
     py::array_t<double> a;
     ar >> a;
+    if(a.size() % 3 != 0)
+        throw std::runtime_error("mean: serialized buffer size is not a multiple of 3");
     s.resize(static_cast<std::size_t>(a.size() / 3));
     // sadly we cannot move the memory from the numpy array into the vector
     std::copy(a.data(), a.data() + a.size(), reinterpret_cast<double*>(s.data()));
@@ -182,6 +188,9 @@ void load(Archive& ar,
     // data is stored as flat numpy array
     py::array_t<double> a;
     ar >> a;
+    if(a.size() % 4 != 0)
+        throw std::runtime_error(
+            "weighted_mean: serialized buffer size is not a multiple of 4");
     s.resize(static_cast<std::size_t>(a.size() / 4));
     // sadly we cannot move the memory from the numpy array into the vector
     std::copy(a.data(), a.data() + a.size(), reinterpret_cast<double*>(s.data()));

--- a/include/bh_python/vector_string_caster.hpp
+++ b/include/bh_python/vector_string_caster.hpp
@@ -21,11 +21,18 @@ struct type_caster<std::vector<std::string>>
 
     bool load(handle src, bool convert) {
         if(isinstance<array>(src)) {
-            auto arr = reinterpret_borrow<array>(src);
-            if(arr.dtype().kind() == 'S')
-                return load_from_array_s(arr);
-            if(arr.dtype().kind() == 'U')
-                return load_from_array_u(arr);
+            auto arr        = reinterpret_borrow<array>(src);
+            const auto kind = arr.dtype().kind();
+            if(kind == 'S' || kind == 'U') {
+                // the loaders below assume tightly packed (C-contiguous) data,
+                // so make a contiguous copy if needed (e.g. sliced arrays)
+                if((arr.flags() & array::c_style) == 0) {
+                    arr = array::ensure(arr, array::c_style);
+                    if(!arr)
+                        return false;
+                }
+                return kind == 'S' ? load_from_array_s(arr) : load_from_array_u(arr);
+            }
         }
         return base_t::load(src, convert);
     }

--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -222,7 +222,7 @@ def _numpy_compatible_edges(cpp_ax: Any, flow: bool) -> np.typing.NDArray[np.flo
 
     if not isinstance(cpp_ax, _no_nudge_cpp_axes):
         last = cpp_ax.size + underflow
-        edges[last] = np.nextafter(edges[last], np.finfo(np.float64).min)
+        edges[last] = np.nextafter(edges[last], -np.inf)
 
     return edges
 

--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -222,7 +222,7 @@ def _numpy_compatible_edges(cpp_ax: Any, flow: bool) -> np.typing.NDArray[np.flo
 
     if not isinstance(cpp_ax, _no_nudge_cpp_axes):
         last = cpp_ax.size + underflow
-        edges[last] = np.nextafter(edges[last], np.finfo(np.float64).tiny)
+        edges[last] = np.nextafter(edges[last], np.finfo(np.float64).min)
 
     return edges
 

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -960,3 +960,50 @@ def test_transform_validation():
 
     with pytest.raises(TypeError, match="AxisTransform"):
         bh.axis.Regular(10, 1, 100, transform=42)
+
+
+class TestNonContiguousIndex:
+    """Regression tests for gh-1143: category axis index() must honor the
+    input array's memory layout (Fortran order, slices, reversed views)."""
+
+    def test_intcategory_fortran_order(self):
+        ax = bh.axis.IntCategory([1, 2, 3])
+        arr = np.asfortranarray([[1, 2], [3, 1]])
+        assert_array_equal(ax.index(arr), [[0, 1], [2, 0]])
+
+    def test_intcategory_negative_stride(self):
+        ax = bh.axis.IntCategory([1, 2, 3])
+        arr = np.array([1, 2, 3, 1])[::-1]
+        assert_array_equal(ax.index(arr), [0, 2, 1, 0])
+
+    def test_intcategory_strided(self):
+        ax = bh.axis.IntCategory([1, 2, 3])
+        arr = np.array([1, 2, 3, 1])[::2]
+        assert_array_equal(ax.index(arr), [0, 2])
+
+    def test_strcategory_strided(self):
+        ax = bh.axis.StrCategory(["a", "b", "c"])
+        arr = np.array(["a", "b", "c", "a"])[::2]
+        assert_array_equal(ax.index(arr), [0, 2])
+
+    def test_strcategory_negative_stride(self):
+        ax = bh.axis.StrCategory(["a", "b", "c"])
+        arr = np.array(["a", "b", "c"])[::-1]
+        assert_array_equal(ax.index(arr), [2, 1, 0])
+
+    def test_strcategory_bytes_strided(self):
+        ax = bh.axis.StrCategory(["a", "b", "c"])
+        arr = np.array([b"a", b"b", b"c", b"a"])[::2]
+        assert_array_equal(ax.index(arr), [0, 2])
+
+
+def test_to_numpy_upper_edge_nudge_direction():
+    # Regression test for gh-1143: the last edge returned by to_numpy() is
+    # nudged one ulp *below* the true edge, which must also hold for
+    # negative and zero upper edges.
+    for start, stop in [(-2, -1), (-1, 0), (1, 2)]:
+        ax = bh.axis.Regular(4, start, stop)
+        h = bh.Histogram(ax)
+        edges = h.to_numpy()[1]
+        assert edges[-1] == np.nextafter(ax.edges[-1], -np.inf)
+        assert edges[-1] < stop

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1746,3 +1746,36 @@ import boost_histogram
     )
     assert result.returncode != 0
     assert "Did you forget to compile boost-histogram?" in result.stderr
+
+
+def test_fill_noncontiguous_int_category():
+    # Regression test for gh-1143: fill must honor input strides
+    cat = [1, 2, 3]
+    expected = bh.Histogram(bh.axis.IntCategory(cat))
+    expected.fill([1, 3, 2, 1])
+
+    h = bh.Histogram(bh.axis.IntCategory(cat))
+    h.fill(np.array([1, 2, 3, 1])[::-1])
+    assert_array_equal(h.view(flow=True), expected.view(flow=True))
+
+    h2 = bh.Histogram(bh.axis.IntCategory(cat))
+    h2.fill(np.array([1, 7, 3, 7, 2, 7, 1, 7])[::2])
+    assert_array_equal(h2.view(flow=True), expected.view(flow=True))
+
+
+def test_fill_noncontiguous_str_category():
+    # Regression test for gh-1143: fill must honor input strides
+    cat = ["a", "b", "c"]
+    expected = bh.Histogram(bh.axis.StrCategory(cat))
+    expected.fill(["a", "c", "a"])
+
+    h = bh.Histogram(bh.axis.StrCategory(cat))
+    h.fill(np.array(["a", "b", "c", "b", "a"])[::2])
+    assert_array_equal(h.view(flow=True), expected.view(flow=True))
+
+    expected2 = bh.Histogram(bh.axis.StrCategory(cat))
+    expected2.fill(["c", "b", "a"])
+
+    h2 = bh.Histogram(bh.axis.StrCategory(cat))
+    h2.fill(np.array(["a", "b", "c"])[::-1])
+    assert_array_equal(h2.view(flow=True), expected2.view(flow=True))

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -291,3 +291,39 @@ def test_cloudpickle():
 
     assert h == h2
     assert h is not h2
+
+
+# Regression tests for gh-1143: a corrupted pickle state must raise instead
+# of writing/reading out of bounds.
+def _corrupt_state(h, corrupt):
+    ch = h._hist
+    state = list(ch.__getstate__())
+    # the (last) flat numpy buffer in the state is the storage data
+    (idx,) = [i for i, x in enumerate(state) if isinstance(x, np.ndarray)][-1:]
+    state[idx] = corrupt(state[idx])
+    new = ch.__class__.__new__(ch.__class__)
+    new.__setstate__(tuple(state))
+
+
+def test_corrupted_pickle_truncated_buffer():
+    h = bh.Histogram(bh.axis.Regular(4, 0, 1), storage=bh.storage.Weight())
+    h.fill([0.1, 0.2])
+
+    with pytest.raises(RuntimeError, match="not a multiple of 2"):
+        _corrupt_state(h, lambda a: a[:-1])
+
+
+def test_corrupted_pickle_non_array():
+    h = bh.Histogram(bh.axis.Regular(4, 0, 1), storage=bh.storage.Weight())
+    h.fill([0.1, 0.2])
+
+    with pytest.raises(ValueError, match="expected a numpy array"):
+        _corrupt_state(h, lambda _: "not an array")
+
+
+def test_corrupted_pickle_mean_storage():
+    h = bh.Histogram(bh.axis.Regular(4, 0, 1), storage=bh.storage.Mean())
+    h.fill([0.1, 0.2], sample=[1.0, 2.0])
+
+    with pytest.raises(RuntimeError, match="not a multiple of 3"):
+        _corrupt_state(h, lambda a: a[:-1])


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1143

Fixes a set of non-contiguous-array and memory-safety findings in the C++ bindings:

- **A1** (heap OOB / wrong results): `array_like<T>` no longer copies the input array's strides onto the output; callers fill the result linearly in C order, so Fortran-order input to `IntCategory.index` returned transposed results and negative-stride input caused out-of-bounds writes. The output is now plain C-contiguous.
- **A2** (silent wrong fills): the `std::vector<std::string>` caster ignored strides when iterating numpy `S`/`U` arrays, so sliced/reversed string arrays gave wrong `StrCategory.index`/`fill` results (and reversed views read OOB). Non-contiguous inputs now get a C-contiguous copy first.
- **A5** (heap overflow on malformed pickle): storage `load()` now validates that the serialized buffer size is a multiple of the accumulator width before resizing/copying; `multi_cell::serialize` validates the loaded buffer length; `tuple_iarchive` validates/converts array elements with `py::array_t<T>::ensure` instead of blindly reinterpreting, and the `array_wrapper` size check is a real runtime check instead of a release-mode no-op `BOOST_ASSERT`.
- **B4** (wrong-direction nudge): `edges(..., numpy_upper=true)` used `std::nextafter(x, std::numeric_limits<double>::min())`, which moves toward ~0 — wrong for negative/zero upper edges (`Regular(4, -2, -1).to_numpy()` reported a last edge above -1). Now nudges toward `lowest()`.
- **B16**: `py::isinstance<int>(x)` is always false, so the int fast path in `axis_cast<int>` was dead and large Python ints went through a lossy double round-trip. Now uses `py::isinstance<py::int_>` with a direct `py::cast<int>` (overflow raises).
- **B17** (leak): the `__deepcopy__` lambdas for axes and histograms leaked the freshly `new`-ed object if `copy.deepcopy(metadata)` threw; they now construct via `std::make_unique` and return the holder.

Regression tests added for: Fortran-order / negative-stride / strided `IntCategory.index` and `fill`; strided / reversed (str and bytes) `StrCategory.index` and `fill`; the `to_numpy` upper-edge nudge direction for negative, zero, and positive edges; and corrupted pickle states (truncated buffer for weight and mean storages, non-array storage element).

🤖 Generated with [Claude Code](https://claude.com/claude-code)