### PR TITLE
fix: rebin with groups — MultiCell support, flow handling, and group_mapping protocol

### DIFF
--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -218,7 +218,8 @@ def _combine_group_contents(
     jj: int,
 ) -> None:
     """
-    Combine two views into one, in-place. This is used for threaded filling.
+    Add bin ``j`` (along view dimension ``i``) of ``reduced_view`` into bin
+    ``jj`` of ``new_view``, in-place. Used for rebinning with groups.
     """
     pos = [slice(None)] * (i)
     if new_view.dtype.names:
@@ -1545,31 +1546,55 @@ class Histogram(typing.Generic[S]):
 
         new_reduced: _core.hist._BaseHistogram | _core.hist.any_multi_cell
         new_reduced = reduced.__class__(axes)
+        if isinstance(reduced, _core.hist.any_multi_cell) and isinstance(
+            new_reduced, _core.hist.any_multi_cell
+        ):
+            # The constructor in reduced.__class__(axes) does not take care of the number of cells.
+            # If reduced is a multi cell histogram, we have to set the number of cells per bin manually for new_reduced
+            new_reduced.reset_nelem(reduced.nelem())
         new_view = new_reduced.view(flow=True)
+
+        # Views of multi cell histograms have the cell index as the first
+        # (index 0) dimension, so the axis position within the view is
+        # shifted by one.
+        view_i = i + 1 if isinstance(reduced, _core.hist.any_multi_cell) else i
+
+        groups = list(groups)  # do not modify the caller's list
         j = 0
         new_j_base = 0
 
         if old_axis.traits_underflow and axes[i].traits_underflow:
-            groups = [1, *groups]
+            groups.insert(0, 1)
         elif axes[i].traits_underflow:
             new_j_base = 1
+        elif old_axis.traits_underflow:
+            # The new axis has no underflow bin: skip the old underflow bin
+            # here. For unordered (categorical) axes its contents are folded
+            # into the new overflow bin below; otherwise they are dropped.
+            j = 1
 
         if old_axis.traits_overflow and axes[i].traits_overflow:
             groups.append(1)
+        # If the old axis has an overflow bin but the new one does not, the
+        # old overflow contents are dropped (the bin is simply not consumed).
 
         for new_j, group in enumerate(groups):
             for _ in range(group):
                 _combine_group_contents(
-                    new_view, reduced_view, i, j, new_j + new_j_base
+                    new_view, reduced_view, view_i, j, new_j + new_j_base
                 )
                 j += 1
 
-            if (
-                old_axis.traits_underflow
-                and not axes[i].traits_ordered
-                and axes[i].traits_overflow
-            ):
-                _combine_group_contents(new_view, reduced_view, i, 0, -1)
+        if (
+            old_axis.traits_underflow
+            and not axes[i].traits_underflow
+            and not axes[i].traits_ordered
+            and axes[i].traits_overflow
+        ):
+            # On an unordered (categorical) axis every out-of-range entry
+            # lands in the overflow bin, so the old underflow contents are
+            # added to the new overflow bin -- exactly once.
+            _combine_group_contents(new_view, reduced_view, view_i, 0, -1)
 
         return new_reduced
 

--- a/src/boost_histogram/tag.py
+++ b/src/boost_histogram/tag.py
@@ -136,6 +136,9 @@ class rebin:
         total_args = sum(i is not None for i in [factor, groups, edges])
         if total_args != 1 and axis is None:
             raise ValueError("Exactly one argument should be provided")
+        if factor is not None and axis is not None:
+            msg = "A factor cannot be combined with an axis; use groups= or edges= with axis= instead"
+            raise ValueError(msg)
 
         self.groups = groups
         self.edges = edges
@@ -166,13 +169,22 @@ class rebin:
         return (self.group_mapping(axis), self.axis)
 
     def group_mapping(self, axis: PlottableAxis) -> Sequence[int]:
+        """
+        Return the list of group sizes (numbers of adjacent bins to merge)
+        for ``axis``. For explicit groups, the sum of the group sizes must
+        equal the number of bins in the axis. For a factor, this returns
+        ``len(axis) // factor`` groups of size ``factor``; if the factor does
+        not divide the number of bins evenly, the leftover bins are not part
+        of any group (a consumer should merge them into the overflow bin,
+        matching the C++ factor-based rebinning).
+        """
         if self.groups is not None:
             if sum(self.groups) != len(axis):
                 msg = f"The sum of the groups ({sum(self.groups)}) must be equal to the number of bins in the axis ({len(axis)})"
                 raise ValueError(msg)
             return self.groups
         if self.factor is not None:
-            return [self.factor] * len(axis)
+            return [self.factor] * (len(axis) // self.factor)
         if self.edges is not None or self.axis is not None:
             newedges = None
             if self.edges is not None:

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -817,8 +817,62 @@ def test_rebin_change_axis_cat():
     h.fill([-1, 1.1, 2.2, 3.3, 4.4, 5.5])
     hs = h[bh.rebin(groups=[2, 3], axis=bh.axis.StrCategory(["a", "b"]))]
     assert_array_equal(hs.view(), [1, 3])
-    assert_array_equal(hs.view(flow=True), [1, 3, 4])
+    # Old underflow (1) and old overflow (1) both end up in the new overflow,
+    # exactly once each.
+    assert_array_equal(hs.view(flow=True), [1, 3, 2])
     assert_array_equal(list(hs.axes[0]), ["a", "b"])
+
+
+def test_rebin_groups_flow_to_noflow():
+    # Issue #1143 (B6b): rebinning a flow axis onto a categorical axis
+    # without an underflow bin must not fold the old underflow into the
+    # first group, and must add it to the new overflow exactly once.
+    h = bh.Histogram(bh.axis.Regular(4, 0, 4))
+    h.view(flow=True)[:] = [100, 1, 2, 3, 4, 200]
+    hs = h[bh.rebin(groups=[2, 2], axis=bh.axis.IntCategory([0, 1]))]
+    assert_array_equal(hs.view(flow=True), [3, 7, 300])
+
+
+def test_rebin_groups_flow_combinations():
+    # All combinations of (old flow) x (new flow) for group rebinning.
+    h = bh.Histogram(bh.axis.Regular(4, 0, 4))
+    h.view(flow=True)[:] = [100, 1, 2, 3, 4, 200]
+
+    # Old flow -> new flow: flow bins are carried over unchanged
+    assert_array_equal(h[bh.rebin(groups=[2, 2])].view(flow=True), [100, 3, 7, 200])
+
+    # Old underflow dropped on an ordered axis without underflow
+    hs = h[bh.rebin(groups=[2, 2], axis=bh.axis.Variable([0, 2, 4], underflow=False))]
+    assert_array_equal(hs.view(flow=True), [3, 7, 200])
+
+    # Old overflow dropped on an axis without overflow
+    hs = h[bh.rebin(groups=[2, 2], axis=bh.axis.Variable([0, 2, 4], overflow=False))]
+    assert_array_equal(hs.view(flow=True), [100, 3, 7])
+
+    # Both flow bins dropped on a flowless ordered axis
+    hs = h[
+        bh.rebin(
+            groups=[2, 2],
+            axis=bh.axis.Variable([0, 2, 4], underflow=False, overflow=False),
+        )
+    ]
+    assert_array_equal(hs.view(flow=True), [3, 7])
+
+    # Old axis without underflow: new axis copies the traits
+    h2 = bh.Histogram(bh.axis.Regular(4, 0, 4, underflow=False))
+    h2.view(flow=True)[:] = [1, 2, 3, 4, 200]
+    assert_array_equal(h2[bh.rebin(groups=[2, 2])].view(flow=True), [3, 7, 200])
+
+    # Old axis without underflow onto a categorical axis: only the old
+    # overflow goes to the new overflow
+    hs = h2[bh.rebin(groups=[2, 2], axis=bh.axis.IntCategory([0, 1]))]
+    assert_array_equal(hs.view(flow=True), [3, 7, 200])
+
+    # Old flowless axis onto an axis with flow: new flow bins stay empty
+    h3 = bh.Histogram(bh.axis.Regular(4, 0, 4, underflow=False, overflow=False))
+    h3.view(flow=True)[:] = [1, 2, 3, 4]
+    hs = h3[bh.rebin(groups=[2, 2], axis=bh.axis.Variable([0, 2, 4]))]
+    assert_array_equal(hs.view(flow=True), [0, 3, 7, 0])
 
 
 def test_shrink_rebin_1d():

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -609,6 +609,34 @@ def test_rebin_groups_no_inplace_modification():
     assert h3 == h4
 
 
+# Issue #1143 (B7)
+def test_rebin_group_mapping_factor():
+    # The factor form of the RebinProtocol must produce groups that sum to
+    # the number of bins when the factor divides evenly
+    ax = bh.axis.Regular(10, 0, 10)
+    groups = bh.rebin(2).group_mapping(ax)
+    assert list(groups) == [2] * 5
+    assert sum(groups) == len(ax)
+
+    # With a remainder, the leftover bins are not part of any group (they
+    # are merged into overflow, matching the C++ factor rebinning)
+    ax5 = bh.axis.Regular(5, 0, 5)
+    assert list(bh.rebin(2).group_mapping(ax5)) == [2, 2]
+
+    # The group form of group_mapping must match the C++ factor rebinning
+    h = bh.Histogram(bh.axis.Regular(5, 0, 5))
+    h.view(flow=True)[:] = [100, 1, 2, 3, 4, 5, 200]
+    hs = h[:: bh.rebin(2)]
+    assert_array_equal(hs.view(flow=True), [100, 3, 7, 205])
+
+
+def test_rebin_factor_and_axis_raises():
+    with pytest.raises(ValueError, match="factor cannot be combined"):
+        bh.rebin(2, axis=bh.axis.Regular(2, 0, 4))
+    with pytest.raises(ValueError, match="factor cannot be combined"):
+        bh.rebin(factor=2, axis=bh.axis.Regular(2, 0, 4))
+
+
 def test_vectorized_get_basic():
     """NumPy integer-array indices gather scattered cells through the buffer."""
     h = bh.Histogram(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -498,6 +498,40 @@ def test_unsupported_histogram_subtraction(storage, fill_kwargs):
         mk() - mk()
 
 
+# Issue #1143 (B6a)
+def test_multi_cell_rebin_groups():
+    h = bh.Histogram(bh.axis.Regular(4, 0, 4), storage=bh.storage.MultiCell(2))
+    h.fill([0.5, 1.5, 2.5, 3.5], weight=[[1, 10], [2, 20], [3, 30], [4, 40]])
+    h.view(flow=True)[:, 0] = [100, 1000]
+    h.view(flow=True)[:, -1] = [200, 2000]
+
+    hs = h[bh.rebin(groups=[2, 2])]
+    assert hs.storage.nelem == 2
+    assert_array_equal(hs.view(), [[3, 7], [30, 70]])
+    assert_array_equal(hs.view(flow=True), [[100, 3, 7, 200], [1000, 30, 70, 2000]])
+
+
+def test_multi_cell_rebin_groups_2d():
+    # Rebin a non-leading axis: the cell index is the leading view dimension,
+    # so the axis offset must be applied when combining groups.
+    h = bh.Histogram(
+        bh.axis.Regular(2, 0, 2),
+        bh.axis.Regular(4, 0, 4),
+        storage=bh.storage.MultiCell(2),
+    )
+    h.fill(
+        [0.5, 0.5, 0.5, 0.5, 1.5],
+        [0.5, 1.5, 2.5, 3.5, 0.5],
+        weight=[[1, 10], [2, 20], [3, 30], [4, 40], [5, 50]],
+    )
+
+    hs = h[:, bh.rebin(groups=[2, 2])]
+    assert hs.storage.nelem == 2
+    assert_array_equal(hs.view(), [[[3, 7], [5, 0]], [[30, 70], [50, 0]]])
+    # The first axis is untouched
+    assert_array_equal(hs.view().sum(axis=(1, 2)), h.view().sum(axis=(1, 2)))
+
+
 @pytest.mark.parametrize("nelem", [1, 3])
 def test_multi_cell_reset(nelem):
     h = _filled_multi_cell(nelem)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #1143.

This fixes three verified findings in rebinning with groups (B6, B7):

## B6a — MultiCell crash

`h[bh.rebin(groups=[2, 2])]` on a `MultiCell` histogram raised `IndexError: index 0 is out of bounds for axis 0 with size 0`. `_rebin_with_groups` built the new C++ histogram with `reduced.__class__(axes)`, which does not preserve the cell count, and `_combine_group_contents` indexed the wrong view dimension because MultiCell views carry the cell index as the leading dimension. Both are now handled the same way as the existing `pick_each` path: `reset_nelem()` is called on the new histogram, and the per-axis position within the view is offset by one for MultiCell storage.

## B6b — flow mishandling when rebinning onto an axis without flow bins

When the old axis has flow bins and the user-supplied `new_axis` does not (e.g. `h[bh.rebin(groups=[2, 2], axis=bh.axis.IntCategory([0, 1]))]`):

- the old underflow bin was folded into the first group,
- the underflow→overflow combine ran once **per group** instead of once, and
- the trailing overflow group consumed a shifted regular bin instead of the old overflow bin.

For `Regular(4)` with flow view `[100, 1, 2, 3, 4, 200]` and `groups=[2, 2]` onto `IntCategory([0, 1])`, the result was `[101, 5, 304]`; it is now `[3, 7, 300]`.

### Flow-handling semantics implemented

For each side (underflow and overflow), all combinations of old/new axis traits are now handled:

| old flow bin | new flow bin | behavior |
| --- | --- | --- |
| yes | yes | carried over unchanged (1-bin group) |
| yes | no (ordered axis) | dropped, matching reduce/crop semantics |
| yes (underflow) | no, but new axis is unordered/categorical with overflow | folded into the new **overflow** bin exactly once, since every out-of-range entry on a categorical axis lands in overflow |
| no | yes | new flow bin stays empty |

The pre-existing `test_rebin_change_axis_cat` expectation encoded the buggy once-per-group behavior (`[1, 3, 4]`) and was updated to the correct value (`[1, 3, 2]`).

## B7 — `rebin.group_mapping` protocol violation

The factor form returned `[factor] * len(axis)` — group sizes summing to `factor * len(axis)` — violating the `sum(groups) == len(axis)` invariant the same method enforces for explicit groups. This is part of the public `RebinProtocol` surface consumed cross-library. It now returns `len(axis) // factor` groups of size `factor`; when the factor does not divide the bin count evenly, the remainder bins are not part of any group, matching the C++ factor rebinning (and the UHI `rebin` spec), which merges leftover bins into the overflow bin. The choice is documented in the docstring. (Internal code is unaffected: the factor path is matched before `group_mapping` in `_handle_slice` and goes through the C++ `slice_and_rebin`.)

Additionally, `rebin(2, axis=...)` silently ignored the axis; the constructor now raises `ValueError` since a factor combined with a replacement axis has no defined meaning (use `groups=`/`edges=` with `axis=` instead). `groups`/`edges` with `axis=` keep working as before.

## Tests

- MultiCell groups rebin (1D with flow bins, and 2D rebinning a non-leading axis)
- the exact flow-to-noflow repro from the issue, plus all constructible (old flow) × (new flow) combinations for both underflow and overflow
- `group_mapping` invariant (`sum(groups) == len(axis)`), factor-with-remainder behavior, and consistency with the C++ factor rebin
- `rebin(factor, axis=...)` raising `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)