### PR TITLE
test: skip pytest plugin end-to-end test on emscripten

### DIFF
--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.metadata
+import sys
 
 import pytest
 
@@ -135,6 +136,9 @@ def test_axis_metadata_differs() -> None:
 # --- end-to-end through pytest (proves the entry point is wired up) -------
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("emscripten"), reason="needs subprocess"
+)
 @pytest.mark.skipif(
     not _plugin_autoloaded(),
     reason="boost-histogram not installed with its pytest11 entry point (CMake-only build)",

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -136,9 +136,7 @@ def test_axis_metadata_differs() -> None:
 # --- end-to-end through pytest (proves the entry point is wired up) -------
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("emscripten"), reason="needs subprocess"
-)
+@pytest.mark.skipif(sys.platform.startswith("emscripten"), reason="needs subprocess")
 @pytest.mark.skipif(
     not _plugin_autoloaded(),
     reason="boost-histogram not installed with its pytest11 entry point (CMake-only build)",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

The Pyodide CI job [fails](https://github.com/scikit-hep/boost-histogram/actions/runs/27492667553/job/81260738210) because `test_plugin_loaded_end_to_end` calls `pytester.runpytest_subprocess(...)`, which spawns a subprocess. Pyodide/Emscripten has no process support, so the test errors instead of being skipped.

## Fix

Add the same `emscripten` skip that the other subprocess-using test (`test_histogram.py`) already carries:

```python
@pytest.mark.skipif(
    sys.platform.startswith("emscripten"), reason="needs subprocess"
)
```

The other `subprocess.run` usage in the suite is already guarded; this test was the gap.
