### PR TITLE
fix: avoid Boost indexed-range UB in rank-0 sum()/empty()

### DIFF
--- a/include/bh_python/register_histogram.hpp
+++ b/include/bh_python/register_histogram.hpp
@@ -173,8 +173,13 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
             "sum",
             [](const histogram_t& self, bool flow) {
                 const py::gil_scoped_release release;
-                return bh::algorithm::sum(
-                    self, flow ? bh::coverage::all : bh::coverage::inner);
+                // A rank-0 histogram has no flow bins, so inner == all. Use
+                // all to avoid Boost's indexed range, which is UB for rank-0
+                // (it reads uninitialized per-axis state); the all path uses
+                // plain iteration instead.
+                const auto cov = (flow || self.rank() == 0) ? bh::coverage::all
+                                                            : bh::coverage::inner;
+                return bh::algorithm::sum(self, cov);
             },
             "flow"_a = false)
 
@@ -182,6 +187,12 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
             "empty",
             [](const histogram_t& self, bool flow) {
                 const py::gil_scoped_release release;
+                if(self.rank() == 0) {
+                    // algorithm::empty drives the same rank-0-UB indexed range;
+                    // check the single cell directly instead.
+                    using value_type = typename histogram_t::value_type;
+                    return !(*self.begin() != value_type());
+                }
                 return bh::algorithm::empty(
                     self, flow ? bh::coverage::all : bh::coverage::inner);
             },
@@ -368,8 +379,12 @@ auto inline register_histogram<bh::multi_cell<double>>(py::module& m,
             "sum",
             [](const histogram_t& self, bool flow) -> value_type {
                 const py::gil_scoped_release release;
-                value_type result = bh::algorithm::sum(
-                    self, flow ? bh::coverage::all : bh::coverage::inner);
+                // rank-0 inner coverage drives Boost's indexed range, which is
+                // UB for rank-0; all coverage is equivalent (no flow bins) and
+                // uses plain iteration.
+                const auto cov    = (flow || self.rank() == 0) ? bh::coverage::all
+                                                               : bh::coverage::inner;
+                value_type result = bh::algorithm::sum(self, cov);
                 // A histogram with zero bins has no cells to accumulate, so the
                 // default-constructed accumulator stays empty. Return a
                 // zero-filled vector of length nelem so the result shape is
@@ -385,6 +400,12 @@ auto inline register_histogram<bh::multi_cell<double>>(py::module& m,
             "empty",
             [](const histogram_t& self, bool flow) {
                 const py::gil_scoped_release release;
+                if(self.rank() == 0) {
+                    // algorithm::empty drives the same rank-0-UB indexed range;
+                    // check the single cell directly instead.
+                    using value_type = typename histogram_t::value_type;
+                    return !(*self.begin() != value_type());
+                }
                 return bh::algorithm::empty(
                     self, flow ? bh::coverage::all : bh::coverage::inner);
             },

--- a/include/bh_python/register_histogram.hpp
+++ b/include/bh_python/register_histogram.hpp
@@ -402,9 +402,9 @@ auto inline register_histogram<bh::multi_cell<double>>(py::module& m,
                 const py::gil_scoped_release release;
                 if(self.rank() == 0) {
                     // algorithm::empty drives the same rank-0-UB indexed range;
-                    // check the single cell directly instead.
-                    using value_type = typename histogram_t::value_type;
-                    return !(*self.begin() != value_type());
+                    // the single MultiCell cell is empty iff it collected
+                    // nothing.
+                    return self.begin()->empty();
                 }
                 return bh::algorithm::empty(
                     self, flow ? bh::coverage::all : bh::coverage::inner);

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1231,6 +1231,25 @@ def test_numpy_conversion_5():
     assert a1[2, 1] == 5
 
 
+def test_rank0_sum_empty():
+    # A rank-0 histogram has a single cell and no flow bins. inner coverage
+    # used to drive Boost's indexed range, which is UB for rank-0 and crashed
+    # depending on stack layout (e.g. free-threaded Windows). inner == all here.
+    h = bh.Histogram()
+    assert h.ndim == 0
+    assert h.empty() is True
+    assert h.empty(flow=True) is True
+    assert h.sum() == 0
+    assert h.sum(flow=True) == 0
+
+    h.fill()
+    h.fill()
+    h.fill()
+    assert h.empty() is False
+    assert h.sum() == 3
+    assert h.sum(flow=True) == 3
+
+
 @pytest.mark.parametrize(
     "dtype",
     [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64],


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`tests/test_histogram.py::test_numpy_conversion_4` crashes the xdist worker with a **Windows access violation** on free-threaded Python (cp314t) — both in [CI](https://github.com/scikit-hep/boost-histogram/actions/runs/27492667553/job/81260738246) and in [integration-tests](https://github.com/scikit-hep/integration-tests/actions/runs/27257489976/job/80494999483). The fatal stack points at `b.sum()` where `b = bh.Histogram()` — the only **rank-0** (zero-axis) histogram among the conversion tests.

## Root cause

`b.sum()` (flow=False) → `bh::algorithm::sum(self, coverage::inner)` → `for (auto&& x : indexed(hist))`.

For a rank-0 histogram, `indexed_range`'s constructor initializes its per-axis `index_data` via `for_each_axis`, which **runs zero times** — so `indices_[0]` stays uninitialized. The empty-range guard (`indexed.hpp:323`) doesn't fire because rank-0 storage still has one cell (`begin_ != end_`). The single iteration then calls `operator++`, which reads the uninitialized `idx`/`end`/`end_skip` and walks `c` off the stack buffer when the garbage doesn't terminate cleanly.

This is **undefined behavior in Boost.Histogram's `indexed` for rank-0**, with an outcome that depends on stack layout. The GIL build got lucky garbage; the free-threaded build's different stack frames did not. It has nothing to do with the GIL itself. `empty()` (also `indexed`-based) shares the latent bug.

## Fix

A rank-0 histogram has no flow bins, so `inner == all`:

- **`sum()`** uses `coverage::all` for rank-0 — Boost's `all` branch uses plain `for (auto&& x : hist)` iteration, not `indexed`.
- **`empty()`** checks the single cell directly for rank-0 (its `all` path is still `indexed`).

Both the dense and `multi_cell` register blocks are fixed, plus a `test_rank0_sum_empty` regression test.

## Verification

Built a free-threaded (3.14t) wheel locally and confirmed: rank-0 `sum`/`empty` (empty and filled) behave correctly, 500k-iteration loop over the previously-UB path is clean, and the full suite passes under `-n auto`. The Windows-specific crash itself can only be confirmed by CI.