### PR TITLE
feat: add reflected __rsub__ and __rtruediv__ operators

### DIFF
--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -764,6 +764,11 @@ class Histogram(typing.Generic[S]):
 
         return self
 
+    def __rsub__(self, other: np.typing.NDArray[Any] | float) -> Self:
+        # Subtraction is not commutative, so unlike __radd__ this cannot defer
+        # to the forward operator: other - self == -(self - other).
+        return (self - other) * -1
+
     # If these fail, the underlying object throws the correct error
     def __mul__(self, other: Histogram[S] | np.typing.NDArray[Any] | float) -> Self:
         result = self.copy(deep=False)
@@ -788,6 +793,19 @@ class Histogram(typing.Generic[S]):
         elif isinstance(other, _histogram_types):
             other = self._as_double_cpp(other)  # type: ignore[assignment]
         return self._compute_inplace_op("__itruediv__", other)
+
+    def __rtruediv__(self, other: np.typing.NDArray[Any] | float) -> Self:
+        # Division is not commutative, so unlike __rmul__ this cannot defer to
+        # the forward operator: divide other by each cell. Promote integer
+        # storages to Double first, matching __itruediv__.
+        result = self.copy(deep=False)
+        result._convert_int_storage_to_double()
+        view = result.view(flow=True)
+        # Empty bins divide to inf/nan; suppress the warnings as elsewhere.
+        with np.errstate(divide="ignore", invalid="ignore"):
+            np.true_divide(other, view, out=view)
+        result._variance_known = False
+        return result
 
     def __imul__(self, other: Histogram[S] | np.typing.NDArray[Any] | float) -> Self:
         return self._compute_inplace_op("__imul__", other)

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -666,6 +666,45 @@ def test_mixed_int_double_division():
     assert (bd / ai).view() == approx(1 / expected)
 
 
+def test_reflected_scalar_operators():
+    # gh-1154: scalar - hist and scalar / hist were missing (only the
+    # commutative __radd__/__rmul__ existed).
+    h = bh.Histogram(bh.axis.Regular(4, 0, 4))
+    h[:] = (1, 2, 4, 5)
+    values = h.view().copy()
+
+    # scalar - hist == -(hist - scalar)
+    assert (10 - h).view() == approx(10 - values)
+    assert (10 - h).view() == approx(((h - 10) * -1).view())
+    # scalar / hist, elementwise
+    assert (8 / h).view() == approx(8 / values)
+    # operands left unchanged
+    assert h.view() == approx(values)
+
+
+def test_reflected_division_promotes_int_storage():
+    # gh-1154: scalar / int-hist must not truncate (mirrors __itruediv__).
+    h = bh.Histogram(bh.axis.Integer(0, 3), storage=bh.storage.Int64())
+    h[:] = (2, 4, 8)
+    result = 1 / h
+    assert result.storage_type is bh.storage.Double
+    assert result.view() == approx(1 / np.array([2, 4, 8]))
+    assert h.storage_type is bh.storage.Int64
+
+
+def test_reflected_operators_weight_storage():
+    # scalar - weighted-hist works (variance is preserved through the negation),
+    # but scalar / weighted-hist is rejected: the reciprocal of a weighted sum
+    # has no meaningful variance (matches test_view_rdiv_rejected).
+    h = bh.Histogram(bh.axis.Regular(3, 0, 3), storage=bh.storage.Weight())
+    h.fill([0, 1, 1, 2], weight=[1, 2, 3, 4])
+    values = h.values().copy()
+
+    assert (10 - h).values() == approx(10 - values)
+    with pytest.raises(TypeError, match="divide a scalar or array"):
+        12 / h
+
+
 def test_project():
     h = bh.Histogram(bh.axis.Integer(0, 2), bh.axis.Integer(1, 4))
     h.fill(0, 1)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #1154.

`Histogram` defined the commutative reflected operators `__radd__` and `__rmul__` but not `__rsub__` or `__rtruediv__`, so `scalar - h` and `scalar / h` raised `TypeError` while the forward and commutative-reflected forms worked. This surfaced downstream in scikit-hep/hist#401.

```python
h = bh.Histogram(bh.axis.Regular(5, 0, 5)); h.fill([1, 2, 3, 4])
h - 100   # OK        100 + h   # OK (__radd__)
100 - h   # was TypeError -> now works
100 / h   # was TypeError -> now works
```

### Changes
- **`__rsub__`**: `other - self == -(self - other)`, reusing the forward `__sub__`/`__mul__` so storage and axis handling stay consistent.
- **`__rtruediv__`**: divides `other` by each cell. Promotes integer storages to `Double` first (mirroring the recent `__itruediv__` fix, #601) and wraps the division in `np.errstate(divide="ignore", invalid="ignore")` for empty bins, matching the existing pattern in `view.py`.

### Semantics for accumulator storages
Reflected **division** of a weighted/mean histogram is intentionally **rejected** — `__rtruediv__` surfaces the existing view-level `TypeError` ("Cannot divide a scalar or array by a …View", #1143), since the reciprocal of a weighted sum carries no meaningful variance. Reflected **subtraction** works for accumulator storages (variance preserved through the negation).

### Scope
Like the existing `__radd__`/`__rmul__`, this covers scalar (and broadcastable) operands. A NumPy array on the left (`np.array(...) - h`) is still handled by NumPy's own dispatch and is unchanged by this PR.

### Tests
Added `test_reflected_scalar_operators`, `test_reflected_division_promotes_int_storage`, and `test_reflected_operators_weight_storage` to `tests/test_histogram.py` (Double, Int64→Double promotion, and the Weight reject-division / allow-subtraction cases). Full suite passes (1127 passed, 1 pre-existing xfail); `nox -s lint` (ruff + strict mypy) clean.