### PR TITLE
fix: MultiCell loses contents when a growing axis resizes storage

### DIFF
--- a/include/bh_python/multi_cell.hpp
+++ b/include/bh_python/multi_cell.hpp
@@ -37,6 +37,10 @@ struct multi_cell_reference : public multi_cell_base<T, boost::span<T>> {
     // using boost::span<T>::span;
     using multi_cell_base<T, boost::span<T>>::multi_cell_base;
 
+    // Copy construction rebinds the view (proxy-reference semantics), so that a
+    // reference refers to the same cells as the one it was copied from.
+    multi_cell_reference(const multi_cell_reference&) = default;
+
     void operator()(const boost::span<T> values) { operator+=(values); }
 
     void operator+=(const boost::span<T> values) {
@@ -62,6 +66,22 @@ struct multi_cell_reference : public multi_cell_base<T, boost::span<T>> {
         auto it = this->begin();
         for(const T& x : values)
             *it++ = x;
+        return *this;
+    }
+
+    // Assignment writes through to the referenced cells (proxy-reference
+    // semantics), it does not rebind the view. This overload must be provided
+    // explicitly: the templated operator= above does not suppress the implicitly
+    // declared copy-assignment operator, and that compiler-generated one (which
+    // rebinds the span and thus discards the write) would otherwise win overload
+    // resolution whenever the right-hand side is another multi_cell_reference.
+    // boost::histogram relies on write-through assignment when it relocates cells
+    // during axis growth (detail::storage_grower::apply does `*new = *old`);
+    // without this overload every growth silently zeroes the existing contents.
+    multi_cell_reference& operator=(const multi_cell_reference& values) {
+        if(values.size() != this->size())
+            throw std::range_error("size does not match for = ref");
+        std::copy(values.begin(), values.end(), this->begin());
         return *this;
     }
 };

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -683,3 +683,39 @@ def test_multi_cell():
     expected_view[:, 2:4, 0:3] = sub_array_to_set
     h[2:4, 0:3] = sub_array_to_set
     assert h.view() == approx(expected_view)
+
+
+@pytest.mark.parametrize("nelem", [1, 3])
+def test_multi_cell_growth_preserves_contents(nelem):
+    # A growing axis (here StrCategory) reallocates the storage mid-fill. Boost
+    # relocates the existing cells with `*new_ref = *old_ref`, which goes through
+    # multi_cell_reference's copy-assignment; if that rebinds the span instead of
+    # writing the elements through, every growth silently zeroes the bins filled
+    # before it. Filling category by category (so each new category forces a
+    # resize) must therefore match filling with every category declared up front.
+    def make(categories):
+        return bh.Histogram(
+            bh.axis.StrCategory(categories, growth=True),
+            bh.axis.Regular(3, 0, 3),
+            storage=bh.storage.MultiCell(nelem),
+        )
+
+    # Each call is a single new category, so each triggers a storage resize; the
+    # last revisits an existing category to check bins survive a later growth too.
+    categories = ["a", "b", "c", "a"]
+    values = [[0.5, 1.5, 2.5], [0.5, 2.5], [1.5], [0.5]]
+    # cell vector for a fill value v is [v, 10*v, ..., 10**(nelem-1) * v]
+    scales = 10.0 ** np.arange(nelem)
+
+    grown = make([])
+    predeclared = make(["a", "b", "c"])  # never resizes during fill
+    for category, xs in zip(categories, values, strict=True):
+        weight = np.asarray(xs)[:, None] * scales
+        grown.fill(category, xs, weight=weight)
+        predeclared.fill(category, xs, weight=weight)
+
+    # The full per-cell contents (including flow) must be identical either way.
+    assert grown.view(flow=True) == approx(predeclared.view(flow=True))
+    # Sanity check that nothing was dropped: cell k holds 10**k times the sum of
+    # all fill values, 0.5 + 1.5 + 2.5 + 0.5 + 2.5 + 1.5 + 0.5 = 9.5.
+    assert grown.view().reshape(nelem, -1).sum(axis=1) == approx(9.5 * scales)


### PR DESCRIPTION
### Problem

Filling a `MultiCell` histogram that has a growing axis (e.g. `StrCategory(growth=True)`)
silently zeroes everything filled before the axis grows. Any category that appears
after the first fill triggers a storage resize, and all previously accumulated cells
are lost. The only workaround today is to declare every category up front.

```python
import boost_histogram as bh, numpy as np

def make(cats):
    return bh.Histogram(bh.axis.StrCategory(cats, growth=True),
                        bh.axis.Regular(3, 0, 3),
                        storage=bh.storage.MultiCell(2))

grown, pre = make([]), make(["a", "b", "c"])
for chan, xs, cells in [("a",[.5,1.5,2.5],[[1,10],[2,20],[3,30]]),
                        ("b",[.5,2.5],[[4,40],[5,50]]),
                        ("c",[1.5],[[6,60]])]:
    grown.fill(chan, np.asarray(xs), weight=np.asarray(cells, float))
    pre.fill(chan,  np.asarray(xs), weight=np.asarray(cells, float))

grown.view().sum()  # 13.0 + 130.0  -> wrong, most of it zeroed on resize
pre.view().sum()    # 28.0 + 280.0  -> correct
```

### Cause

`multi_cell_reference` is a proxy reference (a `span` over a cell's elements). Its
element-wise assignment is provided only as a *template* `operator=`. A templated
assignment operator does **not** suppress the implicitly-declared copy-assignment
operator, so when both sides have the same type — `multi_cell_reference = multi_cell_reference` —
overload resolution prefers the compiler-generated copy-assignment, which just rebinds
the span instead of writing through to the referenced cells.

boost::histogram relocates cells with `*new = *old` in
`detail::storage_grower::apply` when a growing axis enlarges the storage. With the
rebinding assignment the relocation is a no-op, so every growth discards the existing
contents. (Confirmed by reproducing against pristine boost::histogram `develop`: the
cell-relocation offsets are computed correctly, but `*ns = x` never copies.)

### Fix

Provide an explicit write-through copy-assignment operator for `multi_cell_reference`,
and default the copy constructor to keep proxy rebind-on-copy semantics. This is the
same contract every other boost::histogram storage reference already honours.

Adds a regression test that fills a growing `MultiCell` histogram category by category
and checks it matches the pre-declared-categories result. Full test suite passes; clean
under `-Wall -Wextra` and clang-format.

Follow-up to #1008 (MultiCell storage).

🤖 Investigated and drafted with Claude Code; reviewed by @NJManganelli.
