### PR TITLE
fix: remove ODR-violating operator<< for accumulators::sum

### DIFF
--- a/include/bh_python/accumulators/ostream.hpp
+++ b/include/bh_python/accumulators/ostream.hpp
@@ -88,7 +88,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os,
 
 } // namespace accumulators
 
-# Python style output instead of C++
+#Python style output instead of C++
 inline std::string
 shift_to_string(const ::boost::histogram::accumulators::sum<double>& x) {
     std::ostringstream out;

--- a/include/bh_python/accumulators/ostream.hpp
+++ b/include/bh_python/accumulators/ostream.hpp
@@ -16,6 +16,8 @@
 #include <boost/histogram/detail/counting_streambuf.hpp>
 #include <boost/histogram/fwd.hpp>
 #include <iosfwd>
+#include <sstream>
+#include <string>
 
 /**
   \file boost/histogram/accumulators/ostream.hpp
@@ -85,3 +87,15 @@ operator<<(std::basic_ostream<CharT, Traits>& os,
 }
 
 } // namespace accumulators
+
+// Repr contents for Boost's sum accumulator: "large + small" evaluates
+// correctly in Python. An overload of shift_to_string rather than an
+// operator<< in the boost namespace, which would be an ODR violation with
+// boost/histogram/accumulators/ostream.hpp. A non-template so that
+// &shift_to_string<T> stays unambiguous.
+inline std::string
+shift_to_string(const ::boost::histogram::accumulators::sum<double>& x) {
+    std::ostringstream out;
+    out << x.large_part() << " + " << x.small_part();
+    return out.str();
+}

--- a/include/bh_python/accumulators/ostream.hpp
+++ b/include/bh_python/accumulators/ostream.hpp
@@ -88,7 +88,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os,
 
 } // namespace accumulators
 
-#Python style output instead of C++
+// Python style output instead of C++
 inline std::string
 shift_to_string(const ::boost::histogram::accumulators::sum<double>& x) {
     std::ostringstream out;

--- a/include/bh_python/accumulators/ostream.hpp
+++ b/include/bh_python/accumulators/ostream.hpp
@@ -88,11 +88,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os,
 
 } // namespace accumulators
 
-// Repr contents for Boost's sum accumulator: "large + small" evaluates
-// correctly in Python. An overload of shift_to_string rather than an
-// operator<< in the boost namespace, which would be an ODR violation with
-// boost/histogram/accumulators/ostream.hpp. A non-template so that
-// &shift_to_string<T> stays unambiguous.
+# Python style output instead of C++
 inline std::string
 shift_to_string(const ::boost::histogram::accumulators::sum<double>& x) {
     std::ostringstream out;

--- a/include/bh_python/register_accumulator.hpp
+++ b/include/bh_python/register_accumulator.hpp
@@ -12,22 +12,6 @@
 
 #include <utility>
 
-// This can be included here since we don't include Boost.Histogram's ostream
-namespace boost {
-namespace histogram {
-namespace accumulators {
-template <class CharT, class Traits, class W>
-std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os,
-                                              const sum<W>& x) {
-    if(os.width() == 0)
-        return os << x.large_part() << " + " << x.small_part();
-    return handle_nonzero_width(os, x);
-}
-
-} // namespace accumulators
-} // namespace histogram
-} // namespace boost
-
 template <class A, class... Args>
 py::class_<A> register_accumulator(py::module acc, Args&&... args) {
     return py::class_<A>(std::move(acc), std::forward<Args>(args)...)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`register_accumulator.hpp` reopened `namespace boost::histogram::accumulators` to define an `operator<<` for `sum<W>` with the same signature as Boost's own in `boost/histogram/accumulators/ostream.hpp` but a different output format (the Python-evaluable `3.5 + 0.001` instead of `sum(3.5 + 0.001)`). The two definitions were kept apart only by include discipline: a TU including both headers failed to compile (this is what broke a precompiled-header experiment in #1160), and if both templates were ever instantiated for the same type, the linker would silently pick one by link order.

The custom repr contents now come from a `shift_to_string` overload for `sum<double>` (the only instantiation exposed to Python), so nothing is defined in Boost's namespace. The overload is a non-template so `&shift_to_string<T>` with an explicit template argument stays unambiguous.

No behavior change; `repr(Sum(...))` is already asserted in `test_accumulators.py`. Verified that `register_accumulator.hpp` and `boost/histogram/ostream.hpp` now compile together in one TU.