### PR TITLE
ci: test Python 3.15 with SPEC 4 nightly numpy wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,8 @@ jobs:
           - python-version: "3.11"
           - python-version: "3.14"
           - python-version: "3.14t"
+          - python-version: "3.15"
+            nightly-numpy: true
           - python-version: "pypy3.11"
 
     steps:
@@ -88,6 +90,12 @@ jobs:
 
       - name: Install python tools
         run: uv pip install --system --python=python --group github
+        env:
+          # SPEC 4 nightly wheels: numpy has no 3.15 release yet
+          UV_INDEX: ${{ matrix.nightly-numpy && 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' || '' }}
+          UV_PRERELEASE: ${{ matrix.nightly-numpy && 'allow' || 'disallow' }}
+          # Let uv fall back to PyPI for packages the nightly index also mirrors
+          UV_INDEX_STRATEGY: ${{ matrix.nightly-numpy && 'unsafe-best-match' || 'first-index' }}
 
       - name: Configure
         run: cmake --preset default ${{ matrix.cmake-extras }}
@@ -143,6 +151,8 @@ jobs:
             only: cp312-macosx_arm64
           - os: windows-11-arm
             only: cp311-win_arm64
+          - os: ubuntu-latest
+            only: cp315-manylinux_x86_64
           - os: ubuntu-latest
             only: gp312_250-manylinux_x86_64
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,6 @@ test-environment.CI = "1"  # Hypothesis needs this on GraalPy
 test-skip = [
   "cp310-win_arm64",
   "cp31*-musllinux_*", # Threading test crashes
-  "cp315*",  # No numpy wheels yet
   "gp312_*",  # No numpy wheels yet
   "*-ios_*",  # Fails on CI with no device found
 ]
@@ -203,6 +202,17 @@ environment.PIP_ONLY_BINARY = "numpy"
 environment.PIP_PREFER_BINARY = "1"
 environment.UV_ONLY_BINARY = "numpy"
 environment.UV_PREFER_BINARY = "1"
+
+# SPEC 4 nightly wheels: numpy has no 3.15 release yet
+[[tool.cibuildwheel.overrides]]
+select = "cp315*"
+test-environment.CI = "1"
+test-environment.PIP_PRE = "1"
+test-environment.PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+test-environment.UV_PRERELEASE = "allow"
+test-environment.UV_INDEX = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+# Let uv fall back to PyPI for packages the nightly index also mirrors
+test-environment.UV_INDEX_STRATEGY = "unsafe-best-match"
 
 [tool.cibuildwheel.pyodide]
 build-frontend = {name = "pyodide-build", args = ["--exports", "whole_archive"]}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

NumPy has no Python 3.15 release on PyPI yet, so `cp315*` was in `test-skip` and 3.15 was missing from the test matrix. [SPEC 4](https://scientific-python.org/specs/spec-0004/) nightly wheels supply `cp315`/`cp315t` numpy, so we can test now.

- Remove the `cp315*` test skip and add a cibuildwheel override that points the cp315 test environment at the nightly index.
- Add Python 3.15 to the CMake matrix and `cp315-manylinux_x86_64` to the wheel build matrix.

`UV_INDEX_STRATEGY=unsafe-best-match` is needed because the nightly index also mirrors some build dependencies; with uvs default first-match strategy, uv refuses to look at PyPI for them and resolution fails.

Tested locally on CPython 3.15.0b4 (macOS arm64) with numpy 2.6.0.dev0: the extension builds and all 1130 tests pass.

Note that nightly wheels move, so this job can go red from an upstream change. One numpy nightly from 2026-07-22 segfaulted on `import numpy.random` under 3.15; the current nightly is good.