### PR TITLE
fix: reject arithmetic with mismatched storages

### DIFF
--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -836,6 +836,17 @@ class Histogram(typing.Generic[S]):
         self._hist = self._as_double_cpp(self._hist)
 
     def _hist_inplace_op(self, name: str, other: CppHistogram) -> None:
+        if self._hist._storage_type is not other._storage_type:
+            symbol = _INPLACE_OP_SYMBOLS.get(name, name)
+            other_storage = typing.cast(
+                type[Storage], cast(self, other._storage_type, Storage)
+            )
+            msg = (
+                f"Cannot {symbol} histograms with different storage types: "
+                f"{self.storage_type.__name__} and {other_storage.__name__}"
+            )
+            raise TypeError(msg)
+
         # The underlying C++ histogram only exposes the in-place dunders its
         # storage supports (e.g. weight/mean/multi_cell storages have no
         # __isub__). Calling a missing one raises a confusing AttributeError

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -606,6 +606,26 @@ def test_operators():
         h + h2
 
 
+@pytest.mark.parametrize("operation", [operator.add, operator.iadd])
+@pytest.mark.parametrize(
+    ("left_storage", "right_storage"),
+    [
+        (bh.storage.Int64, bh.storage.Double),
+        (bh.storage.Double, bh.storage.Int64),
+    ],
+)
+def test_add_mismatched_storage_raises(operation, left_storage, right_storage):
+    left = bh.Histogram(bh.axis.Regular(3, -1, 1), storage=left_storage())
+    right = bh.Histogram(bh.axis.Regular(3, -1, 1), storage=right_storage())
+    right.fill(0)
+
+    message = (
+        f"different storage types: {left_storage.__name__} and {right_storage.__name__}"
+    )
+    with pytest.raises(TypeError, match=message):
+        operation(left, right)
+
+
 def test_hist_hist_div():
     h1 = bh.Histogram(bh.axis.Boolean())
     h2 = bh.Histogram(bh.axis.Boolean())


### PR DESCRIPTION
﻿## Summary

- reject histogram-to-histogram arithmetic when the two operands use different storage types
- report both storage names in the error instead of silently returning incorrect bin contents
- cover `+` and `+=` in both `Int64`/`Double` directions

The underlying C++ histogram overload does not convert between distinct storage specializations. Today an operation such as an `Int64` histogram plus a populated `Double` histogram can silently leave every bin at zero. Failing before dispatch prevents that data-loss failure mode for both `boost-histogram` and downstream families such as `hist`.

Division remains supported for mixed integer/double storages because its existing promotion path converts both operands to compatible `Double` C++ histograms before this check.

Closes scikit-hep/hist#464.

## Tests

- `uvx prek run -a --quiet`
- `CI=1 uv run pytest -n auto --benchmark-disable -q` (`1134 passed, 1 xfailed`)
