### PR TITLE
docs: correct the wheel table and add a version-support checklist

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -247,7 +247,7 @@ nox -s bump_boost -- 1.88.0
 <details><summary>Making a new release (click to expand)</summary>
 
 - Finish merging open PRs that you want in the new version
-- Add most recent changes to the `docs/CHANGELOG.md`
+- Add most recent changes to the `docs/changelog.md`
 - Sync master with develop using `git checkout master; git merge develop --ff-only` and push
 - Make sure the `cmake --preset tidy` build runs on master without issues (manually trigger if needed)
 - Make the GitHub release in the GitHub UI. Copy the changelog entries and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,21 @@ When adding a new axis/storage/accumulator wrapper, follow this pattern: registe
 - mypy runs in strict mode on `src/` and `examples/`; tests are exempt from untyped-def rules.
 - Version is dynamic from git tags via `setuptools_scm`, generated at build time into
   `boost_histogram/version.py` (do not commit/edit it).
+
+## Supported Python versions
+
+When the supported versions change (a new Python, a dropped one, a new cibuildwheel version, or a
+new wheel platform), update all of these:
+
+- `requires-python` and the `Programming Language :: Python :: *` classifiers in `pyproject.toml`
+- the matrix in `.github/workflows/tests.yml` and the jobs in `.github/workflows/wheels.yml`
+- the "Binaries available" wheel table in `README.md`
+
+Get the true list of wheels from cibuildwheel instead of writing it by hand, one call per platform:
+
+```bash
+uvx cibuildwheel --platform linux --print-build-identifiers
+```
+
+Free-threaded and alternative-implementation builds are opt-in and change between cibuildwheel
+releases, so a version can disappear from the table without an intentional drop.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Python bindings for [Boost::Histogram][] ([source][Boost::Histogram source]), a C++14 library. This is one of the [fastest libraries][] for
 histogramming, while still providing the power of a full histogram object. See
-[what's new](./docs/CHANGELOG.md).
+[what's new](./docs/changelog.md).
 
 Other members of the boost-histogram family include:
 
@@ -193,19 +193,20 @@ when you run the above command on a supported platform. Wheels are produced usin
 [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/); all common
 platforms have wheels provided in boost-histogram:
 
-| System    | Arch   | Python versions                            | PyPy versions | GraalPy versions |
-| --------- | ------ | ------------------------------------------ | ------------- | ---------------- |
-| manylinux | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          | 24.2, 25.0       |
-| manylinux | ARM64  | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          | 24.2, 25.0       |
-| musllinux | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t |               |                  |
-| macOS     | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          | 24.2, 25.0       |
-| macOS     | Arm64  | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          | 24.2, 25.0       |
-| Windows   | 32-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t |               |                  |
-| Windows   | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t | 3.11          | 24.2, 25.0       |
-| Windows   | ARM64  | 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t       |               |                  |
-| iOS       | Device | 3.13, 3.14                                 |               |                  |
-| iOS       | AS Sim | 3.13, 3.14                                 |               |                  |
-| iOS       | Intel  | 3.13, 3.14                                 |               |                  |
+| System    | Arch   | Python versions                                  | PyPy versions | GraalPy versions |
+| --------- | ------ | ------------------------------------------------ | ------------- | ---------------- |
+| manylinux | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t, 3.15, 3.15t | 3.11          | 25.0             |
+| manylinux | ARM64  | 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t, 3.15, 3.15t | 3.11          | 25.0             |
+| musllinux | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t, 3.15, 3.15t |               |                  |
+| macOS     | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t, 3.15, 3.15t | 3.11          | 25.0             |
+| macOS     | Arm64  | 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t, 3.15, 3.15t | 3.11          | 25.0             |
+| Windows   | 32-bit | 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t, 3.15, 3.15t |               |                  |
+| Windows   | 64-bit | 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t, 3.15, 3.15t | 3.11          | 25.0             |
+| Windows   | ARM64  | 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t, 3.15, 3.15t |               |                  |
+| iOS       | Device | 3.13, 3.14, 3.15                                 |               |                  |
+| iOS       | AS Sim | 3.13, 3.14, 3.15                                 |               |                  |
+| iOS       | Intel  | 3.13, 3.14, 3.15                                 |               |                  |
+| Pyodide   | wasm32 | 3.13, 3.14, 3.15                                 |               |                  |
 
 PowerPC, IBM-Z, and RISC-V wheels are not provided but are available on request.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -101,6 +101,7 @@
 [#1148]: https://github.com/scikit-hep/boost-histogram/pull/1148
 [#1149]: https://github.com/scikit-hep/boost-histogram/pull/1149
 [#1150]: https://github.com/scikit-hep/boost-histogram/pull/1150
+[#1151]: https://github.com/scikit-hep/boost-histogram/pull/1151
 [#1152]: https://github.com/scikit-hep/boost-histogram/pull/1152
 [#1153]: https://github.com/scikit-hep/boost-histogram/pull/1153
 [#1155]: https://github.com/scikit-hep/boost-histogram/pull/1155
@@ -259,8 +260,7 @@ This release drops support for Python 3.8, and adds Python 3.14(t), iOS, Windows
 [#999]: https://github.com/scikit-hep/boost-histogram/pull/999
 [#1000]: https://github.com/scikit-hep/boost-histogram/pull/1000
 [#1001]: https://github.com/scikit-hep/boost-histogram/pull/1001
-
-:[#1002]: https://github.com/scikit-hep/boost-histogram/pull/1002
+[#1002]: https://github.com/scikit-hep/boost-histogram/pull/1002
 [#1009]: https://github.com/scikit-hep/boost-histogram/pull/1009
 [#1010]: https://github.com/scikit-hep/boost-histogram/pull/1010
 [#1011]: https://github.com/scikit-hep/boost-histogram/pull/1011
@@ -921,6 +921,7 @@ along with a few new features to better support downstream projects.
 [#401]: https://github.com/scikit-hep/boost-histogram/pull/401
 [#402]: https://github.com/scikit-hep/boost-histogram/pull/402
 [#403]: https://github.com/scikit-hep/boost-histogram/pull/403
+[#404]: https://github.com/scikit-hep/boost-histogram/pull/404
 [#406]: https://github.com/scikit-hep/boost-histogram/pull/406
 
 ## Version 0.8


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The README wheel table missed Python 3.15 and Pyodide. It also still listed 3.13t, which was dropped in #1079, and GraalPy 24.2, which cibuildwheel 4.2 no longer builds. The table now agrees with `cibuildwheel --print-build-identifiers` for each platform.

AGENTS.md gets a "Supported Python versions" section that lists every place to update when the supported versions change, and points to cibuildwheel as the source of truth instead of writing the list by hand.

Also fixes three broken changelog link references (#1151, #1002, #404) and the case of the `docs/changelog.md` link in the README and CONTRIBUTING, which was broken on GitHub.