### PR TITLE
ci: test Python 3.15 now that numpy wheels are on PyPI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,7 @@ jobs:
           - python-version: "3.11"
           - python-version: "3.14"
           - python-version: "3.14t"
+          - python-version: "3.15"
           - python-version: "pypy3.11"
 
     steps:
@@ -143,6 +144,8 @@ jobs:
             only: cp312-macosx_arm64
           - os: windows-11-arm
             only: cp311-win_arm64
+          - os: ubuntu-latest
+            only: cp315-manylinux_x86_64
           - os: ubuntu-latest
             only: gp312_250-manylinux_x86_64
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,6 @@ test-environment.CI = "1"  # Hypothesis needs this on GraalPy
 test-skip = [
   "cp310-win_arm64",
   "cp31*-musllinux_*", # Threading test crashes
-  "cp315*",  # No numpy wheels yet
   "gp312_*",  # No numpy wheels yet
   "*-ios_*",  # Fails on CI with no device found
 ]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

NumPy now publishes `cp315` and `cp315t` wheels on PyPI (2.5.2, all platforms), so the nightly-index setup from #1165 is not necessary. This removes the `cp315*` test skip, adds 3.15 to the CMake matrix, and adds `cp315-manylinux_x86_64` to the wheel test matrix. Close #1165.

Verified locally on CPython 3.15.0b4 (macOS arm64): the extension builds and all 1134 tests pass.