### PR TITLE
refactor: hold the GIL when copying or destroying Python objects in axes

### DIFF
--- a/include/bh_python/guarded_object.hpp
+++ b/include/bh_python/guarded_object.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+// Copyright 2026 Henry Schreiner and Hans Dembinski
 //
 // Distributed under the 3-Clause BSD License.  See accompanying
 // file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
@@ -21,8 +21,9 @@ class guarded_object {
   public:
     guarded_object() noexcept = default;
 
-    /// Adopt an existing reference; no refcount change, so no GIL needed
-    explicit guarded_object(py::object obj) noexcept
+    /// Adopt an existing reference; rvalue-only so no copy (incref) can happen
+    /// here, which is why no GIL is needed
+    explicit guarded_object(py::object&& obj) noexcept
         : obj_(std::move(obj)) {}
 
     guarded_object(const guarded_object& other) {
@@ -40,7 +41,7 @@ class guarded_object {
         return *this;
     }
 
-    // swap defers the decref of the old value to other's guarded destructor
+    // Swap defers the decref of the old value to other's guarded destructor
     guarded_object& operator=(guarded_object&& other) noexcept {
         std::swap(obj_, other.obj_);
         return *this;
@@ -58,9 +59,9 @@ class guarded_object {
         }
     }
 
-    /// Access the held object; hold the GIL to use or copy it
-    const py::object& get() const noexcept { return obj_; }
+    /// Access the held object; the caller must hold the GIL to use or copy it
+    const py::object& unguarded_get() const noexcept { return obj_; }
 
-    /// Mutable access; hold the GIL to assign through this
-    py::object& ref() noexcept { return obj_; }
+    /// Mutable access; the caller must hold the GIL to assign through this
+    py::object& unguarded_ref() noexcept { return obj_; }
 };

--- a/include/bh_python/guarded_object.hpp
+++ b/include/bh_python/guarded_object.hpp
@@ -46,10 +46,15 @@ class guarded_object {
         return *this;
     }
 
+    // Acquiring the GIL can throw if no thread state can be made; leaking the
+    // reference is the only safe option then
     ~guarded_object() {
-        if(obj_) {
+        if(!obj_)
+            return;
+        try {
             const py::gil_scoped_acquire gil;
             obj_ = py::object();
+        } catch(...) { // NOLINT(bugprone-empty-catch)
         }
     }
 

--- a/include/bh_python/guarded_object.hpp
+++ b/include/bh_python/guarded_object.hpp
@@ -1,0 +1,61 @@
+// Copyright 2018-2019 Henry Schreiner and Hans Dembinski
+//
+// Distributed under the 3-Clause BSD License.  See accompanying
+// file LICENSE or https://github.com/scikit-hep/boost-histogram for details.
+
+#pragma once
+
+#include <bh_python/pybind11.hpp>
+
+#include <pybind11/pytypes.h>
+
+#include <utility>
+
+/// A py::object member for C++ values that are copied and destroyed with the
+/// GIL released (axes during reduce, project, growing fill): every special
+/// member that touches reference counts attaches to the interpreter first.
+/// Moves and the adopting constructor are refcount-neutral, so GIL-free.
+class guarded_object {
+    py::object obj_;
+
+  public:
+    guarded_object() noexcept = default;
+
+    /// Adopt an existing reference; no refcount change, so no GIL needed
+    explicit guarded_object(py::object obj) noexcept
+        : obj_(std::move(obj)) {}
+
+    guarded_object(const guarded_object& other) {
+        const py::gil_scoped_acquire gil;
+        obj_ = other.obj_;
+    }
+
+    guarded_object(guarded_object&&) noexcept = default;
+
+    guarded_object& operator=(const guarded_object& other) {
+        if(this != &other) {
+            const py::gil_scoped_acquire gil;
+            obj_ = other.obj_;
+        }
+        return *this;
+    }
+
+    // swap defers the decref of the old value to other's guarded destructor
+    guarded_object& operator=(guarded_object&& other) noexcept {
+        std::swap(obj_, other.obj_);
+        return *this;
+    }
+
+    ~guarded_object() {
+        if(obj_) {
+            const py::gil_scoped_acquire gil;
+            obj_ = py::object();
+        }
+    }
+
+    /// Access the held object; hold the GIL to use or copy it
+    const py::object& get() const noexcept { return obj_; }
+
+    /// Mutable access; hold the GIL to assign through this
+    py::object& ref() noexcept { return obj_; }
+};

--- a/include/bh_python/make_pickle.hpp
+++ b/include/bh_python/make_pickle.hpp
@@ -186,9 +186,13 @@ class tuple_oarchive {
         return operator<<(static_cast<const py::object&>(m));
     }
 
-    tuple_oarchive& operator<<(const metadata_t& m) { return operator<<(m.obj()); }
+    tuple_oarchive& operator<<(const metadata_t& m) {
+        return operator<<(m.unguarded_obj());
+    }
 
-    tuple_oarchive& operator<<(const guarded_object& m) { return operator<<(m.get()); }
+    tuple_oarchive& operator<<(const guarded_object& m) {
+        return operator<<(m.unguarded_get());
+    }
 
     template <class T>
     tuple_oarchive& operator<<(const py::array_t<T>& a) {
@@ -303,7 +307,9 @@ class tuple_iarchive {
         return *this;
     }
 
-    tuple_iarchive& operator>>(guarded_object& m) { return operator>>(m.ref()); }
+    tuple_iarchive& operator>>(guarded_object& m) {
+        return operator>>(m.unguarded_ref());
+    }
 
     template <class T>
     tuple_iarchive& operator>>(py::array_t<T>& a) {

--- a/include/bh_python/make_pickle.hpp
+++ b/include/bh_python/make_pickle.hpp
@@ -44,6 +44,7 @@
 
 #include <bh_python/pybind11.hpp>
 
+#include <bh_python/guarded_object.hpp>
 #include <bh_python/metadata.hpp>
 
 #include <boost/assert.hpp>
@@ -185,9 +186,9 @@ class tuple_oarchive {
         return operator<<(static_cast<const py::object&>(m));
     }
 
-    tuple_oarchive& operator<<(const metadata_t& m) {
-        return operator<<(static_cast<const py::object&>(m));
-    }
+    tuple_oarchive& operator<<(const metadata_t& m) { return operator<<(m.obj()); }
+
+    tuple_oarchive& operator<<(const guarded_object& m) { return operator<<(m.get()); }
 
     template <class T>
     tuple_oarchive& operator<<(const py::array_t<T>& a) {
@@ -296,8 +297,13 @@ class tuple_iarchive {
     }
 
     tuple_iarchive& operator>>(metadata_t& m) {
-        return operator>>(static_cast<py::object&>(m));
+        py::object obj;
+        this->operator>>(obj);
+        m = metadata_t{std::move(obj)};
+        return *this;
     }
+
+    tuple_iarchive& operator>>(guarded_object& m) { return operator>>(m.ref()); }
 
     template <class T>
     tuple_iarchive& operator>>(py::array_t<T>& a) {

--- a/include/bh_python/metadata.hpp
+++ b/include/bh_python/metadata.hpp
@@ -22,20 +22,20 @@ class metadata_t {
     metadata_t()
         : data_(make_dict()) {}
 
-    /// Adopt an existing reference; no refcount change, so no GIL needed
-    explicit metadata_t(py::object data) noexcept
+    /// Adopt an existing reference; rvalue-only, so no GIL needed
+    explicit metadata_t(py::object&& data) noexcept
         : data_(std::move(data)) {}
 
     /// Access the held dict; hold the GIL to use or copy it
-    const py::object& obj() const noexcept { return data_.get(); }
+    const py::object& unguarded_obj() const noexcept { return data_.unguarded_get(); }
 
     bool operator==(const metadata_t& other) const {
         const py::gil_scoped_acquire gil;
-        return obj().equal(other.obj());
+        return unguarded_obj().equal(other.unguarded_obj());
     }
     bool operator!=(const metadata_t& other) const {
         const py::gil_scoped_acquire gil;
-        return obj().not_equal(other.obj());
+        return unguarded_obj().not_equal(other.unguarded_obj());
     }
 
   private:
@@ -48,7 +48,7 @@ class metadata_t {
 /// Deepcopy the held dict, for __deepcopy__ implementations
 inline metadata_t deep_copy_metadata(const metadata_t& m, const py::object& memo) {
     py::module const copy = py::module::import("copy");
-    return metadata_t{copy.attr("deepcopy")(m.obj(), memo)};
+    return metadata_t{copy.attr("deepcopy")(m.unguarded_obj(), memo)};
 }
 
 namespace pybind11 {
@@ -72,7 +72,7 @@ struct type_caster<metadata_t> {
 
     static handle
     cast(const metadata_t& src, return_value_policy /*policy*/, handle /*parent*/) {
-        return src.obj().inc_ref();
+        return src.unguarded_obj().inc_ref();
     }
 };
 } // namespace detail

--- a/include/bh_python/metadata.hpp
+++ b/include/bh_python/metadata.hpp
@@ -5,20 +5,75 @@
 
 #pragma once
 
+#include <bh_python/guarded_object.hpp>
 #include <bh_python/pybind11.hpp>
 
 #include <pybind11/pytypes.h>
 
-struct metadata_t : py::dict {
-    PYBIND11_OBJECT(metadata_t, dict, PyDict_Check);
+#include <utility>
 
-    using dict::dict;
+/// Axis metadata: a Python dict, shared with the Python axis wrapper's
+/// __dict__. The dict is held through guarded_object because axes are copied
+/// and destroyed with the GIL released (reduce, project, growing fill).
+class metadata_t {
+    guarded_object data_; // a dict; null only after being moved from
 
-    // default initialize to empty dict (must not be explicit)
-    metadata_t() = default;
+  public:
+    metadata_t()
+        : data_(make_dict()) {}
 
-    bool operator==(const metadata_t& other) const { return py::dict::equal(other); }
+    /// Adopt an existing reference; no refcount change, so no GIL needed
+    explicit metadata_t(py::object data) noexcept
+        : data_(std::move(data)) {}
+
+    /// Access the held dict; hold the GIL to use or copy it
+    const py::object& obj() const noexcept { return data_.get(); }
+
+    bool operator==(const metadata_t& other) const {
+        const py::gil_scoped_acquire gil;
+        return obj().equal(other.obj());
+    }
     bool operator!=(const metadata_t& other) const {
-        return py::dict::not_equal(other);
+        const py::gil_scoped_acquire gil;
+        return obj().not_equal(other.obj());
+    }
+
+  private:
+    static py::object make_dict() {
+        const py::gil_scoped_acquire gil;
+        return py::dict();
     }
 };
+
+/// Deepcopy the held dict, for __deepcopy__ implementations
+inline metadata_t deep_copy_metadata(const metadata_t& m, const py::object& memo) {
+    py::module const copy = py::module::import("copy");
+    return metadata_t{copy.attr("deepcopy")(m.obj(), memo)};
+}
+
+namespace pybind11 {
+namespace detail {
+/// Convert to/from the held dict itself, preserving identity: the same dict
+/// object is shared between the C++ axis and the Python wrapper's __dict__.
+template <>
+struct type_caster<metadata_t> {
+    PYBIND11_TYPE_CASTER(metadata_t, const_name("dict"));
+
+    // start null instead of allocating a dict that load() would discard
+    type_caster()
+        : value{object()} {}
+
+    bool load(handle src, bool /*convert*/) {
+        if(!isinstance<dict>(src))
+            return false;
+        value = metadata_t{reinterpret_borrow<object>(src)};
+        return true;
+    }
+
+    static handle
+    cast(const metadata_t& src, return_value_policy /*policy*/, handle /*parent*/) {
+        return src.obj().inc_ref();
+    }
+};
+} // namespace detail
+} // namespace pybind11

--- a/include/bh_python/pybind11.hpp
+++ b/include/bh_python/pybind11.hpp
@@ -9,9 +9,6 @@
 
 #pragma once
 
-// TODO: restructure metadata_t to hold a py::dict instead of subclass it, add locks
-#define PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF
-
 #include <pybind11/numpy.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>

--- a/include/bh_python/register_axis.hpp
+++ b/include/bh_python/register_axis.hpp
@@ -186,7 +186,7 @@ py::class_<A> register_axis(py::module& m, Args&&... args) {
         .def_property(
             "raw_metadata",
             [](const A& self) { return self.metadata(); },
-            [](A& self, const metadata_t& label) { self.metadata() = label; },
+            [](A& self, metadata_t label) { self.metadata() = std::move(label); },
             "Set the metadata")
 
         .def_property_readonly(
@@ -202,9 +202,8 @@ py::class_<A> register_axis(py::module& m, Args&&... args) {
         .def("__copy__", [](const A& self) { return A(self); })
         .def("__deepcopy__",
              [](const A& self, const py::object& memo) {
-                 auto a                = std::make_unique<A>(self);
-                 py::module const copy = py::module::import("copy");
-                 a->metadata()         = copy.attr("deepcopy")(a->metadata(), memo);
+                 auto a        = std::make_unique<A>(self);
+                 a->metadata() = deep_copy_metadata(a->metadata(), memo);
                  return a;
              })
 

--- a/include/bh_python/register_histogram.hpp
+++ b/include/bh_python/register_histogram.hpp
@@ -50,11 +50,10 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
         .def("__copy__", [](const histogram_t& self) { return histogram_t(self); })
         .def("__deepcopy__",
              [](const histogram_t& self, const py::object& memo) {
-                 auto a                = std::make_unique<histogram_t>(self);
-                 py::module const copy = py::module::import("copy");
+                 auto a = std::make_unique<histogram_t>(self);
                  for(unsigned i = 0; i < a->rank(); i++) {
                      bh::unsafe_access::axis(*a, i).metadata()
-                         = copy.attr("deepcopy")(a->axis(i).metadata(), memo);
+                         = deep_copy_metadata(a->axis(i).metadata(), memo);
                  }
                  return a;
              })
@@ -255,11 +254,10 @@ auto inline register_histogram<bh::multi_cell<double>>(py::module& m,
         .def("__copy__", [](const histogram_t& self) { return histogram_t(self); })
         .def("__deepcopy__",
              [](const histogram_t& self, const py::object& memo) {
-                 auto a                = std::make_unique<histogram_t>(self);
-                 const py::module copy = py::module::import("copy");
+                 auto a = std::make_unique<histogram_t>(self);
                  for(unsigned i = 0; i < a->rank(); i++) {
                      bh::unsafe_access::axis(*a, i).metadata()
-                         = copy.attr("deepcopy")(a->axis(i).metadata(), memo);
+                         = deep_copy_metadata(a->axis(i).metadata(), memo);
                  }
                  return a;
              })

--- a/include/bh_python/transform.hpp
+++ b/include/bh_python/transform.hpp
@@ -36,10 +36,11 @@ struct func_transform {
     /// Convert an object into a std::function. Can handle ctypes
     /// function pointers and pybind11 C++ functions, or anything
     /// else with a defined convert function
-    std::tuple<raw_t*, py::object> compute(py::object& input) const {
+    std::tuple<raw_t*, py::object> compute(const py::object& input) const {
         // Run the conversion function on the input (unless conversion is None)
-        py::object const tmp_src
-            = _convert_ob.get().is_none() ? input : _convert_ob.get()(input);
+        py::object const tmp_src = _convert_ob.unguarded_get().is_none()
+                                       ? input
+                                       : _convert_ob.unguarded_get()(input);
 
         // If a CTypes object is present, just use that (numba, for example)
         py::object const src = py::getattr(tmp_src, "ctypes", tmp_src);
@@ -88,12 +89,14 @@ struct func_transform {
     }
 
     func_transform(py::object f, py::object i, py::object c, py::str n)
-        : _forward_ob{f}
-        , _inverse_ob{i}
+        : _forward_ob{std::move(f)}
+        , _inverse_ob{std::move(i)}
         , _convert_ob{std::move(c)}
         , _name{std::move(n)} {
-        std::tie(_forward, _forward_converted.ref()) = compute(f);
-        std::tie(_inverse, _inverse_converted.ref()) = compute(i);
+        std::tie(_forward, _forward_converted.unguarded_ref())
+            = compute(_forward_ob.unguarded_get());
+        std::tie(_inverse, _inverse_converted.unguarded_ref())
+            = compute(_inverse_ob.unguarded_get());
     }
 
     func_transform() = default;
@@ -105,8 +108,9 @@ struct func_transform {
     bool operator==(const func_transform& other) const noexcept {
         try {
             const py::gil_scoped_acquire gil;
-            return _forward_ob.get().equal(other._forward_ob.get())
-                   && _inverse_ob.get().equal(other._inverse_ob.get());
+            return _forward_ob.unguarded_get().equal(other._forward_ob.unguarded_get())
+                   && _inverse_ob.unguarded_get().equal(
+                       other._inverse_ob.unguarded_get());
         } catch(const std::exception&) {
             return false;
         }
@@ -120,8 +124,10 @@ struct func_transform {
         ar& boost::make_nvp("name", _name);
 
         if(Archive::is_loading::value) {
-            std::tie(_forward, _forward_converted.ref()) = compute(_forward_ob.ref());
-            std::tie(_inverse, _inverse_converted.ref()) = compute(_inverse_ob.ref());
+            std::tie(_forward, _forward_converted.unguarded_ref())
+                = compute(_forward_ob.unguarded_ref());
+            std::tie(_inverse, _inverse_converted.unguarded_ref())
+                = compute(_inverse_ob.unguarded_ref());
         }
     }
 };
@@ -147,10 +153,13 @@ inline func_transform deep_copy<func_transform>(const func_transform& input,
                                                 py::object& memo) {
     py::module const copy = py::module::import("copy");
 
-    py::object const forward = copy.attr("deepcopy")(input._forward_ob.get(), memo);
-    py::object const inverse = copy.attr("deepcopy")(input._inverse_ob.get(), memo);
-    py::object const convert = copy.attr("deepcopy")(input._convert_ob.get(), memo);
-    py::str const name       = copy.attr("deepcopy")(input._name.get(), memo);
+    py::object const forward
+        = copy.attr("deepcopy")(input._forward_ob.unguarded_get(), memo);
+    py::object const inverse
+        = copy.attr("deepcopy")(input._inverse_ob.unguarded_get(), memo);
+    py::object const convert
+        = copy.attr("deepcopy")(input._convert_ob.unguarded_get(), memo);
+    py::str const name = copy.attr("deepcopy")(input._name.unguarded_get(), memo);
 
     return {forward, inverse, convert, name};
 }

--- a/include/bh_python/transform.hpp
+++ b/include/bh_python/transform.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <bh_python/guarded_object.hpp>
 #include <bh_python/pybind11.hpp>
 
 #include <boost/core/nvp.hpp>
@@ -18,22 +19,26 @@ namespace bh = boost::histogram;
 struct func_transform {
     using raw_t = double(double);
 
+    // guarded_object because axes are copied and destroyed with the GIL
+    // released (reduce, project)
     raw_t* _forward = nullptr;
     raw_t* _inverse = nullptr;
-    py::object _forward_ob; // Held for reference counting, repr, and pickling
-    py::object _inverse_ob;
-    py::object _forward_converted; // Held for reference counting if conversion makes a
-                                   // new object (ctypes does not bump the refcount)
-    py::object _inverse_converted;
-    py::object _convert_ob; // Called before computing transform if not None
-    py::str _name;          // Optional name (uses repr from objects otherwise)
+    guarded_object _forward_ob; // Held for reference counting, repr, and pickling
+    guarded_object _inverse_ob;
+    guarded_object _forward_converted; // Held for reference counting if conversion
+                                       // makes a new object (ctypes does not bump
+                                       // the refcount)
+    guarded_object _inverse_converted;
+    guarded_object _convert_ob; // Called before computing transform if not None
+    guarded_object _name;       // Optional name str (uses repr from objects otherwise)
 
     /// Convert an object into a std::function. Can handle ctypes
     /// function pointers and pybind11 C++ functions, or anything
     /// else with a defined convert function
     std::tuple<raw_t*, py::object> compute(py::object& input) {
         // Run the conversion function on the input (unless conversion is None)
-        py::object const tmp_src = _convert_ob.is_none() ? input : _convert_ob(input);
+        py::object const tmp_src
+            = _convert_ob.get().is_none() ? input : _convert_ob.get()(input);
 
         // If a CTypes object is present, just use that (numba, for example)
         py::object const src = py::getattr(tmp_src, "ctypes", tmp_src);
@@ -82,21 +87,15 @@ struct func_transform {
     }
 
     func_transform(py::object f, py::object i, py::object c, py::str n)
-        : _forward_ob(f)
-        , _inverse_ob(i)
-        , _convert_ob(std::move(c))
-        , _name(std::move(n)) {
-        std::tie(_forward, _forward_converted) = compute(f);
-        std::tie(_inverse, _inverse_converted) = compute(i);
+        : _forward_ob{f}
+        , _inverse_ob{i}
+        , _convert_ob{std::move(c)}
+        , _name{std::move(n)} {
+        std::tie(_forward, _forward_converted.ref()) = compute(f);
+        std::tie(_inverse, _inverse_converted.ref()) = compute(i);
     }
 
-    func_transform()                          = default;
-    ~func_transform()                         = default;
-    func_transform(const func_transform&)     = default;
-    func_transform(func_transform&&) noexcept = default;
-
-    func_transform& operator=(const func_transform&)     = default;
-    func_transform& operator=(func_transform&&) noexcept = default;
+    func_transform() = default;
 
     double forward(double x) const { return _forward(x); }
 
@@ -104,8 +103,9 @@ struct func_transform {
 
     bool operator==(const func_transform& other) const noexcept {
         try {
-            return _forward_ob.equal(other._forward_ob)
-                   && _inverse_ob.equal(other._inverse_ob);
+            const py::gil_scoped_acquire gil;
+            return _forward_ob.get().equal(other._forward_ob.get())
+                   && _inverse_ob.get().equal(other._inverse_ob.get());
         } catch(const py::error_already_set&) {
             return false;
         }
@@ -119,8 +119,8 @@ struct func_transform {
         ar& boost::make_nvp("name", _name);
 
         if(Archive::is_loading::value) {
-            std::tie(_forward, _forward_converted) = compute(_forward_ob);
-            std::tie(_inverse, _inverse_converted) = compute(_inverse_ob);
+            std::tie(_forward, _forward_converted.ref()) = compute(_forward_ob.ref());
+            std::tie(_inverse, _inverse_converted.ref()) = compute(_inverse_ob.ref());
         }
     }
 };
@@ -146,10 +146,10 @@ inline func_transform deep_copy<func_transform>(const func_transform& input,
                                                 py::object& memo) {
     py::module const copy = py::module::import("copy");
 
-    py::object const forward = copy.attr("deepcopy")(input._forward_ob, memo);
-    py::object const inverse = copy.attr("deepcopy")(input._inverse_ob, memo);
-    py::object const convert = copy.attr("deepcopy")(input._convert_ob, memo);
-    py::str const name       = copy.attr("deepcopy")(input._name, memo);
+    py::object const forward = copy.attr("deepcopy")(input._forward_ob.get(), memo);
+    py::object const inverse = copy.attr("deepcopy")(input._inverse_ob.get(), memo);
+    py::object const convert = copy.attr("deepcopy")(input._convert_ob.get(), memo);
+    py::str const name       = copy.attr("deepcopy")(input._name.get(), memo);
 
     return {forward, inverse, convert, name};
 }

--- a/include/bh_python/transform.hpp
+++ b/include/bh_python/transform.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/core/nvp.hpp>
 #include <boost/histogram/axis/regular.hpp>
+#include <exception>
 #include <utility>
 
 #include <pybind11/functional.h>
@@ -35,7 +36,7 @@ struct func_transform {
     /// Convert an object into a std::function. Can handle ctypes
     /// function pointers and pybind11 C++ functions, or anything
     /// else with a defined convert function
-    std::tuple<raw_t*, py::object> compute(py::object& input) {
+    std::tuple<raw_t*, py::object> compute(py::object& input) const {
         // Run the conversion function on the input (unless conversion is None)
         py::object const tmp_src
             = _convert_ob.get().is_none() ? input : _convert_ob.get()(input);
@@ -106,7 +107,7 @@ struct func_transform {
             const py::gil_scoped_acquire gil;
             return _forward_ob.get().equal(other._forward_ob.get())
                    && _inverse_ob.get().equal(other._inverse_ob.get());
-        } catch(const py::error_already_set&) {
+        } catch(const std::exception&) {
             return false;
         }
     }

--- a/src/register_transforms.cpp
+++ b/src/register_transforms.cpp
@@ -93,15 +93,15 @@ void register_transforms(py::module& mod) {
              "convert"_a,
              "name"_a)
         .def("__repr__",
-             [](const py::object& self) {
+             [](const py::object& self) -> py::object {
                  auto& s = py::cast<func_transform&>(self);
-                 if(s._name.equal(py::str(""))) {
+                 if(s._name.get().equal(py::str(""))) {
                      return py::str("{}({}, {})")
                          .format(self.attr("__class__").attr("__name__"),
-                                 s._forward_ob,
-                                 s._inverse_ob);
+                                 s._forward_ob.get(),
+                                 s._inverse_ob.get());
                  }
-                 return s._name;
+                 return s._name.get();
              })
 
         ;

--- a/src/register_transforms.cpp
+++ b/src/register_transforms.cpp
@@ -95,13 +95,13 @@ void register_transforms(py::module& mod) {
         .def("__repr__",
              [](const py::object& self) -> py::object {
                  auto& s = py::cast<func_transform&>(self);
-                 if(s._name.get().equal(py::str(""))) {
+                 if(s._name.unguarded_get().equal(py::str(""))) {
                      return py::str("{}({}, {})")
                          .format(self.attr("__class__").attr("__name__"),
-                                 s._forward_ob.get(),
-                                 s._inverse_ob.get());
+                                 s._forward_ob.unguarded_get(),
+                                 s._inverse_ob.unguarded_get());
                  }
-                 return s._name.get();
+                 return s._name.unguarded_get();
              })
 
         ;


### PR DESCRIPTION
Removing an old TODO.

:robot: _AI text below_ :robot:

Axes are copied and destroyed with the GIL released (`reduce`, `project`, growing `fill`). The `py::object` members of `metadata_t` and `func_transform` were refcounted without the GIL, which was hidden by `PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF`.

This adds a shared `guarded_object` holder (`include/bh_python/guarded_object.hpp`) that acquires the GIL in its copy, copy-assign, and destroy paths. Move and adoption stay refcount-neutral, so they need no GIL. `metadata_t` and all six Python members of `func_transform` use it, which lets `func_transform` go back to defaulted special members. The `PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF` define is removed, so pybind11's debug assertions now check this.

Also:

- `type_caster<metadata_t>` starts with a null `value`, so a metadata argument conversion no longer allocates a throwaway dict.
- The three copy-pasted deepcopy-of-metadata sites use one `deep_copy_metadata` helper.
