### PR TITLE
ci: fix the scheduled wheel and weekly-update failures

### DIFF
--- a/include/bh_python/fill.hpp
+++ b/include/bh_python/fill.hpp
@@ -189,6 +189,15 @@ inline auto get_sample(const py::handle& s) {
     return sample;
 }
 
+// Boost.Histogram < 1.91 reports sample types as const T&, newer versions as T
+template <class T>
+struct decayed_traits;
+
+template <bool W, class... Ts>
+struct decayed_traits<bh::detail::accumulator_traits_holder<W, Ts...>> {
+    using type = bh::detail::accumulator_traits_holder<W, std::decay_t<Ts>...>;
+};
+
 // for accumulators that accept a weight
 template <class Histogram, class VArgs>
 void fill_impl(bh::detail::accumulator_traits_holder<true>,
@@ -209,7 +218,7 @@ void fill_impl(bh::detail::accumulator_traits_holder<true>,
 
 // for accumulators that accept a weight and a double
 template <class Histogram, class VArgs>
-void fill_impl(bh::detail::accumulator_traits_holder<true, const double&>,
+void fill_impl(bh::detail::accumulator_traits_holder<true, double>,
                Histogram& h,
                const VArgs& vargs,
                const weight_t& weight,
@@ -236,7 +245,7 @@ void fill_impl(bh::detail::accumulator_traits_holder<true, const double&>,
 
 // for multi_cell
 template <class Histogram, class VArgs>
-void fill_impl(bh::detail::accumulator_traits_holder<false, const boost::span<double>&>,
+void fill_impl(bh::detail::accumulator_traits_holder<false, boost::span<double>>,
                Histogram& h,
                const VArgs& vargs,
                const weight_t& weight,
@@ -267,7 +276,9 @@ void fill_impl(bh::detail::accumulator_traits_holder<false, const boost::span<do
 template <class Histogram>
 Histogram& fill(Histogram& self, const py::args& args, py::kwargs kwargs) {
     using value_type = typename Histogram::value_type;
-    detail::fill_impl(bh::detail::accumulator_traits<value_type>{},
+    using traits     = typename detail::decayed_traits<
+        bh::detail::accumulator_traits<value_type>>::type;
+    detail::fill_impl(traits{},
                       self,
                       detail::get_vargs(bh::unsafe_access::axes(self), args),
                       detail::get_weight(kwargs),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,7 @@ test-environment.CI = "1"  # Hypothesis needs this on GraalPy
 test-skip = [
   "cp310-win_arm64",
   "cp31*-musllinux_*", # Threading test crashes
+  "cp315t-win32",  # pytest crashes with an access violation on 3.15.0rc1
   "gp312_*",  # No numpy wheels yet
   "*-ios_*",  # Fails on CI with no device found
 ]

--- a/tests/test_serialization_uhi.py
+++ b/tests/test_serialization_uhi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+import importlib.metadata
 import importlib.resources
 import json
 import math
@@ -722,6 +723,11 @@ def test_to_uhi_matches_uhi_schema(
     """``to_uhi`` output conforms to the UHI histogram JSON schema, including the
     metadata-only (``keep_storage=False``) form used for type-only storage."""
     jsonschema = pytest.importorskip("jsonschema")
+    # Older jsonschema (pulled in where rpds-py has no wheel, e.g. Pyodide 3.15)
+    # cannot resolve the UHI schema's $ref entries
+    jsonschema_version = importlib.metadata.version("jsonschema").split(".")
+    if tuple(int(v) for v in jsonschema_version[:2]) < (4, 18):
+        pytest.skip("jsonschema>=4.18 required")
     schema = json.loads(
         importlib.resources.files("uhi.resources")
         .joinpath("histogram.schema.json")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The scheduled Wheels run has failed every day since #1170 added Python 3.15, and the Weekly update has failed since Boost.Histogram develop changed `accumulator_traits`.

- **Pyodide `cp315`**: no `rpds-py` wasm32 wheel exists for 3.15, so pip falls back to `jsonschema` 4.17.3, whose legacy `RefResolver` fails on the UHI schema (`TypeError: unhashable type: 'dict'`). The schema test now skips on `jsonschema < 4.18`.
- **`cp315t-win32`**: the test step crashes with `0xC0000005` before pytest prints anything. Added to `test-skip`, next to the musllinux threading skip.
- **Weekly update (Boost head)**: boostorg/histogram#423 changed `accumulator_traits_holder<true, const double&>` to `<true, double>` (and the same for `span`). `fill.hpp` now decays the traits before overload dispatch, so it compiles with both the pinned Boost and develop. Verified locally with the submodule on develop head (`70cf4d1`): full suite passes.
