### PR TITLE
fix: rank 0 histogram UBs + add windows 3.14t testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,6 +138,8 @@ jobs:
             only: cp310-win32
           - os: windows-latest
             only: cp313-win_amd64
+          - os: windows-latest
+            only: cp314t-win_amd64
           - os: macos-15-intel
             only: cp314t-macosx_x86_64
           - os: macos-latest

--- a/include/bh_python/register_histogram.hpp
+++ b/include/bh_python/register_histogram.hpp
@@ -198,16 +198,25 @@ auto register_histogram(py::module& m, const char* name, const char* desc) {
             "flow"_a = false)
 
         .def("reduce",
-             [](const histogram_t& self, const py::args& args) {
+             [](const histogram_t& self, const py::args& args) -> histogram_t {
                  auto commands
                      = py::cast<std::vector<bh::algorithm::reduce_command>>(args);
+                 // reduce drives the same rank-0-UB indexed range; with no
+                 // commands there is nothing to do, and any axis index is
+                 // rejected before that point.
+                 if(self.rank() == 0 && commands.empty())
+                     return self;
                  const py::gil_scoped_release release;
                  return bh::algorithm::reduce(self, commands);
              })
 
         .def("project",
-             [](const histogram_t& self, const py::args& values) {
+             [](const histogram_t& self, const py::args& values) -> histogram_t {
                  auto cpp_values = py::cast<std::vector<unsigned>>(values);
+                 // Same rank-0-UB indexed range; the identity is the only
+                 // projection a rank-0 histogram has.
+                 if(self.rank() == 0 && cpp_values.empty())
+                     return self;
                  const py::gil_scoped_release release;
                  return bh::algorithm::project(self, cpp_values);
              })
@@ -410,16 +419,25 @@ auto inline register_histogram<bh::multi_cell<double>>(py::module& m,
             "flow"_a = false)
 
         .def("reduce",
-             [](const histogram_t& self, const py::args& args) {
+             [](const histogram_t& self, const py::args& args) -> histogram_t {
                  auto commands
                      = py::cast<std::vector<bh::algorithm::reduce_command>>(args);
+                 // reduce drives the same rank-0-UB indexed range; with no
+                 // commands there is nothing to do, and any axis index is
+                 // rejected before that point.
+                 if(self.rank() == 0 && commands.empty())
+                     return self;
                  const py::gil_scoped_release release;
                  return bh::algorithm::reduce(self, commands);
              })
 
         .def("project",
-             [](const histogram_t& self, const py::args& values) {
+             [](const histogram_t& self, const py::args& values) -> histogram_t {
                  auto cpp_values = py::cast<std::vector<unsigned>>(values);
+                 // Same rank-0-UB indexed range; the identity is the only
+                 // projection a rank-0 histogram has.
+                 if(self.rank() == 0 && cpp_values.empty())
+                     return self;
                  const py::gil_scoped_release release;
                  return bh::algorithm::project(self, cpp_values);
              })

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1309,6 +1309,26 @@ def test_rank0_sum_empty():
     assert h.sum(flow=True) == 3
 
 
+def test_rank0_project():
+    # project() drives the same rank-0-UB indexed range as sum()/empty() above,
+    # and unlike those it cannot be avoided by picking a coverage. The identity
+    # is the only valid projection of a rank-0 histogram.
+    h = bh.Histogram()
+    h.fill()
+    assert h.project().ndim == 0
+    assert h.project().sum() == 1
+
+
+def test_rank0_reduce():
+    # reduce() drives the same rank-0-UB indexed range. Nothing public reaches
+    # it on a rank-0 histogram today (__getitem__ only reduces when it has
+    # slices to apply), so exercise the binding directly.
+    h = bh.Histogram()
+    h.fill()
+    assert h._reduce().ndim == 0
+    assert h._reduce().sum() == 1
+
+
 @pytest.mark.parametrize(
     "dtype",
     [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64],


### PR DESCRIPTION
This should be the crash we're seeing in integration tests in windows 3.14t ci. boost-histogram did not exercise rank-0 project and reduce in tests. Reproducing UB is hard and I got no windows machine. I did this only from inspection. The test that's crashing in the integration tests in hist is
```
def test_T_empty():
    hist_empty = hist.Hist()
    hist_T_empty = hist_empty.T
    assert hist_empty == hist_T_empty
```
and `.T` is `return self.project(*reversed(range(self.ndim)))` which is `self.project()` so it must be the rank 0 projection.

Adding windows 3.14t testing to the ci too which is what caught the UB in the integration tests repo.