### PR TITLE
fix: encode UTF-8 for non-ASCII strings filled into StrCategory

### DIFF
--- a/include/bh_python/vector_string_caster.hpp
+++ b/include/bh_python/vector_string_caster.hpp
@@ -56,6 +56,25 @@ struct type_caster<std::vector<std::string>>
         return true;
     }
 
+    // encode one UCS-4 code point as UTF-8 and append it to s
+    static void append_utf8(std::string& s, std::uint32_t cp) {
+        if(cp < 0x80) {
+            s.push_back(static_cast<char>(cp));
+        } else if(cp < 0x800) {
+            s.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+            s.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+        } else if(cp < 0x10000) {
+            s.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+            s.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+            s.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+        } else {
+            s.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+            s.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+            s.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+            s.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+        }
+    }
+
     bool load_from_array_u(const array& src) {
         const auto step
             = static_cast<std::size_t>(src.itemsize()) / sizeof(std::uint32_t);
@@ -64,16 +83,14 @@ struct type_caster<std::vector<std::string>>
         value.clear();
         value.reserve(size);
         for(std::size_t i = 0; i < size; p += step, ++i) {
-            // check that UTF-32 only contains ASCII, fail if not
+            // numpy 'U' dtype stores each character as a UCS-4 code point;
+            // encode to UTF-8, keeping the fast path for pure ASCII
             const auto n = strlen(p, step);
             std::string s;
             s.reserve(n);
-            for(std::size_t j = 0; j < n; ++j) {
-                if(p[j] >= 128)
-                    return false;
-                s.push_back(static_cast<char>(p[j]));
-            }
-            value.emplace_back(s);
+            for(std::size_t j = 0; j < n; ++j)
+                append_utf8(s, p[j]);
+            value.emplace_back(std::move(s));
         }
         return true;
     }

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -842,6 +842,28 @@ class TestCategory(Axis):
         assert a.centers == approx([0.5, 1.5, 2.5])
         assert a.widths == approx([1, 1, 1])
 
+    def test_non_ascii(self):
+        # non-ASCII strings must round-trip through construction, indexing,
+        # and fill by list/ndarray, not just scalar fill
+        labels = ["é", "日本", "a"]
+        a = bh.axis.StrCategory(labels)
+        assert list(a) == labels
+        assert a.index("é") == 0
+        assert a.index("日本") == 1
+
+        h = bh.Histogram(a)
+        h.fill(["é", "日本", "a", "é"])
+        assert h.view() == approx([2, 1, 1])
+
+        h2 = bh.Histogram(bh.axis.StrCategory(labels))
+        h2.fill(np.array(["é", "日本", "a", "é"]))
+        assert h2.view() == approx([2, 1, 1])
+
+        h3 = bh.Histogram(bh.axis.StrCategory(labels))
+        for label in labels:
+            h3.fill(label)
+        assert h3.view() == approx([1, 1, 1])
+
 
 class TestBoolean(Axis):
     def test_init(self):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Filling `StrCategory` by list or ndarray failed for non-ASCII strings, for
example `bh.Histogram(bh.axis.StrCategory(["é"])).fill(["é"])`. Scalar fill
already worked.

The cause was the numpy `U` (UCS-4) array loader in
`include/bh_python/vector_string_caster.hpp`. It rejected any code point at
or above 128 instead of encoding it to UTF-8. This fix encodes each UCS-4
code point to UTF-8, matching how scalar strings are already handled.

Part of #1176.