### PR TITLE
fix: match numpy more closely in boost_histogram.numpy

### DIFF
--- a/src/boost_histogram/numpy.py
+++ b/src/boost_histogram/numpy.py
@@ -28,6 +28,36 @@ def __dir__() -> list[str]:
     return list(__all__)
 
 
+def _outer_edges(a: ArrayLike, rng: tuple[float, float] | None) -> tuple[float, float]:
+    """
+    Compute the outer bin edges, following ``numpy.lib._histograms_impl._get_outer_edges``.
+    """
+    if rng is not None:
+        first_edge, last_edge = rng
+        if first_edge > last_edge:
+            raise ValueError("max must be larger than min in range parameter.")
+        if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
+            raise ValueError(
+                f"supplied range of [{first_edge}, {last_edge}] is not finite"
+            )
+    elif np.size(a) == 0:
+        # No data, so no range can be found; NumPy uses 0-1 here.
+        first_edge, last_edge = 0.0, 1.0
+    else:
+        first_edge, last_edge = np.amin(a), np.amax(a)
+        if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
+            raise ValueError(
+                f"autodetected range of [{first_edge}, {last_edge}] is not finite"
+            )
+
+    # Expand an empty range to avoid a division by zero
+    if first_edge == last_edge:
+        first_edge -= 0.5
+        last_edge += 0.5
+
+    return first_edge, last_edge
+
+
 def histogramdd(
     a: tuple[ArrayLike, ...],
     bins: int | tuple[int, ...] | tuple[np.typing.NDArray[Any], ...] = 10,
@@ -53,9 +83,12 @@ def histogramdd(
             "boost-histogram does not support the density keyword when returning a boost-histogram object"
         )
 
-    # Odd NumPy design here. Oh well.
+    # Odd NumPy design here. Oh well. A 1D array is N samples of one dimension,
+    # while an ND array has one sample per row.
     if isinstance(a, np.ndarray):  # type: ignore[unreachable]
-        a = a.T  # type: ignore[unreachable]
+        a = np.atleast_2d(a) if a.ndim == 1 else a.T  # type: ignore[unreachable]
+    elif len(a) > 0 and np.ndim(a[0]) == 0:
+        a = (np.asarray(a),)
 
     rank = len(a)
 
@@ -77,13 +110,9 @@ def histogramdd(
     axs: list[_axis.Axis] = []
     for n, (b, r) in enumerate(zip(bins, range, strict=True)):
         if np.issubdtype(type(b), np.integer):
-            if r is None:
-                # Nextafter may affect bin edges slightly
-                r = (np.amin(a[n]), np.amax(a[n]))  # noqa: PLW2901
-                if r[0] == r[1]:
-                    r = (r[0] - 0.5, r[1] + 0.5)  # noqa: PLW2901
+            start, stop = _outer_edges(a[n], r)
             new_ax = _axis.Regular(
-                typing.cast(int, b), r[0], r[1], underflow=False, overflow=False
+                typing.cast(int, b), start, stop, underflow=False, overflow=False
             )
             axs.append(new_ax)
         else:
@@ -122,6 +151,17 @@ def histogram2d(
 ) -> Any:
     if storage is None:
         storage = _storage.Double()
+
+    # NumPy shares a single edge array between both axes, but only if it is not
+    # one or two entries long (those are read as per-axis bin counts).
+    try:
+        n_bins = len(bins)  # type: ignore[arg-type]
+    except TypeError:
+        n_bins = 1
+    if n_bins not in {1, 2}:
+        edges = np.asarray(bins)
+        bins = (edges, edges)  # type: ignore[assignment]
+
     result = histogramdd(
         (x, y),
         bins,

--- a/tests/test_numpy_interface.py
+++ b/tests/test_numpy_interface.py
@@ -249,3 +249,131 @@ def test_histogramdd_mismatched_range(bad_range):
 
     with pytest.raises(ValueError, match="range argument"):
         bh.numpy.histogramdd((x, y), bins=2, range=bad_range)
+
+
+@pytest.mark.parametrize("empty", [[], np.array([]), np.array([], dtype=np.int64)])
+@pytest.mark.parametrize("opt", [{}, {"bins": 5}, {"range": (0, 4)}])
+def test_histogram_empty(empty, opt):
+    h1, e1 = np.histogram(empty, **opt)
+    h2, e2 = bh.numpy.histogram(empty, **opt)
+
+    assert e1 == approx(e2)
+    assert h1 == approx(h2)
+
+
+def test_histogramdd_empty():
+    h1, (e1,) = np.histogramdd((np.array([]),), bins=(4,))
+    h2, (e2,) = bh.numpy.histogramdd((np.array([]),), bins=(4,))
+
+    assert e1 == approx(e2)
+    assert h1 == approx(h2)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.int64])
+def test_histogramdd_1d_array(dtype):
+    v = np.array([1, 2, 3, 4, 3, 4, 5, 10, 9, 11, 21, -2], dtype=dtype)
+
+    h1, (e1,) = np.histogramdd(v)
+    h2, (e2,) = bh.numpy.histogramdd(v)
+
+    assert e1 == approx(e2)
+    assert h1 == approx(h2)
+
+
+def test_histogramdd_1d_list():
+    v = [1.0, 2.0, 3.0, 4.0]
+
+    h1, (e1,) = np.histogramdd(v, bins=3)
+    h2, (e2,) = bh.numpy.histogramdd(v, bins=3)
+
+    assert e1 == approx(e2)
+    assert h1 == approx(h2)
+
+
+@pytest.mark.parametrize("bins", [np.array([0.0, 0.5, 1.0, 2.0]), [0.0, 0.5, 1.0, 2.0]])
+def test_histogram2d_shared_edges(bins):
+    x = np.array([0.3, 0.3, 0.1, 0.8, 0.34, 0.03, 0.32, 0.65])
+    y = np.array([0.4, 0.5, 0.22, 0.65, 0.32, 0.01, 0.23, 1.98])
+
+    h1, e1x, e1y = np.histogram2d(x, y, bins=bins)
+    h2, e2x, e2y = bh.numpy.histogram2d(x, y, bins=bins)
+
+    assert e1x == approx(e2x)
+    assert e1y == approx(e2y)
+    assert h1 == approx(h2)
+
+
+def test_histogram_reversed_range():
+    x = np.array([0.3, 0.3, 0.1, 0.8])
+
+    with pytest.raises(ValueError, match="max must be larger than min"):
+        np.histogram(x, bins=4, range=(1, 0))
+
+    with pytest.raises(ValueError, match="max must be larger than min"):
+        bh.numpy.histogram(x, bins=4, range=(1, 0))
+
+
+def test_histogramdd_reversed_range():
+    x = np.array([0.3, 0.3, 0.1, 0.8])
+    y = np.array([0.4, 0.5, 0.22, 0.65])
+
+    with pytest.raises(ValueError, match="max must be larger than min"):
+        np.histogramdd((x, y), bins=4, range=((0, 1), (1, 0)))
+
+    with pytest.raises(ValueError, match="max must be larger than min"):
+        bh.numpy.histogramdd((x, y), bins=4, range=((0, 1), (1, 0)))
+
+
+def test_histogram_nonfinite_range():
+    x = np.array([0.3, 0.3, 0.1, 0.8])
+
+    with pytest.raises(ValueError, match="is not finite"):
+        np.histogram(x, bins=4, range=(0, np.inf))
+
+    with pytest.raises(ValueError, match="is not finite"):
+        bh.numpy.histogram(x, bins=4, range=(0, np.inf))
+
+
+def test_histogram_empty_range():
+    x = np.array([0.3, 0.3, 0.1, 0.8])
+
+    h1, e1 = np.histogram(x, bins=4, range=(1, 1))
+    h2, e2 = bh.numpy.histogram(x, bins=4, range=(1, 1))
+
+    assert e1 == approx(e2)
+    assert h1 == approx(h2)
+
+
+@pytest.mark.parametrize("opt", [{}, {"density": True}])
+def test_histogram_weights_and_density(opt):
+    x = np.array([0.3, 0.3, 0.1, 0.8, 0.34, 0.03, 0.32, 0.65])
+    weights = np.array([0.4, 0.5, 0.22, 0.65, 0.32, 0.01, 0.23, 1.98])
+
+    h1, e1 = np.histogram(x, bins=7, weights=weights, **opt)
+    h2, e2 = bh.numpy.histogram(x, bins=7, weights=weights, **opt)
+
+    assert e1 == approx(e2)
+    assert h1 == approx(h2)
+
+    h1, e1x, e1y = np.histogram2d(x, x, bins=3, weights=weights, **opt)
+    h2, e2x, e2y = bh.numpy.histogram2d(x, x, bins=3, weights=weights, **opt)
+
+    assert e1x == approx(e2x)
+    assert e1y == approx(e2y)
+    assert h1 == approx(h2)
+
+
+@pytest.mark.xfail(
+    reason="A Regular axis finds the bin from the range, so a value exactly on "
+    "an interior edge can land one bin lower than in NumPy, which compares the "
+    "value against the linspace edges."
+)
+@pytest.mark.parametrize(("lo", "hi", "n"), [(-3, 7, 13), (0, 1, 7), (0, 3, 11)])
+def test_histogram_values_on_edges(lo, hi, n):
+    v = np.linspace(lo, hi, n + 1)
+
+    h1, e1 = np.histogram(v, bins=n, range=(lo, hi))
+    h2, e2 = bh.numpy.histogram(v, bins=n, range=(lo, hi))
+
+    assert e1.tolist() == e2.tolist()
+    assert h1.tolist() == h2.tolist()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`boost_histogram.numpy` must be a drop-in replacement for the NumPy histogram
functions. Four divergences are corrected:

- Empty input raised a `ValueError`. The range is now `(0, 1)`, as in NumPy.
- `histogramdd` read a 1-D array as N dimensions. A 1-D array is now N samples
  of one dimension. A flat sequence of numbers is read the same way.
- `histogram2d` refused a single edge array for `bins`. The array is now used
  for both axes, with the same length 1 and 2 exceptions as NumPy.
- A reversed range, such as `range=(1, 0)`, was accepted. It now raises
  `ValueError`. A non-finite range also raises, and an equal range is expanded
  by 0.5 on each side.

The outer edge calculation is now one helper that follows NumPy's
`_get_outer_edges`.

Not fixed: a value exactly on an interior bin edge can go into the bin below
the NumPy bin. A `Regular` axis calculates the bin from the range, but NumPy
compares the value against the `linspace` edges and then corrects the index. To
agree in all cases, the integer-`bins` path must use a `Variable` axis built
from `np.linspace`. This makes the fill slower and changes the axis type that
users see when they pass `histogram=bh.Histogram`. The test for this is added
as a strict xfail.

Part of #1176.
