### PR TITLE
fix: C++ aborts in axis compare, MultiCell fill, and Boolean value

### DIFF
--- a/include/bh_python/axis.hpp
+++ b/include/bh_python/axis.hpp
@@ -128,6 +128,10 @@ class boolean : public bh::axis::integer<int, metadata_t, option::none_t> {
         return integer::index(x == 0 ? 0 : 1);
     }
 
+    // Redeclared so &boolean::value binds on boolean; pybind11 does not know
+    // the base class, so a base member pointer would reject a boolean self.
+    int value(bh::axis::real_index_type i) const noexcept { return integer::value(i); }
+
     // We can't specify inclusive, since this could be sliced
 };
 

--- a/include/bh_python/axis.hpp
+++ b/include/bh_python/axis.hpp
@@ -130,7 +130,7 @@ class boolean : public bh::axis::integer<int, metadata_t, option::none_t> {
 
     // Redeclared so &boolean::value binds on boolean; pybind11 does not know
     // the base class, so a base member pointer would reject a boolean self.
-    int value(bh::axis::real_index_type i) const noexcept { return integer::value(i); }
+    int value(bh::axis::index_type i) const noexcept { return integer::value(i); }
 
     // We can't specify inclusive, since this could be sliced
 };

--- a/include/bh_python/fill.hpp
+++ b/include/bh_python/fill.hpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <limits>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -294,12 +295,20 @@ void fill_impl(bh::detail::accumulator_traits_holder<false, boost::span<double>>
     if(sarray.ndim() != 2)
         throw std::invalid_argument("Sample or weight array for MultiCell must be 2D");
 
-    auto buf = sarray.request();
-    // releasing gil here is safe, we don't manipulate refcounts
-    const py::gil_scoped_release lock;
+    auto buf              = sarray.request();
     const auto buf_shape0 = static_cast<std::size_t>(buf.shape[0]);
     const auto buf_shape1 = static_cast<std::size_t>(buf.shape[1]);
-    auto* src             = static_cast<double*>(buf.ptr);
+
+    // A row that is not nelem wide would throw deep inside the fill loop
+    const auto nelem = bh::unsafe_access::storage(h).nelem();
+    if(buf_shape1 != nelem)
+        throw std::invalid_argument("Sample or weight array for MultiCell must have "
+                                    + std::to_string(nelem) + " entries per row, got "
+                                    + std::to_string(buf_shape1));
+
+    // releasing gil here is safe, we don't manipulate refcounts
+    const py::gil_scoped_release lock;
+    auto* src = static_cast<double*>(buf.ptr);
     std::vector<boost::span<double>> vec_s;
     vec_s.reserve(buf_shape0);
     for(std::size_t i = 0; i < buf_shape0; i++) {

--- a/include/bh_python/metadata.hpp
+++ b/include/bh_python/metadata.hpp
@@ -45,13 +45,20 @@ class metadata_t {
     /// Access the held dict; hold the GIL to use or copy it
     const py::object& unguarded_obj() const noexcept { return data_.unguarded_get(); }
 
-    bool operator==(const metadata_t& other) const {
+    // Boost compares axes in a noexcept context, so these must not throw. If
+    // the Python comparison raises, or its result has no truth value (a NumPy
+    // array), fall back to identity: only the same dict object is equal.
+    bool operator==(const metadata_t& other) const noexcept {
         const py::gil_scoped_acquire gil;
-        return unguarded_obj().equal(other.unguarded_obj());
+        try {
+            return unguarded_obj().equal(other.unguarded_obj());
+        } catch(...) {
+            // pybind11 fetched the Python error into the exception object
+            return unguarded_obj().is(other.unguarded_obj());
+        }
     }
-    bool operator!=(const metadata_t& other) const {
-        const py::gil_scoped_acquire gil;
-        return unguarded_obj().not_equal(other.unguarded_obj());
+    bool operator!=(const metadata_t& other) const noexcept {
+        return !operator==(other);
     }
 
   private:

--- a/include/bh_python/metadata.hpp
+++ b/include/bh_python/metadata.hpp
@@ -10,6 +10,7 @@
 
 #include <pybind11/pytypes.h>
 
+#include <algorithm>
 #include <utility>
 
 /// Axis metadata: a Python dict, shared with the Python axis wrapper's
@@ -45,9 +46,7 @@ class metadata_t {
     /// Access the held dict; hold the GIL to use or copy it
     const py::object& unguarded_obj() const noexcept { return data_.unguarded_get(); }
 
-    // Boost compares axes in a noexcept context, so these must not throw. If
-    // the Python comparison raises, or its result has no truth value (a NumPy
-    // array), fall back to identity: only the same dict object is equal.
+    // Boost compares axes in a noexcept context, so these must not throw.
     bool operator==(const metadata_t& other) const noexcept {
         try {
             const py::gil_scoped_acquire gil;
@@ -55,7 +54,7 @@ class metadata_t {
                 return unguarded_obj().equal(other.unguarded_obj());
             } catch(...) {
                 // pybind11 fetched the Python error into the exception object
-                return unguarded_obj().is(other.unguarded_obj());
+                return item_equal(unguarded_obj(), other.unguarded_obj());
             }
         } catch(...) {
             return false;
@@ -69,6 +68,27 @@ class metadata_t {
     static py::object make_dict() {
         const py::gil_scoped_acquire gil;
         return py::dict();
+    }
+
+    /// Compare the dicts value by value, used when dict == dict raised. A
+    /// value whose comparison raises, or gives no truth value (a NumPy array),
+    /// is equal only when it is the same object.
+    static bool item_equal(const py::object& a, const py::object& b) {
+        const auto da = py::reinterpret_borrow<py::dict>(a);
+        const auto db = py::reinterpret_borrow<py::dict>(b);
+        if(da.size() != db.size())
+            return false;
+        return std::all_of(da.begin(), da.end(), [&db](const auto& item) {
+            if(!db.contains(item.first))
+                return false;
+            const py::object mine  = py::reinterpret_borrow<py::object>(item.second);
+            const py::object their = db[item.first];
+            try {
+                return mine.equal(their);
+            } catch(...) {
+                return mine.is(their);
+            }
+        });
     }
 
     static py::object shallow_copy_dict(const py::object& obj) {

--- a/include/bh_python/metadata.hpp
+++ b/include/bh_python/metadata.hpp
@@ -49,12 +49,16 @@ class metadata_t {
     // the Python comparison raises, or its result has no truth value (a NumPy
     // array), fall back to identity: only the same dict object is equal.
     bool operator==(const metadata_t& other) const noexcept {
-        const py::gil_scoped_acquire gil;
         try {
-            return unguarded_obj().equal(other.unguarded_obj());
+            const py::gil_scoped_acquire gil;
+            try {
+                return unguarded_obj().equal(other.unguarded_obj());
+            } catch(...) {
+                // pybind11 fetched the Python error into the exception object
+                return unguarded_obj().is(other.unguarded_obj());
+            }
         } catch(...) {
-            // pybind11 fetched the Python error into the exception object
-            return unguarded_obj().is(other.unguarded_obj());
+            return false;
         }
     }
     bool operator!=(const metadata_t& other) const noexcept {

--- a/include/bh_python/register_histogram.hpp
+++ b/include/bh_python/register_histogram.hpp
@@ -20,10 +20,12 @@
 #include <boost/histogram/algorithm/reduce.hpp>
 #include <boost/histogram/algorithm/sum.hpp>
 #include <boost/histogram/histogram.hpp>
+#include <boost/histogram/indexed.hpp>
 #include <boost/histogram/ostream.hpp>
 #include <boost/histogram/unsafe_access.hpp>
 #include <boost/mp11.hpp>
 
+#include <algorithm>
 #include <future>
 #include <memory>
 #include <sstream>
@@ -376,14 +378,20 @@ auto inline register_histogram<bh::multi_cell<double>>(py::module& m,
             "empty",
             [](const histogram_t& self, bool flow) {
                 const py::gil_scoped_release release;
-                if(self.rank() == 0) {
-                    // algorithm::empty drives the same rank-0-UB indexed range;
-                    // the single MultiCell cell is empty iff it collected
-                    // nothing.
-                    return self.begin()->empty();
-                }
-                return bh::algorithm::empty(
-                    self, flow ? bh::coverage::all : bh::coverage::inner);
+                // A cell is empty when every element is zero; algorithm::empty
+                // compares against a default-constructed (zero length) cell,
+                // which never matches. rank 0 also drives the indexed range,
+                // which is UB for rank-0 histograms.
+                const auto all_zero = [](const auto& cell) {
+                    return std::all_of(
+                        cell.begin(), cell.end(), [](double x) { return x == 0; });
+                };
+                if(flow || self.rank() == 0)
+                    return std::all_of(self.begin(), self.end(), all_zero);
+                for(auto&& x : bh::indexed(self))
+                    if(!all_zero(*x))
+                        return false;
+                return true;
             },
             "flow"_a = false)
 

--- a/include/bh_python/register_histogram.hpp
+++ b/include/bh_python/register_histogram.hpp
@@ -388,10 +388,10 @@ auto inline register_histogram<bh::multi_cell<double>>(py::module& m,
                 };
                 if(flow || self.rank() == 0)
                     return std::all_of(self.begin(), self.end(), all_zero);
-                for(auto&& x : bh::indexed(self))
-                    if(!all_zero(*x))
-                        return false;
-                return true;
+                auto range = bh::indexed(self);
+                return std::all_of(range.begin(),
+                                   range.end(),
+                                   [&all_zero](const auto& x) { return all_zero(*x); });
             },
             "flow"_a = false)
 

--- a/include/bh_python/register_storage.hpp
+++ b/include/bh_python/register_storage.hpp
@@ -11,6 +11,9 @@
 #include <bh_python/make_pickle.hpp>
 #include <bh_python/storage.hpp>
 
+#include <cstddef>
+#include <stdexcept>
+
 /// Add helpers common to all storage types
 template <class A>
 py::class_<A> register_storage(py::module& m, const char* name, const char* desc) {
@@ -53,7 +56,13 @@ py::class_<storage::multi_cell> inline register_storage(py::module& m,
     py::class_<A> storage(m, name, desc);
     def_eq(storage);
 
-    storage.def(py::init<int>(), py::arg("k") = 0)
+    storage
+        .def(py::init([](int k) {
+                 if(k < 1)
+                     throw std::invalid_argument("MultiCell nelem must be 1 or larger");
+                 return A{static_cast<std::size_t>(k)};
+             }),
+             py::arg("k"))
         .def(make_pickle<A>())
         .def("__copy__", [](const A& self) { return A(self); })
         .def("__deepcopy__", [](const A& self, const py::object&) { return A(self); })

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -941,6 +941,42 @@ class TestBoolean(Axis):
         assert a.centers == approx([0.5, 1.5])
         assert a.widths == approx([1, 1])
 
+    def test_value(self):
+        a = bh.axis.Boolean()
+        assert a.value(0) == 0
+        assert a.value(1) == 1
+        assert a.value([0, 1]) == approx([0, 1])
+
+
+def test_metadata_compare_no_bool():
+    # Metadata that does not give a plain bool from == must not abort
+    array = np.arange(3)
+    assert bh.axis.Regular(3, 0, 1, metadata=array) == bh.axis.Regular(
+        3, 0, 1, metadata=array
+    )
+    assert bh.axis.Regular(3, 0, 1, metadata=array) != bh.axis.Regular(
+        3, 0, 1, metadata=np.arange(3)
+    )
+    assert not bh.axis.Regular(3, 0, 1, metadata=np.arange(3)) == bh.axis.Regular(  # noqa: SIM201
+        3, 0, 1, metadata=np.arange(3)
+    )
+
+
+def test_metadata_compare_raises():
+    class Bad:
+        def __eq__(self, other):
+            raise RuntimeError("no compare")
+
+        __hash__ = None
+
+    bad = Bad()
+    assert bh.axis.Regular(3, 0, 1, metadata=bad) == bh.axis.Regular(
+        3, 0, 1, metadata=bad
+    )
+    assert bh.axis.Regular(3, 0, 1, metadata=bad) != bh.axis.Regular(
+        3, 0, 1, metadata=Bad()
+    )
+
 
 # Issue #1143 regression tests
 

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -961,6 +961,10 @@ def test_metadata_compare_no_bool():
         3, 0, 1, metadata=np.arange(3)
     )
 
+    # A copy keeps the same metadata object, so it stays equal
+    ax = bh.axis.Regular(3, 0, 1, metadata=array)
+    assert copy.copy(ax) == ax
+
 
 def test_metadata_compare_raises():
     class Bad:

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -2025,6 +2025,7 @@ def test_compare_ndarray_metadata():
     assert h == h_same
     assert h != h_other
     assert (h + h_same).sum() == 0
+    assert h.copy(deep=False) == h
 
     with pytest.raises(ValueError, match="axes"):
         h + h_other

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -2013,3 +2013,18 @@ def test_fill_int_axis_dtypes(dtype):
     b = bh.Histogram(bh.axis.Boolean())
     b.fill(np.array([0, 1, 1], dtype=dtype))
     assert b.view() == approx(np.array([1, 2]))
+
+
+def test_compare_ndarray_metadata():
+    # Metadata that gives no plain bool from == must not abort the interpreter
+    array = np.arange(3)
+    h = bh.Histogram(bh.axis.Regular(3, 0, 1, metadata=array))
+    h_same = bh.Histogram(bh.axis.Regular(3, 0, 1, metadata=array))
+    h_other = bh.Histogram(bh.axis.Regular(3, 0, 1, metadata=np.arange(3)))
+
+    assert h == h_same
+    assert h != h_other
+    assert (h + h_same).sum() == 0
+
+    with pytest.raises(ValueError, match="axes"):
+        h + h_other

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -683,3 +683,31 @@ def test_multi_cell():
     expected_view[:, 2:4, 0:3] = sub_array_to_set
     h[2:4, 0:3] = sub_array_to_set
     assert h.view() == approx(expected_view)
+
+
+def test_multi_cell_bad_nelem():
+    with pytest.raises(ValueError, match="nelem"):
+        bh.storage.MultiCell(-1)
+    with pytest.raises(ValueError, match="nelem"):
+        bh.storage.MultiCell(0)
+
+
+def test_multi_cell_fill_wrong_width():
+    h = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.MultiCell(2))
+    with pytest.raises(ValueError, match="2"):
+        h.fill([0.1, 0.5], weight=[[1, 2, 3], [4, 5, 6]])
+
+
+def test_multi_cell_empty():
+    h = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.MultiCell(2))
+    assert h.empty()
+    assert h.empty(flow=True)
+
+    h.fill([0.1], weight=[[1, 2]])
+    assert not h.empty()
+    assert not h.empty(flow=True)
+
+    h2 = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.MultiCell(2))
+    h2.fill([-1], weight=[[1, 2]])
+    assert h2.empty()
+    assert not h2.empty(flow=True)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Four C++ level failures made the interpreter abort or raise the wrong error.

- Axis metadata compare. `metadata_t::operator==` threw through Boost's noexcept axis compare, so `a == b`, `h == h2` and `h + h2` aborted when the metadata gave no plain bool (a NumPy array) or raised. The compare is now noexcept: if the Python compare fails, it falls back to identity, so only the same object is equal.
- MultiCell fill. A sample or weight row that is not `nelem` wide let `std::range_error` escape from the fill loop and aborted. The width is now checked before the fill and raises `ValueError`. The other paths that use the same code (in-place add, subtract, item set) already raise `ValueError`.
- `MultiCell(-1)` gave `std::bad_alloc`. The storage now requires `nelem` of 1 or larger. The argument has no default any more, because a zero-cell storage cannot be filled.
- `Boolean().value(i)` always raised a `TypeError`, because the bound member pointer came from the base class, which pybind11 does not know. `Boolean` now declares `value` itself.

Also fixed: `empty()` for a MultiCell histogram was always `False`. The generic algorithm compares each cell against a zero-length cell, which never matches. It now tests that every element is zero.

Part of #1176.
