### PR TITLE
perf: cheaper fill argument variant, no int64 wraparound

### DIFF
--- a/include/bh_python/fill.hpp
+++ b/include/bh_python/fill.hpp
@@ -21,6 +21,8 @@
 #include <boost/mp11.hpp>
 #include <boost/variant2/variant.hpp>
 
+#include <cstdint>
+#include <limits>
 #include <stdexcept>
 #include <type_traits>
 #include <vector>
@@ -97,17 +99,50 @@ inline decltype(auto) special_cast<c_array_t<std::string>>(py::handle x) {
     return py::cast<B>(x);
 }
 
+inline bool fits_in_int(std::int64_t v) {
+    return v >= static_cast<std::int64_t>(std::numeric_limits<int>::min())
+           && v <= static_cast<std::int64_t>(std::numeric_limits<int>::max());
+}
+
+inline bool fits_in_int(std::uint64_t v) {
+    return v <= static_cast<std::uint64_t>(std::numeric_limits<int>::max());
+}
+
+/// Narrow a wide or unsigned integer array to int, the value type of the integer
+/// axes. NumPy would wrap out-of-range values silently.
+template <class T>
+inline c_array_t<int> narrow_to_int(py::handle x) {
+    const py::array_t<T, py::array::c_style | py::array::forcecast> wide(
+        py::reinterpret_borrow<py::object>(x));
+    const std::vector<py::ssize_t> shape(wide.shape(), wide.shape() + wide.ndim());
+    py::array_t<int> out(shape);
+
+    const T* in = wide.data();
+    int* op     = out.mutable_data();
+    for(py::ssize_t i = 0, n = wide.size(); i < n; ++i) {
+        if(!fits_in_int(in[i]))
+            throw py::value_error(
+                "Integer axis values must fit in a 32-bit signed integer");
+        op[i] = static_cast<int>(in[i]);
+    }
+
+    return c_array_t<int>(py::reinterpret_borrow<py::object>(out));
+}
+
 // Make sure float arrays don't get cast to integers (-.5 rounds to 0!)
 template <>
 inline decltype(auto) special_cast<c_array_t<int>>(py::handle x) {
-    auto np    = py::module::import("numpy");
-    auto dtype = py::cast<py::array>(x).dtype();
-    if(dtype.equal(np.attr("bool_")) || dtype.equal(np.attr("int8"))
-       || dtype.equal(np.attr("int16")) || dtype.equal(np.attr("int32"))
-       || dtype.equal(np.attr("int64")) || dtype.equal(np.attr("uint8"))
-       || dtype.equal(np.attr("uint16")) || dtype.equal(np.attr("uint32"))
-       || dtype.equal(np.attr("uint64")))
+    const auto dtype  = py::cast<py::array>(x).dtype();
+    const char kind   = dtype.kind();
+    const auto nbytes = dtype.itemsize();
+
+    // These always fit in an int, so let NumPy convert them
+    if(kind == 'b' || (kind == 'i' && nbytes <= 4) || (kind == 'u' && nbytes <= 2))
         return py::cast<c_array_t<int>>(x);
+    if(kind == 'i')
+        return narrow_to_int<std::int64_t>(x);
+    if(kind == 'u')
+        return narrow_to_int<std::uint64_t>(x);
     throw py::type_error("Only integer arrays supported when targeting integer axes");
 }
 
@@ -122,12 +157,14 @@ inline decltype(auto) special_cast<int>(py::handle x) {
     }
 }
 
-using arg_t = variant::variant<c_array_t<double>,
-                               double,
-                               c_array_t<int>,
+// The first alternative must stay cheap to default construct; a stack buffer of
+// these is made for every fill, and only the leading axes.size() are assigned.
+using arg_t = variant::variant<double,
+                               c_array_t<double>,
                                int,
-                               c_array_t<std::string>,
-                               std::string>;
+                               c_array_t<int>,
+                               std::string,
+                               c_array_t<std::string>>;
 
 using weight_t = variant::variant<variant::monostate, double, c_array_t<double>>;
 

--- a/include/bh_python/fill.hpp
+++ b/include/bh_python/fill.hpp
@@ -126,7 +126,7 @@ inline c_array_t<int> narrow_to_int(py::handle x) {
         op[i] = static_cast<int>(in[i]);
     }
 
-    return c_array_t<int>(py::reinterpret_borrow<py::object>(out));
+    return {py::reinterpret_borrow<py::object>(out)};
 }
 
 // Make sure float arrays don't get cast to integers (-.5 rounds to 0!)

--- a/include/bh_python/multi_cell.hpp
+++ b/include/bh_python/multi_cell.hpp
@@ -172,6 +172,24 @@ class multi_cell {
         return *this;
     }
 
+    // Without these the buffer is deep copied on reduce, project and init
+    multi_cell(multi_cell&& other) noexcept
+        : size_{other.size_}
+        , nelem_{other.nelem_}
+        , buffer_{std::move(other.buffer_)} {
+        other.size_ = 0;
+    }
+
+    multi_cell& operator=(multi_cell&& other) noexcept {
+        if(this != &other) {
+            size_       = other.size_;
+            nelem_      = other.nelem_;
+            buffer_     = std::move(other.buffer_);
+            other.size_ = 0;
+        }
+        return *this;
+    }
+
     std::size_t size() const { return size_; }
 
     std::size_t nelem() const { return nelem_; }

--- a/include/bh_python/register_axis.hpp
+++ b/include/bh_python/register_axis.hpp
@@ -62,6 +62,21 @@ inline decltype(auto) axis_cast<int>(py::handle x) {
 }
 } // namespace detail
 
+// we overload vectorize index for the integer axis, whose value type is int
+template <class Options>
+auto vectorize_index(int (bh::axis::integer<int, metadata_t, Options>::*pindex)(int)
+                         const BHP_NOEXCEPT_17) {
+    using A      = bh::axis::integer<int, metadata_t, Options>;
+    auto indexer = py::vectorize(pindex);
+    return [indexer](const A& self, const py::object& arg) mutable -> py::object {
+        auto array = py::array::ensure(arg);
+        // integer input is range checked; anything else keeps the NumPy cast
+        if(array && (array.dtype().kind() == 'i' || array.dtype().kind() == 'u'))
+            return indexer(&self, detail::special_cast<detail::c_array_t<int>>(array));
+        return indexer(&self, py::cast<detail::c_array_t<int>>(arg));
+    };
+}
+
 // we overload vectorize index for category axis
 template <class T, class Options>
 auto vectorize_index(int (bh::axis::category<T, metadata_t, Options>::*pindex)(const T&)

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1930,3 +1930,47 @@ def test_fill_noncontiguous_str_category():
     h2 = bh.Histogram(bh.axis.StrCategory(cat))
     h2.fill(np.array(["a", "b", "c"])[::-1])
     assert h2.view(flow=True) == approx(expected2.view(flow=True))
+
+
+@pytest.mark.parametrize(
+    ("dtype", "value"),
+    [(np.int64, 2**32 + 3), (np.uint32, 2**31 + 3), (np.uint64, 2**32 + 3)],
+)
+def test_fill_int_axis_out_of_range(dtype, value):
+    # Regression test: wide integers were narrowed to int32 and wrapped silently
+    h = bh.Histogram(bh.axis.Integer(0, 5))
+    with pytest.raises(ValueError):
+        h.fill(np.array([value], dtype=dtype))
+    assert h.sum(flow=True) == 0
+
+    c = bh.Histogram(bh.axis.IntCategory([1, 2, 3]))
+    with pytest.raises(ValueError):
+        c.fill(np.array([value], dtype=dtype))
+    assert c.sum(flow=True) == 0
+
+
+def test_index_int_axis_out_of_range():
+    with pytest.raises(ValueError):
+        bh.axis.Integer(0, 5).index(np.array([2**32 + 3]))
+    with pytest.raises(ValueError):
+        bh.axis.IntCategory([1, 2, 3]).index(np.array([2**32 + 2]))
+
+
+def test_fill_int_axis_scalar_out_of_range():
+    h = bh.Histogram(bh.axis.Integer(0, 5))
+    with pytest.raises((ValueError, TypeError)):
+        h.fill(2**32 + 3)
+    assert h.sum(flow=True) == 0
+
+
+@pytest.mark.parametrize(
+    "dtype", [np.bool_, np.int8, np.uint8, np.int16, np.uint16, np.int32, np.int64]
+)
+def test_fill_int_axis_dtypes(dtype):
+    h = bh.Histogram(bh.axis.Integer(0, 5))
+    h.fill(np.array([0, 1, 1], dtype=dtype))
+    assert h.view() == approx(np.array([1, 2, 0, 0, 0]))
+
+    b = bh.Histogram(bh.axis.Boolean())
+    b.fill(np.array([0, 1, 1], dtype=dtype))
+    assert b.view() == approx(np.array([1, 2]))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Three changes in the fill path.

**Cheaper fill argument buffer.** `bh::detail::make_stack_buffer<arg_t>` default constructs 32 variants for every `fill()`. The first alternative was `c_array_t<double>`, so each call made 32 empty NumPy arrays. The scalar types now come first. Nothing depends on the alternative order: the variant is only used through visitors.

**No more silent wraparound on integer axes.** `special_cast<c_array_t<int>>` compared the dtype against nine NumPy scalar types, which imported NumPy on every call. It now reads `dtype.kind()`. int64, uint32 and uint64 input is narrowed with a range check, so `bh.Histogram(bh.axis.Integer(0, 5)).fill(np.array([2**32 + 3]))` raises `ValueError` instead of filling bin 3. `Axis.index()` gets the same check. Bool arrays, small integer types and Python `int` scalars keep their behavior.

**Move operations for `multi_cell`.** The class declared copy operations only, so the buffer was deep copied where a move was possible.

Timings on Python 3.14t, macOS arm64 (`timeit`, mean per call):

| case | before | after |
| --- | --- | --- |
| scalar fill, 1 axis | 3.6-4.5 us | 1.1 us |
| scalar fill, 3 axes | 3.8-4.7 us | 1.3 us |
| 1000-element float array fill | 4.8-5.4 us | 2.3 us |
| 1000-element int32 array fill | 4.8-5.5 us | 2.0 us |
| 1000-element int64 array fill | 5.1-5.6 us | 2.4 us |
| int scalar fill | 3.4-4.0 us | 1.1 us |

The `multi_cell` move operations gave no measurable gain for copy, projection or rebin on a 200x200 histogram with 8 cells per bin. The change is kept because it is correct and cheap.

Part of #1176.
