### PR TITLE
fix: UHI indexing bugs with flow bins and group rebin

### DIFF
--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -1214,17 +1214,54 @@ class Histogram(typing.Generic[S]):
 
         return indexes
 
+    def _flow_pick_index(self, axis: int, idx: int) -> int:
+        """
+        Map a UHI-resolved scalar index for ``axis`` to an offset into the
+        ``flow=True`` view. Regular indices are 0..size-1; the sentinels -1
+        and size (produced by ``bh.underflow``/``bh.overflow``/``bh.loc`` on
+        an out-of-range value) select the flow bins, raising IndexError if
+        the axis does not have the requested flow bin.
+        """
+        traits = self.axes[axis].traits
+        size = self._hist.axis(axis).size
+        offset = 1 if traits.underflow else 0
+        if idx == -1:
+            if not traits.underflow:
+                raise IndexError(f"Axis {axis} has no underflow bin")
+            return 0
+        if idx == size:
+            if not traits.overflow:
+                raise IndexError(f"Axis {axis} has no overflow bin")
+            return size + offset
+        return idx + offset
+
+    @staticmethod
+    def _flow_slice_bound(v: int | None, default: int, size: int, offset: int) -> int:
+        """
+        Resolve one bound of a plain integer slice used in vectorized
+        indexing: None and negative values are resolved the same way NumPy
+        would on the flow=False view, then shifted onto the flow=True view.
+        """
+        if v is None:
+            v = default
+        elif v < 0:
+            v += size
+        return v + offset
+
     def _compute_vectorized_index(self, indexes: list[Any]) -> tuple[Any, ...]:
         """
         Build a NumPy fancy-index tuple from already-normalized indexes for
-        vectorized cell access (gather/scatter). Each axis may be an integer
-        array, an integer, or a plain integer slice. Rebin/sum/locator slices
-        and categorical lists are rejected with a pointer to ``.view()``.
+        vectorized cell access (gather/scatter) into the ``flow=True`` view.
+        Each axis may be an integer array, an integer (including the
+        ``bh.underflow``/``bh.overflow`` sentinels), or a plain integer
+        slice. Rebin/sum/locator slices and categorical lists are rejected
+        with a pointer to ``.view()``.
         """
         view_index: list[Any] = []
         for i, ind in enumerate(indexes):
+            offset = 1 if self.axes[i].traits.underflow else 0
             if isinstance(ind, np.ndarray):
-                view_index.append(ind)
+                view_index.append(ind + offset)
             elif isinstance(ind, slice):
                 if ind.step is not None or not all(
                     s is None or isinstance(s, int) for s in (ind.start, ind.stop)
@@ -1234,9 +1271,17 @@ class Histogram(typing.Generic[S]):
                         "integer slices; use .view() for rebin, sum, or locator slices"
                     )
                     raise IndexError(msg)
-                view_index.append(ind)
+                # Bounds are plain non-flow indices (matching scalar/array
+                # indexing semantics: no flow bins unless asked for), with
+                # None and negative values resolved the same way as NumPy
+                # would on the flow=False view, then shifted onto the
+                # flow=True view.
+                size = self._hist.axis(i).size
+                start = self._flow_slice_bound(ind.start, 0, size, offset)
+                stop = self._flow_slice_bound(ind.stop, size, size, offset)
+                view_index.append(slice(start, stop))
             elif isinstance(ind, SupportsIndex):
-                view_index.append(ind.__index__())
+                view_index.append(self._flow_pick_index(i, ind.__index__()))
             else:
                 msg = (
                     "Vectorized (array) indexing only supports integer arrays, "
@@ -1415,7 +1460,7 @@ class Histogram(typing.Generic[S]):
         # buffer instead of building a new histogram. Only ndarray indices
         # trigger this; lists keep their categorical pick semantics.
         if any(isinstance(a, np.ndarray) for a in indexes):
-            return self.view()[self._compute_vectorized_index(indexes)]
+            return self.view(flow=True)[self._compute_vectorized_index(indexes)]
 
         # Early return for all-integer case
         if all(isinstance(a, SupportsIndex) for a in indexes):
@@ -1430,9 +1475,7 @@ class Histogram(typing.Generic[S]):
         for i, ind in enumerate(indexes):
             match ind:
                 case SupportsIndex():
-                    pick_each[i] = ind.__index__() + (
-                        1 if self.axes[i].traits.underflow else 0
-                    )
+                    pick_each[i] = self._flow_pick_index(i, ind.__index__())
                 # str/bytes are Sequences but not valid indices; they fall
                 # through to the IndexError below.
                 case collections.abc.Sequence() if not isinstance(ind, (str, bytes)):  # type: ignore[unreachable]
@@ -1560,10 +1603,11 @@ class Histogram(typing.Generic[S]):
         groups = []
         new_axis = None
         merge = 1
+        has_bounds = start is not None or stop is not None
         match step:
             case x if x is sum:  # https://github.com/oracle/graalpython/issues/620
                 integrations.add(i)
-                if start is not None or stop is not None:
+                if has_bounds:
                     if start_int >= stop_int:
                         raise IndexError(self._empty_slice_msg(i, start, stop))
                     slices.append(
@@ -1576,10 +1620,31 @@ class Histogram(typing.Generic[S]):
                 pass
             case object(factor=x) if x is not None:
                 merge = x
-            case object(axis_mapping=x) if (tmp_both := x(self.axes[i])) is not None:
+            case object(axis_mapping=x) if x is not None:
+                # Groups are applied against the sliced (start:stop) range,
+                # not the full axis, so crop to that range first.
+                axis_for_groups = self.axes[i]
+                if has_bounds:
+                    if start_int >= stop_int:
+                        raise IndexError(self._empty_slice_msg(i, start, stop))
+                    reduced = (reduced or self._hist).reduce(
+                        _core.algorithm.slice(
+                            i, start_int, stop_int, _core.algorithm.slice_mode.crop
+                        )
+                    )
+                    axis_for_groups = cast(self, reduced.axis(i), Axis)
+                tmp_both = x(axis_for_groups)
+                if tmp_both is None:
+                    msg = "The third argument to a slice must be rebin or projection"
+                    raise IndexError(msg)
                 groups, new_axis = tmp_both
-            case object(group_mapping=x) if (tmp_groups := x(self.axes[i])) is not None:
-                groups = tmp_groups
+                if new_axis is None and not axis_for_groups.traits.ordered:
+                    msg = (
+                        f"Group rebin on categorical axis {i} needs an explicit "
+                        "axis= (the merged category axis); it cannot be inferred "
+                        "automatically"
+                    )
+                    raise ValueError(msg)
             case x if callable(x):
                 raise NotImplementedError
             case _:
@@ -1710,7 +1775,9 @@ class Histogram(typing.Generic[S]):
         # Vectorized (NumPy array) indexing scatters values through the buffer.
         # The View handles accumulator (n+1 dim raw array) assignment itself.
         if any(isinstance(a, np.ndarray) for a in indexes):
-            self.view()[self._compute_vectorized_index(indexes)] = np.asarray(value)
+            self.view(flow=True)[self._compute_vectorized_index(indexes)] = np.asarray(
+                value
+            )
             return
 
         # A Histogram value must keep its flow bins; np.asarray() would call
@@ -1823,7 +1890,7 @@ class Histogram(typing.Generic[S]):
                 value_n += 1
                 value_hist_axis += 1
             else:
-                indexes[n] = request + has_underflow
+                indexes[n] = self._flow_pick_index(n, int(request))  # type: ignore[arg-type]
 
         if isinstance(self._hist, _core.hist.any_multi_cell):
             # View of multi cell histograms has as first (index 0) dimension the cell index

--- a/src/boost_histogram/tag.py
+++ b/src/boost_histogram/tag.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import operator
 from builtins import sum
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, TypeVar
@@ -128,10 +129,17 @@ class rebin:
         edges: Sequence[int | float] | None = None,
         axis: PlottableAxis | None = None,
     ) -> None:
+        # bool is a subclass of int, but is not a sensible rebin factor
+        if isinstance(factor_or_axis, bool):
+            raise TypeError("The factor must be an integer, not a bool")
         if isinstance(factor_or_axis, int):
             factor = factor_or_axis
         elif factor_or_axis is not None:
-            axis = factor_or_axis
+            try:
+                # Accept any other integer-like type (e.g. NumPy integers).
+                factor = operator.index(factor_or_axis)  # type: ignore[arg-type]
+            except TypeError:
+                axis = factor_or_axis
 
         total_args = sum(i is not None for i in [factor, groups, edges])
         if total_args != 1 and axis is None:

--- a/src/register_algorithm.cpp
+++ b/src/register_algorithm.cpp
@@ -16,11 +16,14 @@ void register_algorithms(py::module& algorithm) {
             using range_t = bh::algorithm::reduce_command::range_t;
 
             if(self.range != range_t::none) {
-                const char* suffix  = self.merge > 0 ? "_and_rebin" : "";
+                // merge is always >= 1 (1 means "no extra rebin"), so only
+                // show the "_and_rebin" suffix and merge= value when a real
+                // merge factor was requested.
+                const char* suffix  = self.merge > 1 ? "_and_rebin" : "";
                 const char* c_start = self.iaxis == bh::algorithm::reduce_command::unset
                                           ? ""
                                           : "iaxis={0}, ";
-                const char* c_merge = self.merge > 0 ? ", merge={0}" : "";
+                const char* c_merge = self.merge > 1 ? ", merge={0}" : "";
 
                 py::str const start = py::str(c_start).format(self.iaxis);
                 py::str const merge = py::str(c_merge).format(self.merge);
@@ -35,9 +38,10 @@ void register_algorithms(py::module& algorithm) {
                                 merge,
                                 self.crop ? "slice_mode.crop" : "slice_mode.shrink");
                 }
-                return py::str(
-                           "reduce_command(shrink{0}({1}, lower={2}, upper={3}{4}))")
-                    .format(suffix, start, self.begin.value, self.end.value, merge);
+                const char* name = self.crop ? "crop" : "shrink";
+                return py::str("reduce_command({0}{1}({2}lower={3}, upper={4}{5}))")
+                    .format(
+                        name, suffix, start, self.begin.value, self.end.value, merge);
             }
 
             // self.range == range_t::none

--- a/tests/test_histogram_indexing.py
+++ b/tests/test_histogram_indexing.py
@@ -5,6 +5,7 @@ import pytest
 from pytest import approx
 
 import boost_histogram as bh
+from boost_histogram import _core
 
 
 def test_1D_get_bin():
@@ -812,3 +813,122 @@ def test_string_index_raises():
         h["a"]
 
     assert h[bh.loc("a")] == 2
+
+
+def test_vectorized_get_set_respects_flow_locator():
+    # A flow locator (bh.underflow/bh.overflow) mixed with an array index on
+    # another axis must select the flow bin, not wrap into the regular range.
+    h = bh.Histogram(bh.axis.Regular(4, 0, 1), bh.axis.Regular(3, 0, 1))
+    h.view(flow=True)[...] = np.arange(6 * 5).reshape(6, 5)
+
+    assert h[np.array([0]), bh.underflow] == approx([h.view(flow=True)[1, 0]])
+    assert h[np.array([0, 1]), bh.overflow] == approx(
+        [h.view(flow=True)[1, 4], h.view(flow=True)[2, 4]]
+    )
+
+    h[np.array([0]), bh.underflow] = 999
+    assert h.view(flow=True)[1, 0] == 999
+
+
+def test_vectorized_get_flow_locator_out_of_bounds_raises():
+    h = bh.Histogram(
+        bh.axis.Regular(4, 0, 1, underflow=False), bh.axis.Regular(3, 0, 1)
+    )
+    with pytest.raises(IndexError, match="no underflow bin"):
+        h[bh.underflow, np.array([0])]
+
+
+def test_underflow_locator_raises_without_underflow_bin():
+    # Issue: bh.underflow on an axis without underflow silently wrapped to
+    # the last (overflow) bin instead of raising.
+    h = bh.Histogram(
+        bh.axis.Regular(4, 0, 1, underflow=False), bh.axis.Regular(3, 0, 1)
+    )
+    h.view(flow=True)[...] = np.arange(5 * 5).reshape(5, 5)
+
+    with pytest.raises(IndexError, match="no underflow bin"):
+        h[bh.underflow, :]
+
+
+def test_loc_below_range_raises_without_underflow_bin_setitem():
+    # Issue: bh.loc(value_below_range) on an axis without underflow silently
+    # wrote to the overflow bin instead of raising.
+    h = bh.Histogram(bh.axis.Regular(4, 0, 1, underflow=False))
+
+    with pytest.raises(IndexError, match="no underflow bin"):
+        h[bh.loc(-5)] = 7
+
+    assert h.view(flow=True) == approx([0, 0, 0, 0, 0])
+
+
+def test_group_rebin_respects_slice_bounds():
+    # Issue: h[start:stop:bh.rebin(groups=...)] ignored start/stop and
+    # grouped the full axis instead of just the sliced range.
+    h = bh.Histogram(bh.axis.Regular(6, 0, 6))
+    h.view()[:] = [1, 2, 3, 4, 5, 6]
+
+    hs = h[1 : 5 : bh.rebin(groups=[2, 2])]
+    assert hs.view() == approx([2 + 3, 4 + 5])
+    assert hs.axes[0].edges == approx([1, 3, 5])
+
+
+def test_group_rebin_mismatched_sum_raises():
+    h = bh.Histogram(bh.axis.Regular(6, 0, 6))
+    h.view()[:] = [1, 2, 3, 4, 5, 6]
+
+    with pytest.raises(ValueError, match="sum of the groups"):
+        h[1 : 5 : bh.rebin(groups=[2, 3])]
+
+
+def test_group_rebin_categorical_without_axis_raises():
+    # Issue: group rebin on a category axis without axis= silently produced
+    # a nonsensical Variable axis instead of a category axis.
+    h = bh.Histogram(bh.axis.IntCategory([1, 2, 3, 4]))
+    h.view()[:] = [10, 20, 30, 40]
+
+    with pytest.raises(ValueError, match="categorical axis"):
+        h[:: bh.rebin(groups=[2, 2])]
+
+
+def test_group_rebin_categorical_with_axis():
+    h = bh.Histogram(bh.axis.IntCategory([1, 2, 3, 4]))
+    h.view()[:] = [10, 20, 30, 40]
+
+    new_axis = bh.axis.IntCategory([1, 3])
+    hs = h[:: bh.rebin(groups=[2, 2], axis=new_axis)]
+    assert hs.view() == approx([30, 70])
+    assert hs.axes[0] == new_axis
+
+
+def test_rebin_numpy_integer_factor():
+    # Issue: bh.rebin(np.int64(2)) was treated as an axis (isinstance(x, int)
+    # is False for NumPy integer scalars), not a factor.
+    r = bh.rebin(np.int64(2))
+    assert r.factor == 2
+    assert r.axis is None
+
+    h = bh.Histogram(bh.axis.Regular(6, 0, 6))
+    h.view()[:] = [1, 2, 3, 4, 5, 6]
+    hs = h[:: bh.rebin(np.int64(2))]
+    assert hs.view() == approx([3, 7, 11])
+
+
+def test_rebin_bool_is_not_a_factor():
+    with pytest.raises(TypeError, match="not a bool"):
+        bh.rebin(True)
+
+
+def test_reduce_command_repr():
+    assert (
+        repr(_core.algorithm.slice(0, 1, 3, _core.algorithm.slice_mode.crop))
+        == "reduce_command(slice(iaxis=0, begin=1, end=3, mode=slice_mode.crop))"
+    )
+    assert repr(_core.algorithm.crop(0, 1.0, 3.0)) == (
+        "reduce_command(crop(iaxis=0, lower=1.0, upper=3.0))"
+    )
+    assert repr(_core.algorithm.shrink(0, 1.0, 3.0)) == (
+        "reduce_command(shrink(iaxis=0, lower=1.0, upper=3.0))"
+    )
+    assert repr(_core.algorithm.shrink_and_rebin(0, 1.0, 3.0, 2)) == (
+        "reduce_command(shrink_and_rebin(iaxis=0, lower=1.0, upper=3.0, merge=2))"
+    )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This fixes several UHI indexing bugs found in `boost_histogram.histogram.Histogram` and `boost_histogram.tag`.

- Vectorized (NumPy array) indexing ignored flow locators. `h[np.array([0]), bh.underflow]` read and wrote the wrong bin because the gather/scatter path used the `flow=False` view while flow locators resolve to flow-offset sentinels. It now uses the `flow=True` view and maps indices onto it.
- `bh.underflow`/`bh.loc(value_below_range)` on an axis built with `underflow=False` silently wrapped to the overflow bin instead of raising, in both `__getitem__` (mixed pick+slice path) and `__setitem__`. Both now raise `IndexError`, matching the existing behavior of the all-integer fast path.
- `h[start:stop:bh.rebin(groups=[...])]` ignored `start`/`stop` and grouped the whole axis. It now crops to the slice first, then groups, and raises if the groups do not sum to the sliced length. Group rebin on a categorical axis without an explicit `axis=` used to silently produce a nonsensical `Variable` axis; it now raises a clear error asking for `axis=`.
- `bh.rebin(np.int64(2))` was treated as an axis, not a factor, because the check used `isinstance(x, int)`. It now accepts any integer-like value via `operator.index`, while still rejecting `bool`.
- `reduce_command.__repr__` (C++) mislabeled `crop` as `shrink`, always appended a stray `merge=1` and `_and_rebin` suffix even when no rebin was requested, and had a duplicated comma in its output. Fixed in `src/register_algorithm.cpp`.

Regression tests are added to `tests/test_histogram_indexing.py`.

Part of #1176.