### PR TITLE
fix: python-layer bugs in axis metadata, serialization, and repr

### DIFF
--- a/include/bh_python/metadata.hpp
+++ b/include/bh_python/metadata.hpp
@@ -26,6 +26,22 @@ class metadata_t {
     explicit metadata_t(py::object&& data) noexcept
         : data_(std::move(data)) {}
 
+    /// Copying an axis must not alias its dict with the source axis, so make
+    /// a fresh shallow copy here rather than sharing guarded_object's
+    /// reference. Code that wants the identical dict (e.g. the Python
+    /// wrapper's raw_metadata getter) must go through unguarded_obj() instead
+    /// of copying a metadata_t.
+    metadata_t(const metadata_t& other)
+        : data_(shallow_copy_dict(other.data_.unguarded_get())) {}
+    metadata_t& operator=(const metadata_t& other) {
+        if(this != &other)
+            data_ = guarded_object(shallow_copy_dict(other.data_.unguarded_get()));
+        return *this;
+    }
+    metadata_t(metadata_t&&) noexcept            = default;
+    metadata_t& operator=(metadata_t&&) noexcept = default;
+    ~metadata_t()                                = default;
+
     /// Access the held dict; hold the GIL to use or copy it
     const py::object& unguarded_obj() const noexcept { return data_.unguarded_get(); }
 
@@ -42,6 +58,11 @@ class metadata_t {
     static py::object make_dict() {
         const py::gil_scoped_acquire gil;
         return py::dict();
+    }
+
+    static py::object shallow_copy_dict(const py::object& obj) {
+        const py::gil_scoped_acquire gil;
+        return py::reinterpret_steal<py::object>(PyDict_Copy(obj.ptr()));
     }
 };
 

--- a/include/bh_python/register_axis.hpp
+++ b/include/bh_python/register_axis.hpp
@@ -185,7 +185,13 @@ py::class_<A> register_axis(py::module& m, Args&&... args) {
 
         .def_property(
             "raw_metadata",
-            [](const A& self) { return self.metadata(); },
+            // Return the actual held dict (not a metadata_t copy, which
+            // would now be an independent dict): callers rely on repeated
+            // .raw_metadata accesses returning the identical object.
+            [](const A& self) -> const py::object& {
+                const py::gil_scoped_acquire gil;
+                return self.metadata().unguarded_obj();
+            },
             [](A& self, metadata_t label) { self.metadata() = std::move(label); },
             "Set the metadata")
 

--- a/include/bh_python/transform.hpp
+++ b/include/bh_python/transform.hpp
@@ -116,6 +116,10 @@ struct func_transform {
         }
     }
 
+    bool operator!=(const func_transform& other) const noexcept {
+        return !(*this == other);
+    }
+
     template <class Archive>
     void serialize(Archive& ar, unsigned /* version */) {
         ar& boost::make_nvp("forward", _forward_ob);

--- a/src/boost_histogram/_pytest.py
+++ b/src/boost_histogram/_pytest.py
@@ -114,7 +114,7 @@ def _plain_contents(lv: NDArray[Any], rv: NDArray[Any]) -> list[str]:
         lines.append(f"  bin {key}: {lv[tuple(idx)]} != {rv[tuple(idx)]}")
     if count > _MAX_SAMPLES:
         lines.append(f"  ... and {count - _MAX_SAMPLES} more")
-    lines.append(f"sum (no flow): {lv.sum()} vs {rv.sum()}")
+    lines.append(f"sum (with flow): {lv.sum()} vs {rv.sum()}")
     return lines
 
 

--- a/src/boost_histogram/_utils.py
+++ b/src/boost_histogram/_utils.py
@@ -54,7 +54,7 @@ def register(
             cls._types = set()  # type: ignore[attr-defined]
             return cls
 
-        if not hasattr(cls, "_types"):
+        if "_types" not in cls.__dict__:
             cls._types = set()  # type: ignore[attr-defined]
 
         for cpp_type in cpp_types:

--- a/src/boost_histogram/axis/__init__.py
+++ b/src/boost_histogram/axis/__init__.py
@@ -430,7 +430,7 @@ class Regular(Axis, family=boost_histogram):
     def _repr_args_(self) -> list[str]:
         "Return inner part of signature for use in repr"
 
-        ret = [f"{self.size:g}", f"{self.edges[0]:g}", f"{self.edges[-1]:g}"]
+        ret = [f"{self.size}", f"{self.edges[0]:g}", f"{self.edges[-1]:g}"]
 
         if self.traits.growth:
             ret.append("growth=True")

--- a/src/boost_histogram/axis/transform.py
+++ b/src/boost_histogram/axis/transform.py
@@ -57,6 +57,15 @@ class AxisTransform:
         "Compute the inverse transform"
         return self._this.inverse(value)
 
+    def __eq__(self, other: object) -> bool:
+        # Compare by type and parameters, not by repr - two different
+        # Function transforms can have the same name (and so the same repr).
+        # Subclasses override this and __hash__ with real comparisons.
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(type(self))
+
 
 @register({ca.transform.pow})
 class Pow(AxisTransform, family=boost_histogram):
@@ -80,6 +89,14 @@ class Pow(AxisTransform, family=boost_histogram):
     # This one does need to be a normal method
     def _produce(self, bins: int, start: float, stop: float) -> Any:
         return self.__class__._type(bins, start, stop, self.power)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Pow):
+            return NotImplemented
+        return self.power == other.power
+
+    def __hash__(self) -> int:
+        return hash((Pow, self.power))
 
 
 @register({ca.transform.func_transform})
@@ -147,10 +164,22 @@ class Function(AxisTransform, family=boost_histogram):
     def _produce(self, bins: int, start: float, stop: float) -> Any:
         return self.__class__._type(bins, start, stop, self._this)
 
+    def __eq__(self, other: object) -> bool:
+        # Compares the underlying forward/inverse functions, not the name -
+        # two Function transforms with the same name are not necessarily equal.
+        if not isinstance(other, Function):
+            return NotImplemented
+        return bool(self._this == other._this)
+
+    def __hash__(self) -> int:
+        return hash(Function)
+
 
 def _internal_conversion(name: str) -> Any:
     return getattr(ca.transform, name)
 
 
-sqrt = Function("_sqrt_fn", "_sq_fn", convert=_internal_conversion, name="sqrt")
-log = Function("_log_fn", "_exp_fn", convert=_internal_conversion, name="log")
+sqrt: Function = Function(
+    "_sqrt_fn", "_sq_fn", convert=_internal_conversion, name="sqrt"
+)
+log: Function = Function("_log_fn", "_exp_fn", convert=_internal_conversion, name="log")

--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -505,7 +505,10 @@ class Histogram(typing.Generic[S]):
         self.__dict__ = copy.copy(other.__dict__)
         self.axes = self._generate_axes_()
         for ax in self.axes:
-            ax.__dict__.update(ax._ax.raw_metadata)
+            # Give each axis its own metadata dict, so mutating it here does
+            # not alias with the axes of `other` (or of each other).
+            ax._ax.raw_metadata = copy.copy(ax._ax.raw_metadata)
+            ax.__dict__ = ax._ax.raw_metadata
         self.__dict__.update(__dict__)
 
         # Allow custom behavior on either "from" or "to"
@@ -772,7 +775,7 @@ class Histogram(typing.Generic[S]):
     # If these fail, the underlying object throws the correct error
     def __mul__(self, other: Histogram[S] | np.typing.NDArray[Any] | float) -> Self:
         result = self.copy(deep=False)
-        return result._compute_inplace_op("__imul__", other)
+        return result.__imul__(other)
 
     def __rmul__(self, other: np.typing.NDArray[Any] | float) -> Self:
         return self * other
@@ -808,6 +811,13 @@ class Histogram(typing.Generic[S]):
         return result
 
     def __imul__(self, other: Histogram[S] | np.typing.NDArray[Any] | float) -> Self:
+        # Multiplying by a non-integer scalar/array should promote an integer
+        # storage to Double, matching __itruediv__, instead of leaking a
+        # numpy UFuncTypeError from the in-place view multiply.
+        if not isinstance(other, (Histogram, *_histogram_types)) and not np.issubdtype(
+            np.asarray(other).dtype, np.integer
+        ):
+            self._convert_int_storage_to_double()
         return self._compute_inplace_op("__imul__", other)
 
     @staticmethod
@@ -1136,7 +1146,13 @@ class Histogram(typing.Generic[S]):
         ret += f"{sep}{storage_newline}storage={self.storage}"
         ret += ")"
         outer = self.sum(flow=True)
-        if outer:
+        # Accumulators (Mean, WeightedSum, ...) have no __bool__, so they are
+        # always truthy; compare against a fresh instance to detect "empty".
+        if isinstance(outer, (int, float)):
+            non_empty = bool(outer)
+        else:
+            non_empty = outer != type(outer)()
+        if non_empty:
             inner = self.sum(flow=False)
             ret += f" # Sum: {inner}"
             if inner != outer:

--- a/src/boost_histogram/serialization/__init__.py
+++ b/src/boost_histogram/serialization/__init__.py
@@ -89,7 +89,9 @@ def to_uhi(
         data["storage"] = _storage_to_dict(storage_obj, h.view(flow=True))
     else:
         data["storage"] = {"type": storage_type_str}
-    data["metadata"] = serialize_metadata(h.__dict__)
+    # _variance_known is internal Histogram state, not user metadata
+    public_dict = {k: v for k, v in h.__dict__.items() if k != "_variance_known"}
+    data["metadata"] = serialize_metadata(public_dict)
 
     return data
 
@@ -102,7 +104,9 @@ def from_uhi(data: dict[str, Any], /) -> histogram.Histogram[Any]:
     storage_data = data["storage"]
     storage_ = _storage_from_dict(storage_data, data.get("writer_info", {}))
     h = histogram.Histogram[Any](*axis, storage=storage_)
-    h.__dict__ = data.get("metadata", {})
+    h.__dict__ = dict(data.get("metadata", {}))
+    # Not part of the UHI schema; assume known unless the dict says otherwise
+    h.__dict__.setdefault("_variance_known", True)
 
     # Check if storage has data (if not, it's a structure-only histogram)
     # Validate required keys per storage type before deciding to skip data loading

--- a/src/boost_histogram/serialization/_axis.py
+++ b/src/boost_histogram/serialization/_axis.py
@@ -12,8 +12,10 @@ __all__ = ["_axis_from_dict", "_axis_to_dict"]
 # written as a ``variable`` axis (with the transformed edges) for interoperability
 # and additionally tagged with the original Regular parameters + transform identity
 # under boost-histogram's writer_info, letting us restore the exact axis on read.
-# Only transforms we can reconstruct from these names are recorded here.
-_KNOWN_FUNCTION_TRANSFORMS = frozenset({"log", "sqrt"})
+# Only transforms we can reconstruct from these names are recorded here. Keyed
+# by name, but matched against the actual transform object (via __eq__), not
+# its repr - a custom Function transform can share a name with a built-in.
+_KNOWN_FUNCTION_TRANSFORMS = {"log": axis.transform.log, "sqrt": axis.transform.sqrt}
 
 
 def __dir__() -> list[str]:
@@ -27,10 +29,14 @@ def _transform_writer_info(ax: axis.Regular, /) -> dict[str, Any]:
     info: dict[str, Any]
     if isinstance(tr, axis.transform.Pow):
         info = {"transform": "pow", "power": tr.power}
-    elif repr(tr) in _KNOWN_FUNCTION_TRANSFORMS:
-        info = {"transform": repr(tr)}
     else:
-        return {}
+        name = next(
+            (n for n, known in _KNOWN_FUNCTION_TRANSFORMS.items() if tr == known),
+            None,
+        )
+        if name is None:
+            return {}
+        info = {"transform": name}
     info["bins"] = ax.size
     info["lower"] = float(ax.edges[0])
     info["upper"] = float(ax.edges[-1])

--- a/src/register_transforms.cpp
+++ b/src/register_transforms.cpp
@@ -92,6 +92,8 @@ void register_transforms(py::module& mod) {
              "inverse"_a,
              "convert"_a,
              "name"_a)
+        .def(py::self == py::self)
+        .def(py::self != py::self)
         .def("__repr__",
              [](const py::object& self) -> py::object {
                  auto& s = py::cast<func_transform&>(self);

--- a/tests/test_axes_object.py
+++ b/tests/test_axes_object.py
@@ -84,6 +84,24 @@ def test_axis_misconstuct():
         bh.axis.AxesTuple(inp[0])
 
 
+def test_histogram_axes_do_not_alias_metadata():
+    # Passing the same axis instance twice must not let the two histogram
+    # axes (or the original axis) share one metadata dict.
+    a = bh.axis.Regular(3, 0, 1)
+    h = bh.Histogram(a, a)
+    h.axes[0].label = "x"
+
+    assert a.metadata is None
+    assert h.axes[1].metadata is None
+
+    # The conversion constructor must give its axes their own metadata too.
+    h1 = bh.Histogram(bh.axis.Regular(2, 0, 1))
+    h2 = bh.Histogram(h1)
+    h2.axes[0].label = "y"
+
+    assert h1.axes[0].metadata is None
+
+
 def test_array_tuple_dir(h):
     # Issue #1143 (B15): __dir__ used dir() of a string literal
     listing = dir(h.axes.centers)

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -248,6 +248,17 @@ class TestRegular(Axis):
         ax = bh.axis.Regular(4, 1.1, 2.2, transform=bh.axis.transform.Pow(0.5))
         assert repr(ax) == "Regular(4, 1.1, 2.2, transform=pow(0.5))"
 
+    def test_repr_large_bin_count(self):
+        # A large bin count must print as an integer, not "1e+06"
+        ax = bh.axis.Regular(1_000_000, 0, 1)
+        assert repr(ax) == "Regular(1000000, 0, 1)"
+
+    def test_copy_does_not_alias_metadata(self):
+        a = bh.axis.Regular(3, 0, 1)
+        b = copy.copy(a)
+        b.label = "x"
+        assert a.metadata is None
+
     def test_getitem(self):
         a = bh.axis.Regular(2, 1.0, 2.0)
         ref = [1.0, 1.5, 2.0]

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -525,6 +525,19 @@ def test_empty_repr():
     assert repr(h) == hrepr
 
 
+def test_empty_mean_repr_has_no_sum_line():
+    # Mean/WeightedMean accumulators have no __bool__, so an empty sum is
+    # still truthy; the repr must not print a spurious "# Sum:" for it.
+    h = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.Mean())
+    assert "# Sum:" not in repr(h)
+
+    h2 = bh.Histogram(bh.axis.Regular(3, 0, 1), storage=bh.storage.WeightedMean())
+    assert "# Sum:" not in repr(h2)
+
+    h.fill([0.5], sample=[1.0])
+    assert "# Sum:" in repr(h)
+
+
 def test_str():
     h1 = bh.Histogram(bh.axis.Regular(3, 0, 1))
     h1.view(True)[...] = [0, 1, 3, 2, 1]
@@ -672,6 +685,32 @@ def test_int_storage_division_promotes_to_double(storage):
     assert a is a_orig
     assert a.storage_type is bh.storage.Double
     assert a.view() == approx(expected)
+
+
+@pytest.mark.parametrize("storage", [bh.storage.Int64, bh.storage.AtomicInt64])
+def test_int_storage_mul_by_float_promotes_to_double(storage):
+    # A non-integer scalar multiply must promote like division, instead of
+    # leaking a numpy UFuncTypeError from the in-place int64 view multiply.
+    a = bh.Histogram(bh.axis.Integer(0, 3), storage=storage())
+    a[:] = (1, 2, 3)
+
+    result = a * 0.5
+    assert result.storage_type is bh.storage.Double
+    assert result.view() == approx(np.array([0.5, 1.0, 1.5]))
+    # operand is unchanged
+    assert a.storage_type is storage
+
+    # multiplying by an integer scalar keeps the int storage
+    int_result = a * 2
+    assert int_result.storage_type is storage
+    assert int_result.view() == approx(np.array([2, 4, 6]))
+
+    # in-place multiply promotes storage but keeps the same object
+    a_orig = a
+    a *= 0.5
+    assert a is a_orig
+    assert a.storage_type is bh.storage.Double
+    assert a.view() == approx(np.array([0.5, 1.0, 1.5]))
 
 
 def test_mixed_int_double_division():

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -78,7 +78,9 @@ def test_histogram_contents_differ_plain() -> None:
     h2.fill([0.05, 0.05])
     out = text(pytest_assertrepr_compare("==", h1, h2))
     assert "1 of 12 bins differ" in out
-    assert "sum (no flow): 1.0 vs 2.0" in out
+    # The summed values include flow bins (there are none filled here, but the
+    # label must say so, since lv/rv passed to _plain_contents include flow).
+    assert "sum (with flow): 1.0 vs 2.0" in out
 
 
 def test_histogram_contents_truncated() -> None:

--- a/tests/test_serialization_uhi.py
+++ b/tests/test_serialization_uhi.py
@@ -180,6 +180,30 @@ def test_round_trip_transform_custom_falls_back_to_variable() -> None:
     assert np.asarray(h2.axes[0].edges) == pytest.approx(np.asarray(h.axes[0].edges))
 
 
+@pytest.mark.skipif(
+    sys.implementation.name == "pypy",
+    reason="ctypes function-pointer transforms hang forever on PyPy",
+)
+@pytest.mark.skipif(
+    sys.implementation.name == "graalpy",
+    reason="ctypes function-pointer transforms are not supported on GraalPy",
+)
+def test_transform_same_name_as_builtin_is_not_confused() -> None:
+    """A custom Function transform named 'log' must not round-trip as the
+    built-in log transform - the two have different forward/inverse math."""
+    ftype = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double)
+    transform = bh.axis.transform.Function(ftype(math.exp), ftype(math.log), name="log")
+    assert transform != bh.axis.transform.log
+
+    h = bh.Histogram(bh.axis.Regular(5, 1, 10, transform=transform))
+    data = to_uhi(h)
+
+    # Not reconstructable, so it must fall back to a Variable axis, not "log"
+    assert "writer_info" not in data["axes"][0]
+    h2 = from_uhi(data)
+    assert isinstance(h2.axes[0], bh.axis.Variable)
+
+
 def test_from_uhi_unknown_transform_falls_back_to_variable() -> None:
     """An unrecognized transform name in writer_info reads back as a Variable
     axis instead of raising."""
@@ -295,6 +319,36 @@ def test_uhi_direct_conversion():
     uhi_dict = h._to_uhi_()
     h2 = bh.Histogram(uhi_dict)
     assert h == h2
+
+
+def test_to_uhi_does_not_leak_variance_known() -> None:
+    h = bh.Histogram(bh.axis.Regular(3, 0, 1))
+    data = to_uhi(h)
+    assert "_variance_known" not in data["metadata"]
+
+
+def test_from_uhi_sets_variance_known_by_default() -> None:
+    # A dict without boost-histogram's private "_variance_known" flag (e.g.
+    # built by hand, or written by another UHI library) must still produce a
+    # histogram whose .variances() works.
+    data = {
+        "uhi_schema": 1,
+        "axes": [
+            {
+                "type": "regular",
+                "lower": 0.0,
+                "upper": 1.0,
+                "bins": 3,
+                "underflow": True,
+                "overflow": True,
+                "circular": False,
+            }
+        ],
+        "storage": {"type": "double"},
+        "metadata": {},
+    }
+    h = from_uhi(data)
+    assert h.variances() is not None
 
 
 def test_round_trip_native() -> None:
@@ -471,7 +525,8 @@ def test_unserializable_metadata() -> None:
     h.__dict__["@b"] = 2
     data = to_uhi(h)
 
-    assert data["metadata"] == {"a": 1, "_variance_known": True}
+    # _variance_known is internal Histogram state, not user metadata
+    assert data["metadata"] == {"a": 1}
     assert data["axes"][0]["metadata"] == {"c": 3}
 
 
@@ -487,7 +542,6 @@ def test_histogram_metadata() -> None:
         "name": "Hi",
         "label": "hi",
         "other": 3,
-        "_variance_known": True,
     }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from boost_histogram._utils import register
+
+
+def test_register_subclass_does_not_mutate_parent_types():
+    # register() must give each decorated class its own "_types" set - it
+    # used to inherit the parent's set via hasattr() and mutate it in place.
+    class CppBase:
+        pass
+
+    class CppChild(CppBase):
+        pass
+
+    @register({CppBase})
+    class Parent:
+        pass
+
+    @register({CppChild})
+    class Child(Parent):
+        pass
+
+    assert Parent._types == {CppBase}
+    assert Child._types == {CppChild}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This fixes a batch of small Python-layer bugs found in a review of develop.

- Copying an axis, or building a Histogram from existing axis objects (for
  example `Histogram(a, a)`, or `Histogram(other_hist)`), shared one
  metadata dict across the copies. Setting `.label` on one axis changed
  the others. Each axis copy now gets its own dict.
- `serialization.from_uhi` dropped the internal `_variance_known` flag, so
  `.variances()` raised `AttributeError` on a histogram built from a plain
  dict. `to_uhi` leaked that same private flag into the public metadata.
  Both are fixed.
- `register()` in `_utils.py` copied the parent class's `_types` set
  instead of giving each decorated class its own, so registering a
  subclass could mutate the parent's set.
- Multiplying an integer-storage histogram by a non-integer scalar (for
  example `h * 0.5`) leaked a numpy `UFuncTypeError`. It now promotes to
  Double storage, matching how division already behaves.
- The pytest plugin's assertion-diff helper mislabeled a flow-inclusive
  sum as "no flow".
- `repr()` of a `Regular` axis with a large bin count printed `1e+06`
  instead of an integer. `repr()` of an empty Mean/WeightedMean histogram
  printed a spurious `# Sum:` line, because those accumulators have no
  `__bool__` and are always truthy.
- Transforms had no `__eq__`, so UHI serialization matched a `Function`
  transform to a built-in (`log`/`sqrt`) by comparing `repr()` strings.
  A custom transform merely named `"log"` could round-trip as the real
  `log` transform. Transforms now compare by type and parameters.

Part of #1176.