### PR TITLE
ci: drop cmake reinstall from iOS wheel job

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -152,8 +152,6 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - run: brew uninstall cmake; brew install cmake
-
       - uses: pypa/cibuildwheel@v4.2
         env:
           CIBW_PLATFORM: ios


### PR DESCRIPTION
Hand written, but used `claude -p "make draft PR"` to make the commit and PR.

:robot: _AI text below_ :robot:

Removes the `brew uninstall cmake; brew install cmake` step from the iOS wheel job. It was a workaround for a broken cmake on the runner images. Draft so the wheel builds can confirm the plain runner cmake works on both `macos-latest` and `macos-15-intel`.