### PR TITLE
fix: accept objects with _to_uhi_ in the constructor

### DIFF
--- a/src/boost_histogram/histogram.py
+++ b/src/boost_histogram/histogram.py
@@ -397,7 +397,10 @@ class Histogram(typing.Generic[S]):
             )
             return
 
-        # Support UHI
+        # Support UHI, either a dict or an object providing one
+        if len(axes) == 1 and hasattr(axes[0], "_to_uhi_"):
+            axes = (axes[0]._to_uhi_(),)
+
         if len(axes) == 1 and isinstance(axes[0], dict) and "uhi_schema" in axes[0]:
             if storage is not None:
                 raise TypeError(storage_err_msg)

--- a/tests/test_serialization_uhi.py
+++ b/tests/test_serialization_uhi.py
@@ -324,6 +324,23 @@ def test_uhi_direct_conversion():
     assert h == h2
 
 
+def test_uhi_protocol_object_conversion():
+    class Wrapper:
+        def __init__(self, hist):
+            self._hist = hist
+
+        def _to_uhi_(self):
+            return to_uhi(self._hist)
+
+    h = bh.Histogram(
+        bh.axis.Regular(3, 0, 1),
+        storage=bh.storage.Int64(),
+    )
+    h.fill([0.1, 0.2, 0.9])
+    h2 = bh.Histogram(Wrapper(h))
+    assert h == h2
+
+
 def test_to_uhi_does_not_leak_variance_known() -> None:
     h = bh.Histogram(bh.axis.Regular(3, 0, 1))
     data = to_uhi(h)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`bh.Histogram(obj)` now accepts any object with a `_to_uhi_` method, next to the existing `_to_boost_histogram_` and raw UHI dict paths. The object is converted to its UHI dict, so the `storage=` conflict check still applies.