### PR TITLE
feat(docs): add llms.txt and Markdown page versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx_copybutton",
+    "sphinx_llm.txt",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -75,6 +76,15 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
+
+# -- Options for LLM-friendly output -----------------------------------------
+
+# The default is the full README, which is too long for the summary block
+llms_txt_description = (
+    "Python bindings for Boost.Histogram, a fast multi-dimensional histogram"
+    " library, with a NumPy-like API and Unified Histogram Interface support."
+)
+
 
 # -- Options for Notebook input ----------------------------------------------
 
@@ -136,6 +146,11 @@ def prepare(app):
 
 
 def clean_up(app, exception):
+    # sphinx-llm spawns a second build sharing this source dir; only the main
+    # build removes the copied-in files
+    if app.tags.has("sphinx_llm_markdown"):
+        return
+
     inner_nb = DIR / "notebooks"
     for notebook in inner_nb.glob("*.ipynb"):
         notebook.unlink()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,6 @@
-.. boost-histogram documentation master file, created by
-   sphinx-quickstart on Tue Apr 23 12:12:27 2019.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root ``toctree`` directive.
+.. meta::
+   :description: boost-histogram is a Python package for fast, multi-dimensional
+      histograms, with Python bindings for the Boost.Histogram C++ library.
 
 .. image:: _images/BoostHistogramPythonLogo.png
   :width: 70%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ docs = [
     "sphinx-book-theme>=0.0.33",
     "sphinx>=4.0",
     "sphinx_copybutton",
+    "sphinx-llm",
 ]
 examples = [
     "matplotlib",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Port of scikit-hep/uhi#252. Adds LLM-friendly docs output with NVIDIA's `sphinx-llm` (`sphinx_llm.txt` extension). It runs the markdown builder alongside the HTML build and merges the results, so the whole thing is one extension and one build:

- `llms.txt` — sitemap with a one-line description per page.
- `llms-full.txt` — all docs in one file.
- `<page>.html.md` next to each `<page>.html`, the llmstxt.org convention of appending `.md` to the page URL.

`llms_txt_description` is set because the default summary is the full README. The stale sphinx-quickstart comment in `index.rst` became a `meta` description, which `llms.txt` uses for the index page.

Unlike uhi, `conf.py` here copies notebooks and `CONTRIBUTING.md` into the source directory and removes them at the end of the build. The spawned markdown build shares that source directory, so its `clean_up` now returns early; otherwise the two builds delete each other's files and the build fails.